### PR TITLE
dashboard: 定时任务时刻表，每槽一枚灯

### DIFF
--- a/ops/host/cron_health_check.py
+++ b/ops/host/cron_health_check.py
@@ -33,6 +33,7 @@ from zoneinfo import ZoneInfo
 _CHECKOUT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(_CHECKOUT))
 sys.path.insert(0, str(_CHECKOUT / "src"))
+from clawock.scheduling import parse_cron_slots  # noqa: E402
 from clawock.workspace import workspace_root  # noqa: E402
 from clawock.providers import openclaw  # noqa: E402
 
@@ -77,63 +78,6 @@ COMMIT_PATTERNS = {
     '美股盘中盯盘-overnight': None,
     'Memory Dreaming Promotion': None,  # 不 commit
 }
-
-
-def parse_cron_slots(expr, tz_name, target_date_utc):
-    """Given cron expr like `*/30 10-11,14-15 * * 1-5` + tz, return list of
-    HH:MM strings that should fire on `target_date_utc` (UTC datetime).
-
-    Simple parser: handles minute (*/N or list), hour (range,list), DOW.
-    """
-    parts = expr.split()
-    if len(parts) < 5:
-        return []
-    m_field, h_field, _dom, _mo, dow_field = parts[:5]
-
-    # Minute: */N or list
-    def parse_field(field, lo, hi):
-        vals = set()
-        for tok in field.split(','):
-            tok = tok.strip()
-            if tok == '*':
-                vals.update(range(lo, hi+1))
-            elif tok.startswith('*/'):
-                step = int(tok[2:])
-                vals.update(range(lo, hi+1, step))
-            elif '-' in tok:
-                a, b = tok.split('-')
-                # may have /step
-                step = 1
-                if '/' in b:
-                    b, step = b.split('/')
-                    step = int(step)
-                vals.update(range(int(a), int(b)+1, step))
-            else:
-                vals.add(int(tok))
-        return sorted(vals)
-
-    mins = parse_field(m_field, 0, 59)
-    hours = parse_field(h_field, 0, 23)
-    dows = set(parse_field(dow_field, 0, 7))
-    # 0 and 7 both = Sunday in cron
-    if 7 in dows:
-        dows.discard(7); dows.add(0)
-
-    # Get target date in target tz
-    try:
-        from zoneinfo import ZoneInfo
-        tz = ZoneInfo(tz_name)
-    except Exception:
-        # fall back: assume UTC
-        tz = timezone.utc
-    target_local = target_date_utc.astimezone(tz)
-    # cron DOW: 0=Sun, 1=Mon, ..., 6=Sat
-    py_weekday = target_local.weekday()  # 0=Mon
-    cron_dow = (py_weekday + 1) % 7      # convert: Mon→1 ... Sun→0
-    if cron_dow not in dows:
-        return []
-
-    return [f"{h:02d}:{m:02d}" for h in hours for m in mins]
 
 
 def runs_finished_today(job_id, provider=None):

--- a/site/assets/css/dashboard.css
+++ b/site/assets/css/dashboard.css
@@ -2668,6 +2668,77 @@
   .bs-dot[data-tone="ok"] { background: var(--accent); }
   .bs-dot[data-tone="warn"] { background: var(--warning); }
   .bs-dot[data-tone="bad"] { background: var(--negative, var(--red)); }
+  /* ── 定时任务时刻表 ──
+     色彩预算不变：绿=落地、黄=降级、红=没落地、蓝=进行中、灰=还没到。
+     「兜底补上」不引入第四种颜色——它也落地了，只是烧掉了一次尝试，所以用
+     空心圆这个**形状**差别表示，颜色仍是绿的。档位只染色不减信息。 */
+  /* 与数据健康卡同宽：时刻表是横向的，占一列会把每一行都挤成一个字。 */
+  .cron-board { grid-column: 1 / -1; display: grid; gap: 12px;
+                padding: 16px 18px 14px; }
+  .cb-head {
+    display: flex; align-items: flex-start; justify-content: space-between;
+    gap: 12px; flex-wrap: wrap;
+  }
+  .cb-verdict { margin: 2px 0 0; font-size: var(--fs-lg, 1.05rem); font-weight: 600; }
+  .cron-board[data-tone="warn"] .cb-verdict { color: var(--warning); }
+  .cron-board[data-tone="bad"] .cb-verdict { color: var(--negative, var(--red)); }
+  .cb-meta {
+    margin-top: 4px; color: var(--text-tertiary);
+    font: 500 var(--fs-micro)/1.5 var(--mono);
+  }
+  .cb-legend { display: flex; flex-wrap: wrap; gap: 4px 10px; align-items: center; }
+  .cb-key {
+    display: inline-flex; align-items: center; gap: 4px;
+    color: var(--text-tertiary); font: 500 var(--fs-micro)/1 var(--mono);
+  }
+  .cb-dot {
+    display: inline-block; width: 7px; height: 7px; border-radius: 50%;
+    background: var(--neutral, var(--text-tertiary)); flex: none;
+  }
+  .cb-dot[data-tone="ok"]   { background: var(--positive); }
+  .cb-dot[data-tone="warn"] { background: var(--warning); }
+  .cb-dot[data-tone="bad"]  { background: var(--negative, var(--red)); }
+  .cb-dot[data-tone="live"] { background: var(--accent); }
+  .cb-dot[data-tone="idle"] { background: transparent; box-shadow: inset 0 0 0 1px var(--border-strong); }
+  /* 落地了，但靠 watchdog 补的：同一个绿，空心。 */
+  .cb-dot[data-tone="ok-soft"] {
+    background: transparent; box-shadow: inset 0 0 0 1.5px var(--positive);
+  }
+  .cb-rows { display: grid; gap: 2px; }
+  .cb-row {
+    display: grid; grid-template-columns: minmax(6.5em, max-content) 1fr;
+    gap: 10px; align-items: center; padding: 4px 0;
+    border-top: 1px solid var(--border-subtle);
+  }
+  .cb-row:first-child { border-top: 0; }
+  /* 账本看不到的 job：虚线边把它和「待跑」分开——两者都不是绿的，但一个是
+     「还没到」，一个是「永远不会有记录」，读者不该把它们看成同一件事。 */
+  .cb-row[data-unmonitored="1"] { opacity: .6; }
+  .cb-row[data-unmonitored="1"] .cb-slot { border-style: dashed; }
+  .cb-job {
+    color: var(--text-secondary); font: 500 var(--fs-micro)/1.4 var(--sans, inherit);
+    white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+  }
+  /* 槽多的时候在自己这一行里横向滚动，不让整页横滚。 */
+  .cb-slots {
+    display: flex; gap: 4px; overflow-x: auto; padding-bottom: 2px;
+    scrollbar-width: none;
+  }
+  .cb-slots::-webkit-scrollbar { display: none; }
+  .cb-slot {
+    display: inline-flex; align-items: center; gap: 4px; flex: none;
+    padding: 2px 7px; border-radius: 999px;
+    border: 1px solid var(--border-subtle); background: var(--surface-1);
+    color: var(--text-tertiary); font: 500 var(--fs-micro)/1.5 var(--mono);
+  }
+  .cb-slot[data-tone="ok"]      { color: var(--text-secondary); }
+  .cb-slot[data-tone="ok-soft"] { color: var(--text-secondary); }
+  .cb-slot[data-tone="warn"]    { color: var(--warning); border-color: color-mix(in srgb, var(--warning) 34%, transparent); }
+  .cb-slot[data-tone="bad"]     { color: var(--negative, var(--red)); border-color: color-mix(in srgb, var(--negative, var(--red)) 40%, transparent); }
+  .cb-slot[data-tone="live"]    { color: var(--accent); border-color: color-mix(in srgb, var(--accent) 34%, transparent); }
+  @media (max-width: 560px) {
+    .cb-row { grid-template-columns: 1fr; gap: 2px; }
+  }
   .dh-caption {
     margin-top: 10px; color: var(--text-faint, var(--text-tertiary));
     font: 500 var(--fs-micro)/1.5 var(--mono);

--- a/site/assets/js/dashboard.hero.js
+++ b/site/assets/js/dashboard.hero.js
@@ -353,7 +353,7 @@
   // registry mutable avoids parsing 100KB+ of functions that Overview cannot call.
   const TAB_RENDERERS = {
     hero: [
-      renderCommandDeck, renderDataHealth, renderRiskGuardrail, renderOverviewSummaries,
+      renderCommandDeck, renderDataHealth, renderCronSchedule, renderRiskGuardrail, renderOverviewSummaries,
       renderMarketSnapshot, renderTodayHighlights, renderHonesty, renderGoldDca,
       setupVerdictDeck,
     ],
@@ -1258,6 +1258,94 @@
       });
     }
   }
+
+  // ── 定时任务时刻表 ──
+  // 每槽一枚灯。状态不在这里推导：dashboard.json 的 cron_schedule 里已经是
+  // workflow-outcomes 账本 final_product 的定论，前端只做「定论 → 颜色」的映射。
+  // 未知状态刻意落到 unknown（灰）而不是绿——新状态该被看见，不该被默认成好。
+  const CRON_STATES = {
+    ok:          { tone: "ok",      cn: "正常" },
+    recovered:   { tone: "ok-soft", cn: "兜底补上" },
+    degraded:    { tone: "warn",    cn: "降级送达" },
+    failed:      { tone: "bad",     cn: "未落地" },
+    missed:      { tone: "bad",     cn: "没跑" },
+    running:     { tone: "live",    cn: "进行中" },
+    upcoming:    { tone: "idle",    cn: "待跑" },
+    unmonitored: { tone: "idle",    cn: "账本看不到" },
+    unknown:     { tone: "idle",    cn: "状态未知" },
+  };
+
+  function renderCronSchedule() {
+    const root = document.getElementById("cron-board");
+    if (!root) return;
+    const cs = safe(DATA, "cron_schedule");
+    const jobs = (cs && cs.jobs) || [];
+    if (!jobs.length) { root.hidden = true; return; }
+    root.hidden = false;
+    root.classList.remove("is-pending");
+
+    const rowsEl = document.getElementById("cb-rows");
+    const counts = {};
+    let scheduled = 0;
+    jobs.forEach(j => (j.slots || []).forEach(s => {
+      const key = CRON_STATES[s.state] ? s.state : "unknown";
+      counts[key] = (counts[key] || 0) + 1;
+      if (key !== "unmonitored") scheduled += 1;
+    }));
+    const n = k => counts[k] || 0;
+    const landed = n("ok") + n("recovered");
+    const broken = n("failed") + n("missed");
+
+    // 判词只说落地了多少、坏了多少。把「兜底补上」单列，因为它和「首次即成」
+    // 是两件事：都送到了，但一个烧掉了一次尝试。
+    // 判词只能说到证据为止：有降级就不许说「正常」，有兜底就点出来——都送到了，
+    // 但一个是首次即成、一个烧掉了一次尝试，混成一句话就把区别抹掉了。
+    const verdictEl = root.querySelector(".cb-verdict");
+    if (verdictEl) {
+      verdictEl.textContent =
+        broken ? `${broken} 槽没落地`
+        : n("degraded") ? `${n("degraded")} 槽降级送达`
+        : n("recovered") ? `${n("recovered")} 槽靠兜底补上`
+        : (n("upcoming") + n("running") ? "已跑的都正常" : "今天全部正常");
+    }
+    root.dataset.tone = broken ? "bad" : (n("degraded") || n("recovered") ? "warn" : "ok");
+
+    const bits = [];
+    if (landed) bits.push(`${landed} 落地`);
+    if (n("recovered")) bits.push(`其中 ${n("recovered")} 靠兜底`);
+    if (n("degraded")) bits.push(`${n("degraded")} 降级`);
+    if (broken) bits.push(`${broken} 没落地`);
+    if (n("running")) bits.push(`${n("running")} 进行中`);
+    if (n("upcoming")) bits.push(`${n("upcoming")} 待跑`);
+    const metaEl = document.getElementById("cb-meta");
+    if (metaEl) {
+      metaEl.textContent = `${cs.date || ""} · 共 ${scheduled} 槽` +
+        (bits.length ? ` · ${bits.join(" · ")}` : "");
+    }
+
+    const legendEl = document.getElementById("cb-legend");
+    if (legendEl) {
+      legendEl.innerHTML = ["ok", "recovered", "degraded", "missed", "upcoming"]
+        .map(k => `<span class="cb-key"><i class="cb-dot" data-tone="${CRON_STATES[k].tone}"></i>`
+          + `${escapeHtml(CRON_STATES[k].cn)}</span>`).join("");
+    }
+
+    if (rowsEl) {
+      rowsEl.innerHTML = jobs.map(j => {
+        const slots = (j.slots || []).map(s => {
+          const st = CRON_STATES[s.state] ? s.state : "unknown";
+          const label = `${j.job} ${s.at} ${CRON_STATES[st].cn}`;
+          return `<span class="cb-slot" data-tone="${CRON_STATES[st].tone}" title="${escapeHtml(label)}"`
+            + ` aria-label="${escapeHtml(label)}"><i class="cb-dot" data-tone="${CRON_STATES[st].tone}"></i>`
+            + `${escapeHtml(s.at)}</span>`;
+        }).join("");
+        return `<div class="cb-row"${j.unmonitored ? ' data-unmonitored="1"' : ""}>`
+          + `<span class="cb-job">${escapeHtml(j.job)}</span>`
+          + `<span class="cb-slots">${slots}</span></div>`;
+      }).join("");
+    }
+  }
+
   function flatHoldings() {
     const us = (safe(DATA, "holdings", "us") || []).map(h => ({ ...h, region: "us" }));
     const hk = (safe(DATA, "holdings", "hk") || []).map(h => ({ ...h, region: "hk" }));

--- a/site/assets/js/dashboard.render.js
+++ b/site/assets/js/dashboard.render.js
@@ -364,7 +364,7 @@
   const TAB_RENDERERS = {
     hero: [
       renderTodayHighlights, renderHonesty, renderMarketSnapshot, renderCommandDeck,
-      renderDataHealth, renderRiskGuardrail, renderOverviewSummaries, renderGoldDca,
+      renderDataHealth, renderCronSchedule, renderRiskGuardrail, renderOverviewSummaries, renderGoldDca,
       setupVerdictDeck,
     ],
     drill: [
@@ -1249,6 +1249,94 @@
       });
     }
   }
+
+  // ── 定时任务时刻表 ──
+  // 每槽一枚灯。状态不在这里推导：dashboard.json 的 cron_schedule 里已经是
+  // workflow-outcomes 账本 final_product 的定论，前端只做「定论 → 颜色」的映射。
+  // 未知状态刻意落到 unknown（灰）而不是绿——新状态该被看见，不该被默认成好。
+  const CRON_STATES = {
+    ok:          { tone: "ok",      cn: "正常" },
+    recovered:   { tone: "ok-soft", cn: "兜底补上" },
+    degraded:    { tone: "warn",    cn: "降级送达" },
+    failed:      { tone: "bad",     cn: "未落地" },
+    missed:      { tone: "bad",     cn: "没跑" },
+    running:     { tone: "live",    cn: "进行中" },
+    upcoming:    { tone: "idle",    cn: "待跑" },
+    unmonitored: { tone: "idle",    cn: "账本看不到" },
+    unknown:     { tone: "idle",    cn: "状态未知" },
+  };
+
+  function renderCronSchedule() {
+    const root = document.getElementById("cron-board");
+    if (!root) return;
+    const cs = safe(DATA, "cron_schedule");
+    const jobs = (cs && cs.jobs) || [];
+    if (!jobs.length) { root.hidden = true; return; }
+    root.hidden = false;
+    root.classList.remove("is-pending");
+
+    const rowsEl = document.getElementById("cb-rows");
+    const counts = {};
+    let scheduled = 0;
+    jobs.forEach(j => (j.slots || []).forEach(s => {
+      const key = CRON_STATES[s.state] ? s.state : "unknown";
+      counts[key] = (counts[key] || 0) + 1;
+      if (key !== "unmonitored") scheduled += 1;
+    }));
+    const n = k => counts[k] || 0;
+    const landed = n("ok") + n("recovered");
+    const broken = n("failed") + n("missed");
+
+    // 判词只说落地了多少、坏了多少。把「兜底补上」单列，因为它和「首次即成」
+    // 是两件事：都送到了，但一个烧掉了一次尝试。
+    // 判词只能说到证据为止：有降级就不许说「正常」，有兜底就点出来——都送到了，
+    // 但一个是首次即成、一个烧掉了一次尝试，混成一句话就把区别抹掉了。
+    const verdictEl = root.querySelector(".cb-verdict");
+    if (verdictEl) {
+      verdictEl.textContent =
+        broken ? `${broken} 槽没落地`
+        : n("degraded") ? `${n("degraded")} 槽降级送达`
+        : n("recovered") ? `${n("recovered")} 槽靠兜底补上`
+        : (n("upcoming") + n("running") ? "已跑的都正常" : "今天全部正常");
+    }
+    root.dataset.tone = broken ? "bad" : (n("degraded") || n("recovered") ? "warn" : "ok");
+
+    const bits = [];
+    if (landed) bits.push(`${landed} 落地`);
+    if (n("recovered")) bits.push(`其中 ${n("recovered")} 靠兜底`);
+    if (n("degraded")) bits.push(`${n("degraded")} 降级`);
+    if (broken) bits.push(`${broken} 没落地`);
+    if (n("running")) bits.push(`${n("running")} 进行中`);
+    if (n("upcoming")) bits.push(`${n("upcoming")} 待跑`);
+    const metaEl = document.getElementById("cb-meta");
+    if (metaEl) {
+      metaEl.textContent = `${cs.date || ""} · 共 ${scheduled} 槽` +
+        (bits.length ? ` · ${bits.join(" · ")}` : "");
+    }
+
+    const legendEl = document.getElementById("cb-legend");
+    if (legendEl) {
+      legendEl.innerHTML = ["ok", "recovered", "degraded", "missed", "upcoming"]
+        .map(k => `<span class="cb-key"><i class="cb-dot" data-tone="${CRON_STATES[k].tone}"></i>`
+          + `${escapeHtml(CRON_STATES[k].cn)}</span>`).join("");
+    }
+
+    if (rowsEl) {
+      rowsEl.innerHTML = jobs.map(j => {
+        const slots = (j.slots || []).map(s => {
+          const st = CRON_STATES[s.state] ? s.state : "unknown";
+          const label = `${j.job} ${s.at} ${CRON_STATES[st].cn}`;
+          return `<span class="cb-slot" data-tone="${CRON_STATES[st].tone}" title="${escapeHtml(label)}"`
+            + ` aria-label="${escapeHtml(label)}"><i class="cb-dot" data-tone="${CRON_STATES[st].tone}"></i>`
+            + `${escapeHtml(s.at)}</span>`;
+        }).join("");
+        return `<div class="cb-row"${j.unmonitored ? ' data-unmonitored="1"' : ""}>`
+          + `<span class="cb-job">${escapeHtml(j.job)}</span>`
+          + `<span class="cb-slots">${slots}</span></div>`;
+      }).join("");
+    }
+  }
+
   function renderDelta() {
     const tbody = document.getElementById("delta-tbody");
     const d = safe(DATA, "delta");

--- a/site/index.html
+++ b/site/index.html
@@ -313,6 +313,22 @@ layout: null
         <div class="dh-files" id="dh-files" hidden></div>
       </section>
 
+      <!-- 定时任务时刻表：数据健康卡回答「页面上的数字能不能信」，这张回答
+           「今天每个槽有没有按时跑成」。判定不在前端算——直接印
+           workflow-outcomes 账本里 final_product 的定论，前端只负责上色，
+           否则面板会和账本各说各话。 -->
+      <section class="card cron-board is-pending" id="cron-board" aria-labelledby="cb-title" hidden>
+        <div class="cb-head">
+          <div>
+            <div class="overview-card-kicker">定时任务</div>
+            <h3 id="cb-title" class="cb-verdict">&mdash;</h3>
+            <div class="cb-meta" id="cb-meta">&mdash;</div>
+          </div>
+          <div class="cb-legend" id="cb-legend" aria-hidden="true"></div>
+        </div>
+        <div class="cb-rows" id="cb-rows"></div>
+      </section>
+
       <div class="card hero-gold-card is-pending" id="gold-dca-card">
         <h3>Gold DCA <span class="muted" id="gold-sub" style="text-transform:none;letter-spacing:0;font-weight:500;font-size:var(--fs-xs)"></span></h3>
         <div id="gold-hero"></div>

--- a/src/clawock/publish/cron_schedule.py
+++ b/src/clawock/publish/cron_schedule.py
@@ -1,0 +1,157 @@
+"""Today's cron timetable, folded small enough to ship inside the dashboard.
+
+The panel answers one question per slot: *did this fire and land?* The verdict
+is not derived here — `workflow_outcomes._derive_final` already computes it once
+for the ledger, and a second opinion computed for the display is how a green
+light starts disagreeing with the ledger it claims to summarise. This module
+only joins two things that already exist:
+
+  expected  = the tracked cron contract, expanded for the day
+  actual    = the published outcome records' `final_product.status`
+
+A slot with no record yet is not a failure until its grace window has passed;
+before that it is simply upcoming, which is why this needs `now` and not just
+the date.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
+
+from clawock.scheduling import effective_schedule, parse_cron_slots
+
+HKT = ZoneInfo('Asia/Hong_Kong')
+
+#: How long after a slot fires before "no record" stops meaning "still running".
+#: The runs take 4-6 minutes and the watchdog re-dispatch lands by +10, so a slot
+#: with nothing on it 20 minutes later genuinely did not report.
+GRACE_MINUTES = 20
+
+#: How far a record may sit from an expected slot and still be that slot's run.
+#: Capped further by half the gap between adjacent slots, so two 30-minute slots
+#: can never claim the same record.
+SNAP_MINUTES = 15
+
+#: Ledger verdict -> what the panel shows. An explicit table so a ledger status
+#: nobody mapped shows up as `unknown` rather than silently rendering green —
+#: the failure mode of a `.get(status, 'ok')` default.
+STATE_OF_VERDICT = {
+    'success': 'ok',
+    'degraded': 'degraded',
+    'recovered': 'recovered',
+    'failed': 'failed',
+    'pending': 'running',
+    'skipped': 'closed',
+}
+
+
+def _has_harness(job):
+    """Whether this job runs a harness that reports into the outcome ledger.
+
+    The contract writes an em dash for the jobs that have none (Memory Dreaming
+    is the only one today). Anything falsy or a dash means the ledger will never
+    carry a record for it, no matter how well the job ran.
+    """
+    harness = str(job.get('harness') or '').strip()
+    return bool(harness) and harness not in {'-', '—', '–'}
+
+
+def _local_slots(job, day_utc):
+    """The HH:MM slots this job should fire on `day_utc`, in its own timezone."""
+    schedule = effective_schedule(job, day_utc)
+    expr, tz_name = schedule.get('expr'), schedule.get('tz') or 'Asia/Shanghai'
+    if not expr:
+        return [], tz_name
+    return parse_cron_slots(expr, tz_name, day_utc), tz_name
+
+
+def _records_by_slot(records, job_name, day, tz, slots):
+    """This job's records for `day`, snapped to the expected slot each belongs to.
+
+    Snapped rather than joined exactly because a record carries the slot the
+    contract held *when it ran*: on the day a schedule moves, every record is
+    minutes off the new grid and an exact join paints the whole day as missed
+    (#1278 moved nine jobs by three minutes — a panel reading that as nine
+    outages is worse than no panel). The tolerance is capped at half the gap
+    between adjacent slots, so windows never overlap and a genuinely absent run
+    still finds nothing to snap to.
+    """
+    grid = []
+    for slot in slots:
+        hour, minute = (int(part) for part in slot.split(':'))
+        grid.append((slot, datetime.combine(day, datetime.min.time(), tzinfo=tz)
+                     .replace(hour=hour, minute=minute)))
+    tolerance = timedelta(minutes=SNAP_MINUTES)
+    if len(grid) > 1:
+        gaps = [later[1] - earlier[1] for earlier, later in zip(grid, grid[1:])]
+        tolerance = min(tolerance, min(gaps) / 2)
+    found = {}
+    for record in records:
+        if record.get('job') != job_name:
+            continue
+        try:
+            at = datetime.fromisoformat(record['slot']).astimezone(tz)
+        except (KeyError, TypeError, ValueError):
+            continue
+        if at.date() != day:
+            continue
+        nearest = min(grid, key=lambda cell: abs(cell[1] - at), default=None)
+        if nearest and abs(nearest[1] - at) <= tolerance:
+            found.setdefault(nearest[0], record)
+    return found
+
+
+def timetable(contract, records, *, now=None):
+    """One row per job, one light per slot, for the day `now` falls in."""
+    now = now or datetime.now(HKT)
+    now_utc = now.astimezone(ZoneInfo('UTC'))
+    # An empty ledger is not a day when nothing ran — it is a day we cannot
+    # speak about (a fresh checkout, or the file not written yet). Returning no
+    # rows hides the card, which is the honest answer; the alternative paints
+    # every past slot red and blames the cron for a bookkeeping gap.
+    if not records:
+        return {'date': now.astimezone(HKT).strftime('%Y-%m-%d'),
+                'grace_minutes': GRACE_MINUTES, 'jobs': []}
+    rows = []
+    for job in contract.get('jobs', []):
+        name = job.get('name')
+        slots, tz_name = _local_slots(job, now_utc)
+        if not slots:
+            continue  # not a firing day for this job; an empty row says nothing
+        tz = ZoneInfo(tz_name)
+        day = now.astimezone(tz).date()
+        # A job with no harness writes no ledger record, so the ledger can say
+        # nothing about it — painting its slot red would report an outage every
+        # single day and teach the reader to ignore the panel. `system_check`
+        # names the same blind spot in the same words ("this gate cannot see
+        # them"). The criterion is the contract's own `harness` field rather
+        # than "absent from the ledger": the ledger is windowed, so absence
+        # there also describes a job that simply has not run for a few days.
+        if not _has_harness(job):
+            rows.append({'job': name, 'tz': tz_name, 'unmonitored': True,
+                         'slots': [{'at': slot, 'state': 'unmonitored'}
+                                   for slot in slots]})
+            continue
+        found = _records_by_slot(records, name, day, tz, slots)
+        cells = []
+        for slot in slots:
+            hour, minute = (int(part) for part in slot.split(':'))
+            fires_at = datetime.combine(day, datetime.min.time(), tzinfo=tz).replace(
+                hour=hour, minute=minute)
+            record = found.get(slot)
+            if record:
+                verdict = (record.get('final_product') or {}).get('status')
+                state = STATE_OF_VERDICT.get(verdict, 'unknown')
+            elif now.astimezone(tz) < fires_at:
+                state = 'upcoming'
+            elif now.astimezone(tz) - fires_at < timedelta(minutes=GRACE_MINUTES):
+                state = 'running'
+            else:
+                state = 'missed'
+            cells.append({'at': slot, 'state': state})
+        rows.append({'job': name, 'tz': tz_name, 'slots': cells})
+    return {
+        'date': now.astimezone(HKT).strftime('%Y-%m-%d'),
+        'grace_minutes': GRACE_MINUTES,
+        'jobs': rows,
+    }

--- a/src/clawock/publish/dashboard.py
+++ b/src/clawock/publish/dashboard.py
@@ -281,6 +281,12 @@ def compile_overview_projection(dashboard):
             )),
             'recent': compact_recent,
         },
+        # Passed through whole rather than field-picked: it is already the
+        # folded shape (~1.4 KB) and every key is one the panel draws. The two
+        # comments above are what a field-picked projection costs — a card on
+        # the critical path printing a count with no denominator because the
+        # projection quietly dropped the field that carried it.
+        'cron_schedule': dashboard.get('cron_schedule'),
         'risk_guardrail': {
             **_fields(guardrail, (
                 'computed', 'error', 'breach_count', 'directive',
@@ -3276,6 +3282,23 @@ def compute_workflow_outcomes():
         return None
 
 
+def compute_cron_schedule():
+    """Today's cron timetable for the schedule panel, or None if unavailable.
+
+    Fail-soft on purpose: an unreadable contract or ledger costs the panel, never
+    the build. The card then hides, which is what every other optional workspace
+    input here does.
+    """
+    try:
+        from clawock.publish.cron_schedule import timetable  # noqa: PLC0415
+        from clawock.scheduling import load_contract  # noqa: PLC0415
+        payload = load_json(WS_ROOT / 'assets' / 'data' / 'workflow-outcomes.json')
+        return timetable(load_contract(), (payload or {}).get('records', []))
+    except Exception as e:
+        print(f'  warn: cron schedule panel failed: {e}', file=sys.stderr)
+        return None
+
+
 def parse_args(argv=None):
     parser = argparse.ArgumentParser(
         description='Build the public dashboard payloads from the workspace.')
@@ -3646,6 +3669,15 @@ def build_projection(previous_source=None, shadow_previous=None):
     out['workflow_outcomes'] = compute_workflow_outcomes()
     _presence['workflow_outcomes'] = bool(
         (out.get('workflow_outcomes') or {}).get('recent'))
+
+    # Today's timetable, one light per slot. Built from the same ledger the card
+    # above folds — the panel must not develop a second opinion about whether a
+    # slot landed — joined against the tracked contract for what SHOULD have run.
+    # ~1.4 KB, kept inside dashboard.json rather than published as a new output:
+    # the outputs contract, the fingerprint list and the root allowlist would all
+    # have to agree about a new file, and none of that buys the reader anything.
+    out['cron_schedule'] = compute_cron_schedule()
+    _presence['cron_schedule'] = bool((out.get('cron_schedule') or {}).get('jobs'))
 
     # ── LLM narrative sidecars (agent-written in Step 3; text-only, no keys) ──
     # Each sidecar is validated (validate_insights / validate_intraday_insights)

--- a/src/clawock/scheduling.py
+++ b/src/clawock/scheduling.py
@@ -168,6 +168,65 @@ def load_contract(path: str | Path | None = None, *, workspace: str | Path | Non
     return data
 
 
+# Expanding a cron expression into the slots it fires on a given day has exactly
+# one implementation on purpose: the health check asks "did these slots happen"
+# and the dashboard panel asks "what should have happened today". Two expanders
+# would let those answers drift apart while both looked right.
+def parse_cron_slots(expr, tz_name, target_date_utc):
+    """Given cron expr like `*/30 10-11,14-15 * * 1-5` + tz, return list of
+    HH:MM strings that should fire on `target_date_utc` (UTC datetime).
+
+    Simple parser: handles minute (*/N or list), hour (range,list), DOW.
+    """
+    parts = expr.split()
+    if len(parts) < 5:
+        return []
+    m_field, h_field, _dom, _mo, dow_field = parts[:5]
+
+    # Minute: */N or list
+    def parse_field(field, lo, hi):
+        vals = set()
+        for tok in field.split(','):
+            tok = tok.strip()
+            if tok == '*':
+                vals.update(range(lo, hi+1))
+            elif tok.startswith('*/'):
+                step = int(tok[2:])
+                vals.update(range(lo, hi+1, step))
+            elif '-' in tok:
+                a, b = tok.split('-')
+                # may have /step
+                step = 1
+                if '/' in b:
+                    b, step = b.split('/')
+                    step = int(step)
+                vals.update(range(int(a), int(b)+1, step))
+            else:
+                vals.add(int(tok))
+        return sorted(vals)
+
+    mins = parse_field(m_field, 0, 59)
+    hours = parse_field(h_field, 0, 23)
+    dows = set(parse_field(dow_field, 0, 7))
+    # 0 and 7 both = Sunday in cron
+    if 7 in dows:
+        dows.discard(7); dows.add(0)
+
+    # Get target date in target tz
+    try:
+        tz = ZoneInfo(tz_name)
+    except Exception:
+        tz = timezone.utc
+    target_local = target_date_utc.astimezone(tz)
+    # cron DOW: 0=Sun, 1=Mon, ..., 6=Sat
+    py_weekday = target_local.weekday()  # 0=Mon
+    cron_dow = (py_weekday + 1) % 7      # convert: Mon→1 ... Sun→0
+    if cron_dow not in dows:
+        return []
+
+    return [f"{h:02d}:{m:02d}" for h in hours for m in mins]
+
+
 def us_season(at: datetime | None = None) -> str:
     """Return daylight/standard using the actual New York UTC offset."""
     at = at or datetime.now(timezone.utc)

--- a/tests/test_cron_schedule_panel.py
+++ b/tests/test_cron_schedule_panel.py
@@ -1,0 +1,118 @@
+"""The timetable panel reports the ledger's verdict — it never forms its own."""
+from __future__ import annotations
+
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+from clawock.publish.cron_schedule import timetable
+
+HKT = ZoneInfo('Asia/Hong_Kong')
+
+
+def _contract(expr='3,33 10-11 * * 1-5', name='盘中盯盘', harness='intraday --hk'):
+    return {'jobs': [{'name': name, 'harness': harness,
+                      'schedule': {'expr': expr, 'tz': 'Asia/Shanghai'}}]}
+
+
+def _record(slot, status, job='盘中盯盘'):
+    return {'job': job, 'slot': slot, 'final_product': {'status': status}}
+
+
+def _states(result, job=0):
+    return [cell['state'] for cell in result['jobs'][job]['slots']]
+
+
+def test_the_panel_prints_the_ledgers_verdict_not_its_own():
+    at = datetime(2026, 9, 3, 12, 0, tzinfo=HKT)  # Thursday, after every slot
+    result = timetable(_contract(), [
+        _record('2026-09-03T10:03:00+08:00', 'success'),
+        _record('2026-09-03T10:33:00+08:00', 'recovered'),
+        _record('2026-09-03T11:03:00+08:00', 'degraded'),
+        _record('2026-09-03T11:33:00+08:00', 'failed'),
+    ], now=at)
+
+    assert _states(result) == ['ok', 'recovered', 'degraded', 'failed']
+
+
+def test_an_unmapped_ledger_status_shows_as_unknown_not_as_green():
+    """A default of 'ok' would render a status nobody has looked at as healthy."""
+    at = datetime(2026, 9, 3, 12, 0, tzinfo=HKT)
+    result = timetable(_contract('3 10 * * 1-5'),
+                       [_record('2026-09-03T10:03:00+08:00', 'brand-new-status')],
+                       now=at)
+
+    assert _states(result) == ['unknown']
+
+
+def test_a_slot_is_upcoming_before_it_fires_and_running_inside_its_grace():
+    # A record for some other job: the ledger has content, it just has nothing
+    # for these slots yet.
+    result = timetable(_contract(), [_record('2026-09-03T09:33:00+08:00', 'success',
+                                             job='港股开盘报告')],
+                       now=datetime(2026, 9, 3, 10, 10, tzinfo=HKT))
+
+    # 10:03 fired 7 minutes ago (grace 20) — still running, not a miss yet.
+    assert _states(result) == ['running', 'upcoming', 'upcoming', 'upcoming']
+
+
+def test_a_slot_past_its_grace_with_nothing_on_it_is_missed():
+    result = timetable(_contract(), [_record('2026-09-03T09:33:00+08:00', 'success',
+                                             job='港股开盘报告')],
+                       now=datetime(2026, 9, 3, 10, 30, tzinfo=HKT))
+
+    assert _states(result)[0] == 'missed'
+
+
+def test_records_snap_to_the_grid_so_a_schedule_move_is_not_nine_outages():
+    """#1278 shifted nine jobs by three minutes. The records written that day
+    carry the OLD slot, so an exact join would call the whole day missed."""
+    at = datetime(2026, 9, 3, 12, 0, tzinfo=HKT)
+    result = timetable(_contract(), [
+        _record('2026-09-03T10:00:00+08:00', 'success'),   # old grid
+        _record('2026-09-03T10:30:00+08:00', 'success'),
+    ], now=at)
+
+    assert _states(result)[:2] == ['ok', 'ok']
+
+
+def test_snapping_never_lets_one_record_answer_for_two_slots():
+    """The tolerance is capped at half the gap, so a single run cannot light up
+    its neighbour — which would turn one delivered report into two green slots."""
+    at = datetime(2026, 9, 3, 12, 0, tzinfo=HKT)
+    result = timetable(_contract(), [
+        _record('2026-09-03T10:03:00+08:00', 'success'),
+    ], now=at)
+
+    assert _states(result) == ['ok', 'missed', 'missed', 'missed']
+
+
+def test_a_job_the_ledger_cannot_see_is_not_reported_as_an_outage():
+    """Memory Dreaming runs no harness, so the ledger will never carry a record
+    for it however well it ran. Red every day trains the reader to ignore the
+    panel. The criterion is the contract's `harness` field, not absence from a
+    windowed ledger — absence there also describes a job idle for a few days."""
+    at = datetime(2026, 9, 3, 12, 0, tzinfo=HKT)
+    contract = _contract('0 3 * * *', name='Memory Dreaming Promotion', harness='—')
+
+    result = timetable(contract, [_record('2026-09-03T10:03:00+08:00', 'success')],
+                       now=at)
+
+    assert result['jobs'][0]['unmonitored'] is True
+    assert _states(result) == ['unmonitored']
+
+
+def test_an_empty_ledger_hides_the_panel_rather_than_reporting_red():
+    """A day we cannot speak about is not a day when nothing ran. Painting every
+    past slot red would blame the cron for a bookkeeping gap."""
+    at = datetime(2026, 9, 3, 12, 0, tzinfo=HKT)
+
+    assert timetable(_contract(), [], now=at)['jobs'] == []
+
+
+def test_a_day_the_job_does_not_fire_produces_no_row():
+    """Saturday: the cron dow excludes it, so there is nothing to report — an
+    empty row of grey lights would read as 'something should have happened'."""
+    saturday = datetime(2026, 9, 5, 12, 0, tzinfo=HKT)
+    ledger = [_record('2026-09-05T09:33:00+08:00', 'success', job='港股开盘报告')]
+
+    assert timetable(_contract(), ledger, now=saturday)['jobs'] == []

--- a/tests/test_cron_schedule_panel.py
+++ b/tests/test_cron_schedule_panel.py
@@ -116,3 +116,17 @@ def test_a_day_the_job_does_not_fire_produces_no_row():
     ledger = [_record('2026-09-05T09:33:00+08:00', 'success', job='港股开盘报告')]
 
     assert timetable(_contract(), ledger, now=saturday)['jobs'] == []
+
+
+def test_the_overview_projection_carries_the_timetable():
+    """The first screen reads overview.json, not dashboard.json.
+
+    A projection that drops the key renders an empty card forever and nothing
+    fails — the same shape as the `window_hours` and `wechat_dropped_*` fields
+    this file's neighbours had to add back after the card went out without them.
+    """
+    from clawock.publish.dashboard import compile_overview_projection
+
+    projected = compile_overview_projection({'cron_schedule': {'jobs': [{'job': 'x'}]}})
+
+    assert projected['cron_schedule'] == {'jobs': [{'job': 'x'}]}


### PR DESCRIPTION
kcn：「dashboard 里面可以有一个好的显示定时任务表，然后正常触发了就是绿灯那种。每个时刻表」

数据健康卡回答的是「页面上的数字能不能信」，这张回答的是另一个问题——「今天每个槽有没有按时跑成」——所以是一张新卡，不是往那张里塞。

## 一眼能读到什么

11 个 job 各一行，槽位是带时刻的药丸，颜色即定论：

| | 含义 |
|---|---|
| ● 绿 | 落地 |
| ○ 空心绿 | 兜底补上 |
| ● 黄 | 降级送达 |
| ● 红 | 没落地 / 没跑 |
| ● 蓝 | 进行中 |
| ○ 灰 | 还没到 |
| ○ 灰虚线 | 账本看不到 |

判词只说到证据为止：**有降级就不许写「正常」**，有兜底就单独点出来——都送到了，但一个是首次即成、一个烧掉了一次尝试，混成一句话就把区别抹掉了（这正是 #1278 想让你看见的东西）。

色彩预算没变（涨跌两色＋告警红＋品牌蓝）：「兜底补上」用**空心**这个形状差别表示，不引入第四种装饰色；「账本看不到」用虚线边和「待跑」分开——都不是绿的，但一个是「还没到」，一个是「永远不会有记录」。

## 判定不在面板里推导

`workflow_outcomes._derive_final` 已经为账本算过一次每槽的定论。为显示再算一遍，就是绿灯和它声称在概括的账本各说各话的开始。所以投影只做一件事：把**契约按当天展开的槽**和**账本里 `final_product` 的定论**对上。

三个容易画错的地方，都按「不知道就别染色」处理：

- **换排程当天**：记录带的是运行时契约的槽，#1278 挪了 3 分钟，精确 join 会把整天判成没跑。改成就近吸附，容差取相邻槽间距的一半封顶——既不会让一次运行点亮两个槽，也不会把真缺的槽吸出一个来。
- **账本为空**：不是「今天什么都没跑」，是「无从判断」。返回空行让卡片隐藏，而不是把过去每个槽画红、替记账的窟窿去怪 cron。
- **没有 harness 的 job**（Memory Dreaming）：账本永远不会有它的记录，跑得再好也一样。判据用契约的 harness 字段，不用「账本里找不到」——账本是带窗口的，找不到也可能只是这个 job 几天没跑。

未映射的账本状态落到 `unknown`（灰）而不是 `ok`：新状态该被看见，不该被默认成好。

## 接线上的一个坑

`cron_schedule` 折出后**必须同时进 overview 投影**：首屏读的是 `overview.json` 不是 `dashboard.json`，投影漏掉就等于卡片永远空、而且什么都不会红。我第一版就是这么翻的车——`dashboard.py` 里 `window_hours` 和 `wechat_dropped_*` 两条注释记的正是这个坑各踩过一次。已加 `test_the_overview_projection_carries_the_timetable` 钉住。

面板同时落进 `hero.js` 与 `render.js` 两份手写实现，`test_dashboard_bundle_parity` 就是为「只落一份」而存在的。

另：`parse_cron_slots` 从 `ops/host/cron_health_check.py` 搬进 `clawock.scheduling`——体检脚本问「这些槽发生了没有」，面板问「今天本该跑哪些」，两个展开器会让这两个答案各自漂移而看上去都对。

## 验证

- 暗色 / 浅色、1440 与 390 两种宽度都实截过；手机上换行堆叠、槽位在自己那行横滚，**整页无横向溢出**（脚本断言，不是目测）。
- 10 条测试逐条钉住上面每一个判断，含空账本、无 harness、吸附不越界、周末不出行。
- dashboard / overview / cron / parity / payload_size / publish 全选 **523 passed**。
- `dashboard.json` 193,184 / 200,000 —— 面板占 1.4KB，**余量剩 6.8KB**，size 闸的 WARN 依旧在，之后别再往里塞大件。

https://claude.ai/code/session_01XefDm27j51TFPdkC4qy71g