### PR TITLE
health: 定时任务折进数据健康牌，时刻表换成带时间轴的槽位轨

### DIFF
--- a/site/assets/css/dashboard.css
+++ b/site/assets/css/dashboard.css
@@ -2668,77 +2668,75 @@
   .bs-dot[data-tone="ok"] { background: var(--accent); }
   .bs-dot[data-tone="warn"] { background: var(--warning); }
   .bs-dot[data-tone="bad"] { background: var(--negative, var(--red)); }
-  /* ── 定时任务时刻表 ──
-     色彩预算不变：绿=落地、黄=降级、红=没落地、蓝=进行中、灰=还没到。
-     「兜底补上」不引入第四种颜色——它也落地了，只是烧掉了一次尝试，所以用
-     空心圆这个**形状**差别表示，颜色仍是绿的。档位只染色不减信息。 */
-  /* 与数据健康卡同宽：时刻表是横向的，占一列会把每一行都挤成一个字。 */
-  .cron-board { grid-column: 1 / -1; display: grid; gap: 12px;
-                padding: 16px 18px 14px; }
-  .cb-head {
-    display: flex; align-items: flex-start; justify-content: space-between;
-    gap: 12px; flex-wrap: wrap;
-  }
-  .cb-verdict { margin: 2px 0 0; font-size: var(--fs-lg, 1.05rem); font-weight: 600; }
-  .cron-board[data-tone="warn"] .cb-verdict { color: var(--warning); }
-  .cron-board[data-tone="bad"] .cb-verdict { color: var(--negative, var(--red)); }
-  .cb-meta {
-    margin-top: 4px; color: var(--text-tertiary);
-    font: 500 var(--fs-micro)/1.5 var(--mono);
-  }
-  .cb-legend { display: flex; flex-wrap: wrap; gap: 4px 10px; align-items: center; }
-  .cb-key {
-    display: inline-flex; align-items: center; gap: 4px;
-    color: var(--text-tertiary); font: 500 var(--fs-micro)/1 var(--mono);
-  }
-  .cb-dot {
+  /* ── 今天的槽位轨（数据健康牌内）──
+     色彩预算不变：绿=落地、黄=降级、红=没落地、蓝=进行中、灰=还没到，没有第四
+     种装饰色。「兜底补上」用**空心**这个形状差别表示 —— 它也落地了，只是烧掉了
+     一次尝试，值得看见但不值得一个新颜色。 */
+  .dh-pip {
     display: inline-block; width: 7px; height: 7px; border-radius: 50%;
     background: var(--neutral, var(--text-tertiary)); flex: none;
   }
-  .cb-dot[data-tone="ok"]   { background: var(--positive); }
-  .cb-dot[data-tone="warn"] { background: var(--warning); }
-  .cb-dot[data-tone="bad"]  { background: var(--negative, var(--red)); }
-  .cb-dot[data-tone="live"] { background: var(--accent); }
-  .cb-dot[data-tone="idle"] { background: transparent; box-shadow: inset 0 0 0 1px var(--border-strong); }
-  /* 落地了，但靠 watchdog 补的：同一个绿，空心。 */
-  .cb-dot[data-tone="ok-soft"] {
-    background: transparent; box-shadow: inset 0 0 0 1.5px var(--positive);
+  .dh-pip[data-tone="ok"]   { background: var(--positive); }
+  .dh-pip[data-tone="warn"] { background: var(--warning); }
+  .dh-pip[data-tone="bad"]  { background: var(--negative, var(--red)); }
+  .dh-pip[data-tone="live"] { background: var(--accent); }
+  .dh-pip[data-tone="idle"] { background: transparent; box-shadow: inset 0 0 0 1px var(--border-strong); }
+  /* 轨道上的针只有 3px 宽，描边在这个尺寸上等于不可见。「排了但还没到」必须
+     读得出来（否则一个还没开始的夜晚看起来像没排班），所以换成淡填充。 */
+  .dh-pip.is-slot[data-tone="idle"] {
+    background: var(--border-strong); box-shadow: none; opacity: .8;
   }
-  .cb-rows { display: grid; gap: 2px; }
-  .cb-row {
-    display: grid; grid-template-columns: minmax(6.5em, max-content) 1fr;
-    gap: 10px; align-items: center; padding: 4px 0;
-    border-top: 1px solid var(--border-subtle);
+  .dh-pip[data-tone="ok-soft"] { background: transparent; box-shadow: inset 0 0 0 1.5px var(--positive); }
+  .dh-pip[data-unmonitored="1"] { opacity: .5; }
+
+  .dh-rail { margin-top: 12px; display: grid; gap: 5px; }
+  .dh-rail-head {
+    display: flex; align-items: baseline; justify-content: space-between;
+    gap: 10px; flex-wrap: wrap;
   }
-  .cb-row:first-child { border-top: 0; }
-  /* 账本看不到的 job：虚线边把它和「待跑」分开——两者都不是绿的，但一个是
-     「还没到」，一个是「永远不会有记录」，读者不该把它们看成同一件事。 */
-  .cb-row[data-unmonitored="1"] { opacity: .6; }
-  .cb-row[data-unmonitored="1"] .cb-slot { border-style: dashed; }
-  .cb-job {
-    color: var(--text-secondary); font: 500 var(--fs-micro)/1.4 var(--sans, inherit);
-    white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+  .dh-rail-name {
+    color: var(--text-secondary); font: 500 var(--fs-micro)/1.4 var(--mono);
   }
-  /* 槽多的时候在自己这一行里横向滚动，不让整页横滚。 */
-  .cb-slots {
-    display: flex; gap: 4px; overflow-x: auto; padding-bottom: 2px;
-    scrollbar-width: none;
+  .dh-rail-keys { display: flex; flex-wrap: wrap; gap: 3px 9px; }
+  .dh-rail-key {
+    display: inline-flex; align-items: center; gap: 4px;
+    color: var(--text-tertiary); font: 500 var(--fs-micro)/1 var(--mono);
   }
-  .cb-slots::-webkit-scrollbar { display: none; }
-  .cb-slot {
-    display: inline-flex; align-items: center; gap: 4px; flex: none;
-    padding: 2px 7px; border-radius: 999px;
-    border: 1px solid var(--border-subtle); background: var(--surface-1);
-    color: var(--text-tertiary); font: 500 var(--fs-micro)/1.5 var(--mono);
+  /* 轨道按时刻绝对定位，不是等距排列：等距会把 10:03 和 21:33 画成邻居，而
+     「一整个下午没有槽」正是该被看见的东西。刻度线只给 06/12/18 三条，多了
+     就从「看一眼」变成「读一张图」。 */
+  .dh-rail-track {
+    position: relative; height: 20px; border-radius: 4px;
+    background: var(--surface-1); border: 1px solid var(--border-subtle);
+    background-image: linear-gradient(to right,
+      transparent calc(25% - .5px), var(--border-subtle) calc(25% - .5px),
+      var(--border-subtle) calc(25% + .5px), transparent calc(25% + .5px)),
+      linear-gradient(to right,
+      transparent calc(50% - .5px), var(--border-subtle) calc(50% - .5px),
+      var(--border-subtle) calc(50% + .5px), transparent calc(50% + .5px)),
+      linear-gradient(to right,
+      transparent calc(75% - .5px), var(--border-subtle) calc(75% - .5px),
+      var(--border-subtle) calc(75% + .5px), transparent calc(75% + .5px));
   }
-  .cb-slot[data-tone="ok"]      { color: var(--text-secondary); }
-  .cb-slot[data-tone="ok-soft"] { color: var(--text-secondary); }
-  .cb-slot[data-tone="warn"]    { color: var(--warning); border-color: color-mix(in srgb, var(--warning) 34%, transparent); }
-  .cb-slot[data-tone="bad"]     { color: var(--negative, var(--red)); border-color: color-mix(in srgb, var(--negative, var(--red)) 40%, transparent); }
-  .cb-slot[data-tone="live"]    { color: var(--accent); border-color: color-mix(in srgb, var(--accent) 34%, transparent); }
-  @media (max-width: 560px) {
-    .cb-row { grid-template-columns: 1fr; gap: 2px; }
+  .dh-pip.is-slot {
+    position: absolute; top: 4px; width: 3px; height: 12px; border-radius: 1.5px;
+    transform: translateX(-1.5px); border-radius: 1.5px;
   }
+  .dh-pip.is-slot[data-tone="ok-soft"] { box-shadow: inset 0 0 0 1.5px var(--positive); }
+  .dh-rail-axis {
+    display: flex; justify-content: space-between;
+    color: var(--text-faint, var(--text-tertiary));
+    font: 500 var(--fs-micro)/1 var(--mono);
+  }
+  /* 逐项里那一组：灯挤在 .dh-bar 这一列，槽多时在自己格里横滚，不让整页横滚。 */
+  .dh-row.is-cron .dh-bar.is-lamps {
+    display: flex; align-items: center; gap: 3px;
+    overflow-x: auto; scrollbar-width: none; background: none;
+  }
+  .dh-row.is-cron .dh-bar.is-lamps::-webkit-scrollbar { display: none; }
+  .dh-row.is-cron[data-tone="bad"] .dh-state { color: var(--negative, var(--red)); }
+  .dh-row.is-cron[data-tone="warn"] .dh-state { color: var(--warning); }
+  .dh-row.is-cron[data-tone="idle"] { opacity: .6; }
   .dh-caption {
     margin-top: 10px; color: var(--text-faint, var(--text-tertiary));
     font: 500 var(--fs-micro)/1.5 var(--mono);

--- a/site/assets/js/dashboard.hero.js
+++ b/site/assets/js/dashboard.hero.js
@@ -353,7 +353,7 @@
   // registry mutable avoids parsing 100KB+ of functions that Overview cannot call.
   const TAB_RENDERERS = {
     hero: [
-      renderCommandDeck, renderDataHealth, renderCronSchedule, renderRiskGuardrail, renderOverviewSummaries,
+      renderCommandDeck, renderDataHealth, renderRiskGuardrail, renderOverviewSummaries,
       renderMarketSnapshot, renderTodayHighlights, renderHonesty, renderGoldDca,
       setupVerdictDeck,
     ],
@@ -984,6 +984,118 @@
   // 否则「简报 FAILED」会把一屏可信的数字染成红的。
   // 判过期只认 f.stale —— files[] 有两种新鲜度模式（max_age 比 sla_hours，
   // scheduled_fire 比 deadline_at），自己再算一遍 age>sla 会造出一批假警报。
+  // ── 今天的槽位轨（数据健康牌的一部分，不是另一张牌）──
+  // 状态不在这里推导：dashboard.json 的 cron_schedule 已经是 workflow-outcomes
+  // 账本 final_product 的定论，这里只做「定论 → 颜色」。未知状态刻意落到
+  // unknown（灰）而不是绿 —— 新状态该被看见，不该被默认成好。
+  const CRON_STATES = {
+    ok:          { tone: "ok",      cn: "正常" },
+    recovered:   { tone: "ok-soft", cn: "兜底补上" },
+    degraded:    { tone: "warn",    cn: "降级送达" },
+    failed:      { tone: "bad",     cn: "未落地" },
+    missed:      { tone: "bad",     cn: "没跑" },
+    running:     { tone: "live",    cn: "进行中" },
+    upcoming:    { tone: "idle",    cn: "待跑" },
+    unmonitored: { tone: "idle",    cn: "账本看不到" },
+    unknown:     { tone: "idle",    cn: "状态未知" },
+  };
+  const cronState = s => (CRON_STATES[s] ? s : "unknown");
+
+  // 轨道按 24 小时刻度摆位（不是等距排列）：等距会把 10:03 和 21:33 画成邻居，
+  // 而「一整个下午没有槽」正是读者该看见的东西。
+  function renderCronRail(cs) {
+    const rail = document.getElementById("dh-rail");
+    if (!rail) return null;
+    const jobs = (cs && cs.jobs) || [];
+    if (!jobs.length) { rail.hidden = true; return null; }
+    rail.hidden = false;
+
+    const cells = [];
+    jobs.forEach(j => (j.slots || []).forEach(s => cells.push({
+      job: j.job, at: s.at, state: cronState(s.state), unmonitored: !!j.unmonitored,
+    })));
+    cells.sort((a, b) => a.at.localeCompare(b.at));
+
+    const counts = {};
+    cells.forEach(c => { counts[c.state] = (counts[c.state] || 0) + 1; });
+    const n = k => counts[k] || 0;
+
+    const nameEl = document.getElementById("dh-rail-name");
+    if (nameEl) {
+      const bits = [`${cells.length} 槽`];
+      const landed = n("ok") + n("recovered");
+      if (landed) bits.push(`${landed} 落地`);
+      if (n("recovered")) bits.push(`其中 ${n("recovered")} 靠兜底`);
+      if (n("degraded")) bits.push(`${n("degraded")} 降级`);
+      if (n("failed") + n("missed")) bits.push(`${n("failed") + n("missed")} 没落地`);
+      if (n("running")) bits.push(`${n("running")} 进行中`);
+      if (n("upcoming")) bits.push(`${n("upcoming")} 待跑`);
+      // 账本看不到的那些也要报出来，否则「26 槽」后面跟的分项加起来只有 25，
+      // 剩下的那一个无人认领 —— 有计数没分母正是 #1270 拆这块牌的病因之一。
+      if (n("unmonitored")) bits.push(`${n("unmonitored")} 账本看不到`);
+      nameEl.textContent = `今天 · ${bits.join(" · ")}`;
+    }
+
+    const keysEl = document.getElementById("dh-rail-keys");
+    if (keysEl) {
+      // 图例只列今天真的出现过的状态。把「没跑」常驻在图例里，会让一个全绿的
+      // 早晨看起来也有红色可言。
+      const seen = ["ok", "recovered", "degraded", "failed", "missed", "running",
+                    "upcoming", "unmonitored"].filter(k => n(k));
+      keysEl.innerHTML = seen.map(k =>
+        `<span class="dh-rail-key"><i class="dh-pip" data-tone="${CRON_STATES[k].tone}"></i>`
+        + `${escapeHtml(CRON_STATES[k].cn)}</span>`).join("");
+    }
+
+    const track = document.getElementById("dh-rail-track");
+    if (track) {
+      track.innerHTML = cells.map(c => {
+        const [h, m] = c.at.split(":").map(Number);
+        const left = ((h * 60 + m) / 1440) * 100;
+        const label = `${c.job} ${c.at} ${CRON_STATES[c.state].cn}`;
+        return `<i class="dh-pip is-slot" data-tone="${CRON_STATES[c.state].tone}"`
+          + `${c.unmonitored ? ' data-unmonitored="1"' : ""}`
+          + ` style="left:${left.toFixed(3)}%" title="${escapeHtml(label)}"></i>`;
+      }).join("");
+    }
+    return { cells, counts };
+  }
+
+  // 逐项里的一组：沿用这张牌已有的 .dh-row 语法（名/位置/条/说明/状态五列），
+  // 灯就放在 .dh-bar 那一列 —— 不另发明一张表。
+  function cronScheduleRows(cs) {
+    const jobs = (cs && cs.jobs) || [];
+    if (!jobs.length) return "";
+    return `<div class="dh-sub">定时任务 · 今天每槽</div>` + jobs.map(j => {
+      const slots = (j.slots || []).map(s => ({ ...s, state: cronState(s.state) }));
+      const bad = slots.filter(s => ["failed", "missed"].includes(s.state));
+      const soft = slots.filter(s => ["degraded", "recovered"].includes(s.state));
+      const waiting = slots.filter(s => ["upcoming", "running"].includes(s.state));
+      const state = j.unmonitored ? "账本看不到"
+        : bad.length ? `${bad.length} 没落地`
+        : soft.length ? `${soft.length} ${CRON_STATES[soft[0].state].cn}`
+        : waiting.length && waiting.length < slots.length ? "已跑的正常"
+        : waiting.length ? "待跑"
+        : "正常";
+      const why = j.unmonitored
+        ? "这个 job 没有 harness，账本永远不会有它的记录"
+        : (bad.length || soft.length
+            ? [...bad, ...soft].slice(0, 3)
+                .map(s => `${s.at} ${CRON_STATES[s.state].cn}`).join(" · ")
+            : slots.map(s => s.at).join(" · "));
+      const lamps = slots.map(s =>
+        `<i class="dh-pip" data-tone="${CRON_STATES[s.state].tone}"`
+        + ` title="${escapeHtml(`${s.at} ${CRON_STATES[s.state].cn}`)}"></i>`).join("");
+      const rowState = j.unmonitored ? "idle" : bad.length ? "bad" : soft.length ? "warn" : "ok";
+      return `<div class="dh-row is-cron" data-tone="${rowState}">`
+        + `<span class="dh-name">${escapeHtml(j.job)}</span>`
+        + `<span class="dh-file">${escapeHtml(slots.length > 1 ? `${slots.length} 槽` : slots[0] ? slots[0].at : "")}</span>`
+        + `<span class="dh-bar is-lamps">${lamps}</span>`
+        + `<span class="dh-detail">${escapeHtml(why)}</span>`
+        + `<span class="dh-state">${escapeHtml(state)}</span></div>`;
+    }).join("");
+  }
+
   function renderDataHealth() {
     const root = document.getElementById("data-health");
     if (!root) return;
@@ -1136,6 +1248,9 @@
       { k: "idle", n: pending, t: "进行中" },
     ]);
 
+    // 槽位轨：投递泳道之后紧接着的同一件事，加上时间轴。它不参与判词。
+    renderCronRail(safe(DATA, "cron_schedule"));
+
     // ── 判词只回答一件事：页面上的数字能不能信 ─────────────────────────
     // 数据面逾期 / 体检 ERROR 会让读者正在看的数字变旧或变错；一个任务
     // FAILED 不会 —— 它影响的是成品有没有送出去与有没有归档。两者混成
@@ -1231,7 +1346,8 @@
             : "")
         : "";
 
-      filesEl.innerHTML = todoRows + deliveryRows + `<div class="dh-sub">数据面</div>` + files
+      const cronRows = cronScheduleRows(safe(DATA, "cron_schedule"));
+      filesEl.innerHTML = todoRows + cronRows + deliveryRows + `<div class="dh-sub">数据面</div>` + files
         .slice()
         .sort((a, b) => usage(b) - usage(a))
         .map(f => {
@@ -1256,93 +1372,6 @@
         toggle.textContent = open ? "收起" : "逐项";
         if (filesEl) filesEl.hidden = !open;
       });
-    }
-  }
-
-  // ── 定时任务时刻表 ──
-  // 每槽一枚灯。状态不在这里推导：dashboard.json 的 cron_schedule 里已经是
-  // workflow-outcomes 账本 final_product 的定论，前端只做「定论 → 颜色」的映射。
-  // 未知状态刻意落到 unknown（灰）而不是绿——新状态该被看见，不该被默认成好。
-  const CRON_STATES = {
-    ok:          { tone: "ok",      cn: "正常" },
-    recovered:   { tone: "ok-soft", cn: "兜底补上" },
-    degraded:    { tone: "warn",    cn: "降级送达" },
-    failed:      { tone: "bad",     cn: "未落地" },
-    missed:      { tone: "bad",     cn: "没跑" },
-    running:     { tone: "live",    cn: "进行中" },
-    upcoming:    { tone: "idle",    cn: "待跑" },
-    unmonitored: { tone: "idle",    cn: "账本看不到" },
-    unknown:     { tone: "idle",    cn: "状态未知" },
-  };
-
-  function renderCronSchedule() {
-    const root = document.getElementById("cron-board");
-    if (!root) return;
-    const cs = safe(DATA, "cron_schedule");
-    const jobs = (cs && cs.jobs) || [];
-    if (!jobs.length) { root.hidden = true; return; }
-    root.hidden = false;
-    root.classList.remove("is-pending");
-
-    const rowsEl = document.getElementById("cb-rows");
-    const counts = {};
-    let scheduled = 0;
-    jobs.forEach(j => (j.slots || []).forEach(s => {
-      const key = CRON_STATES[s.state] ? s.state : "unknown";
-      counts[key] = (counts[key] || 0) + 1;
-      if (key !== "unmonitored") scheduled += 1;
-    }));
-    const n = k => counts[k] || 0;
-    const landed = n("ok") + n("recovered");
-    const broken = n("failed") + n("missed");
-
-    // 判词只说落地了多少、坏了多少。把「兜底补上」单列，因为它和「首次即成」
-    // 是两件事：都送到了，但一个烧掉了一次尝试。
-    // 判词只能说到证据为止：有降级就不许说「正常」，有兜底就点出来——都送到了，
-    // 但一个是首次即成、一个烧掉了一次尝试，混成一句话就把区别抹掉了。
-    const verdictEl = root.querySelector(".cb-verdict");
-    if (verdictEl) {
-      verdictEl.textContent =
-        broken ? `${broken} 槽没落地`
-        : n("degraded") ? `${n("degraded")} 槽降级送达`
-        : n("recovered") ? `${n("recovered")} 槽靠兜底补上`
-        : (n("upcoming") + n("running") ? "已跑的都正常" : "今天全部正常");
-    }
-    root.dataset.tone = broken ? "bad" : (n("degraded") || n("recovered") ? "warn" : "ok");
-
-    const bits = [];
-    if (landed) bits.push(`${landed} 落地`);
-    if (n("recovered")) bits.push(`其中 ${n("recovered")} 靠兜底`);
-    if (n("degraded")) bits.push(`${n("degraded")} 降级`);
-    if (broken) bits.push(`${broken} 没落地`);
-    if (n("running")) bits.push(`${n("running")} 进行中`);
-    if (n("upcoming")) bits.push(`${n("upcoming")} 待跑`);
-    const metaEl = document.getElementById("cb-meta");
-    if (metaEl) {
-      metaEl.textContent = `${cs.date || ""} · 共 ${scheduled} 槽` +
-        (bits.length ? ` · ${bits.join(" · ")}` : "");
-    }
-
-    const legendEl = document.getElementById("cb-legend");
-    if (legendEl) {
-      legendEl.innerHTML = ["ok", "recovered", "degraded", "missed", "upcoming"]
-        .map(k => `<span class="cb-key"><i class="cb-dot" data-tone="${CRON_STATES[k].tone}"></i>`
-          + `${escapeHtml(CRON_STATES[k].cn)}</span>`).join("");
-    }
-
-    if (rowsEl) {
-      rowsEl.innerHTML = jobs.map(j => {
-        const slots = (j.slots || []).map(s => {
-          const st = CRON_STATES[s.state] ? s.state : "unknown";
-          const label = `${j.job} ${s.at} ${CRON_STATES[st].cn}`;
-          return `<span class="cb-slot" data-tone="${CRON_STATES[st].tone}" title="${escapeHtml(label)}"`
-            + ` aria-label="${escapeHtml(label)}"><i class="cb-dot" data-tone="${CRON_STATES[st].tone}"></i>`
-            + `${escapeHtml(s.at)}</span>`;
-        }).join("");
-        return `<div class="cb-row"${j.unmonitored ? ' data-unmonitored="1"' : ""}>`
-          + `<span class="cb-job">${escapeHtml(j.job)}</span>`
-          + `<span class="cb-slots">${slots}</span></div>`;
-      }).join("");
     }
   }
 

--- a/site/assets/js/dashboard.render.js
+++ b/site/assets/js/dashboard.render.js
@@ -364,7 +364,7 @@
   const TAB_RENDERERS = {
     hero: [
       renderTodayHighlights, renderHonesty, renderMarketSnapshot, renderCommandDeck,
-      renderDataHealth, renderCronSchedule, renderRiskGuardrail, renderOverviewSummaries, renderGoldDca,
+      renderDataHealth, renderRiskGuardrail, renderOverviewSummaries, renderGoldDca,
       setupVerdictDeck,
     ],
     drill: [
@@ -975,6 +975,118 @@
   // 否则「简报 FAILED」会把一屏可信的数字染成红的。
   // 判过期只认 f.stale —— files[] 有两种新鲜度模式（max_age 比 sla_hours，
   // scheduled_fire 比 deadline_at），自己再算一遍 age>sla 会造出一批假警报。
+  // ── 今天的槽位轨（数据健康牌的一部分，不是另一张牌）──
+  // 状态不在这里推导：dashboard.json 的 cron_schedule 已经是 workflow-outcomes
+  // 账本 final_product 的定论，这里只做「定论 → 颜色」。未知状态刻意落到
+  // unknown（灰）而不是绿 —— 新状态该被看见，不该被默认成好。
+  const CRON_STATES = {
+    ok:          { tone: "ok",      cn: "正常" },
+    recovered:   { tone: "ok-soft", cn: "兜底补上" },
+    degraded:    { tone: "warn",    cn: "降级送达" },
+    failed:      { tone: "bad",     cn: "未落地" },
+    missed:      { tone: "bad",     cn: "没跑" },
+    running:     { tone: "live",    cn: "进行中" },
+    upcoming:    { tone: "idle",    cn: "待跑" },
+    unmonitored: { tone: "idle",    cn: "账本看不到" },
+    unknown:     { tone: "idle",    cn: "状态未知" },
+  };
+  const cronState = s => (CRON_STATES[s] ? s : "unknown");
+
+  // 轨道按 24 小时刻度摆位（不是等距排列）：等距会把 10:03 和 21:33 画成邻居，
+  // 而「一整个下午没有槽」正是读者该看见的东西。
+  function renderCronRail(cs) {
+    const rail = document.getElementById("dh-rail");
+    if (!rail) return null;
+    const jobs = (cs && cs.jobs) || [];
+    if (!jobs.length) { rail.hidden = true; return null; }
+    rail.hidden = false;
+
+    const cells = [];
+    jobs.forEach(j => (j.slots || []).forEach(s => cells.push({
+      job: j.job, at: s.at, state: cronState(s.state), unmonitored: !!j.unmonitored,
+    })));
+    cells.sort((a, b) => a.at.localeCompare(b.at));
+
+    const counts = {};
+    cells.forEach(c => { counts[c.state] = (counts[c.state] || 0) + 1; });
+    const n = k => counts[k] || 0;
+
+    const nameEl = document.getElementById("dh-rail-name");
+    if (nameEl) {
+      const bits = [`${cells.length} 槽`];
+      const landed = n("ok") + n("recovered");
+      if (landed) bits.push(`${landed} 落地`);
+      if (n("recovered")) bits.push(`其中 ${n("recovered")} 靠兜底`);
+      if (n("degraded")) bits.push(`${n("degraded")} 降级`);
+      if (n("failed") + n("missed")) bits.push(`${n("failed") + n("missed")} 没落地`);
+      if (n("running")) bits.push(`${n("running")} 进行中`);
+      if (n("upcoming")) bits.push(`${n("upcoming")} 待跑`);
+      // 账本看不到的那些也要报出来，否则「26 槽」后面跟的分项加起来只有 25，
+      // 剩下的那一个无人认领 —— 有计数没分母正是 #1270 拆这块牌的病因之一。
+      if (n("unmonitored")) bits.push(`${n("unmonitored")} 账本看不到`);
+      nameEl.textContent = `今天 · ${bits.join(" · ")}`;
+    }
+
+    const keysEl = document.getElementById("dh-rail-keys");
+    if (keysEl) {
+      // 图例只列今天真的出现过的状态。把「没跑」常驻在图例里，会让一个全绿的
+      // 早晨看起来也有红色可言。
+      const seen = ["ok", "recovered", "degraded", "failed", "missed", "running",
+                    "upcoming", "unmonitored"].filter(k => n(k));
+      keysEl.innerHTML = seen.map(k =>
+        `<span class="dh-rail-key"><i class="dh-pip" data-tone="${CRON_STATES[k].tone}"></i>`
+        + `${escapeHtml(CRON_STATES[k].cn)}</span>`).join("");
+    }
+
+    const track = document.getElementById("dh-rail-track");
+    if (track) {
+      track.innerHTML = cells.map(c => {
+        const [h, m] = c.at.split(":").map(Number);
+        const left = ((h * 60 + m) / 1440) * 100;
+        const label = `${c.job} ${c.at} ${CRON_STATES[c.state].cn}`;
+        return `<i class="dh-pip is-slot" data-tone="${CRON_STATES[c.state].tone}"`
+          + `${c.unmonitored ? ' data-unmonitored="1"' : ""}`
+          + ` style="left:${left.toFixed(3)}%" title="${escapeHtml(label)}"></i>`;
+      }).join("");
+    }
+    return { cells, counts };
+  }
+
+  // 逐项里的一组：沿用这张牌已有的 .dh-row 语法（名/位置/条/说明/状态五列），
+  // 灯就放在 .dh-bar 那一列 —— 不另发明一张表。
+  function cronScheduleRows(cs) {
+    const jobs = (cs && cs.jobs) || [];
+    if (!jobs.length) return "";
+    return `<div class="dh-sub">定时任务 · 今天每槽</div>` + jobs.map(j => {
+      const slots = (j.slots || []).map(s => ({ ...s, state: cronState(s.state) }));
+      const bad = slots.filter(s => ["failed", "missed"].includes(s.state));
+      const soft = slots.filter(s => ["degraded", "recovered"].includes(s.state));
+      const waiting = slots.filter(s => ["upcoming", "running"].includes(s.state));
+      const state = j.unmonitored ? "账本看不到"
+        : bad.length ? `${bad.length} 没落地`
+        : soft.length ? `${soft.length} ${CRON_STATES[soft[0].state].cn}`
+        : waiting.length && waiting.length < slots.length ? "已跑的正常"
+        : waiting.length ? "待跑"
+        : "正常";
+      const why = j.unmonitored
+        ? "这个 job 没有 harness，账本永远不会有它的记录"
+        : (bad.length || soft.length
+            ? [...bad, ...soft].slice(0, 3)
+                .map(s => `${s.at} ${CRON_STATES[s.state].cn}`).join(" · ")
+            : slots.map(s => s.at).join(" · "));
+      const lamps = slots.map(s =>
+        `<i class="dh-pip" data-tone="${CRON_STATES[s.state].tone}"`
+        + ` title="${escapeHtml(`${s.at} ${CRON_STATES[s.state].cn}`)}"></i>`).join("");
+      const rowState = j.unmonitored ? "idle" : bad.length ? "bad" : soft.length ? "warn" : "ok";
+      return `<div class="dh-row is-cron" data-tone="${rowState}">`
+        + `<span class="dh-name">${escapeHtml(j.job)}</span>`
+        + `<span class="dh-file">${escapeHtml(slots.length > 1 ? `${slots.length} 槽` : slots[0] ? slots[0].at : "")}</span>`
+        + `<span class="dh-bar is-lamps">${lamps}</span>`
+        + `<span class="dh-detail">${escapeHtml(why)}</span>`
+        + `<span class="dh-state">${escapeHtml(state)}</span></div>`;
+    }).join("");
+  }
+
   function renderDataHealth() {
     const root = document.getElementById("data-health");
     if (!root) return;
@@ -1127,6 +1239,9 @@
       { k: "idle", n: pending, t: "进行中" },
     ]);
 
+    // 槽位轨：投递泳道之后紧接着的同一件事，加上时间轴。它不参与判词。
+    renderCronRail(safe(DATA, "cron_schedule"));
+
     // ── 判词只回答一件事：页面上的数字能不能信 ─────────────────────────
     // 数据面逾期 / 体检 ERROR 会让读者正在看的数字变旧或变错；一个任务
     // FAILED 不会 —— 它影响的是成品有没有送出去与有没有归档。两者混成
@@ -1222,7 +1337,8 @@
             : "")
         : "";
 
-      filesEl.innerHTML = todoRows + deliveryRows + `<div class="dh-sub">数据面</div>` + files
+      const cronRows = cronScheduleRows(safe(DATA, "cron_schedule"));
+      filesEl.innerHTML = todoRows + cronRows + deliveryRows + `<div class="dh-sub">数据面</div>` + files
         .slice()
         .sort((a, b) => usage(b) - usage(a))
         .map(f => {
@@ -1247,93 +1363,6 @@
         toggle.textContent = open ? "收起" : "逐项";
         if (filesEl) filesEl.hidden = !open;
       });
-    }
-  }
-
-  // ── 定时任务时刻表 ──
-  // 每槽一枚灯。状态不在这里推导：dashboard.json 的 cron_schedule 里已经是
-  // workflow-outcomes 账本 final_product 的定论，前端只做「定论 → 颜色」的映射。
-  // 未知状态刻意落到 unknown（灰）而不是绿——新状态该被看见，不该被默认成好。
-  const CRON_STATES = {
-    ok:          { tone: "ok",      cn: "正常" },
-    recovered:   { tone: "ok-soft", cn: "兜底补上" },
-    degraded:    { tone: "warn",    cn: "降级送达" },
-    failed:      { tone: "bad",     cn: "未落地" },
-    missed:      { tone: "bad",     cn: "没跑" },
-    running:     { tone: "live",    cn: "进行中" },
-    upcoming:    { tone: "idle",    cn: "待跑" },
-    unmonitored: { tone: "idle",    cn: "账本看不到" },
-    unknown:     { tone: "idle",    cn: "状态未知" },
-  };
-
-  function renderCronSchedule() {
-    const root = document.getElementById("cron-board");
-    if (!root) return;
-    const cs = safe(DATA, "cron_schedule");
-    const jobs = (cs && cs.jobs) || [];
-    if (!jobs.length) { root.hidden = true; return; }
-    root.hidden = false;
-    root.classList.remove("is-pending");
-
-    const rowsEl = document.getElementById("cb-rows");
-    const counts = {};
-    let scheduled = 0;
-    jobs.forEach(j => (j.slots || []).forEach(s => {
-      const key = CRON_STATES[s.state] ? s.state : "unknown";
-      counts[key] = (counts[key] || 0) + 1;
-      if (key !== "unmonitored") scheduled += 1;
-    }));
-    const n = k => counts[k] || 0;
-    const landed = n("ok") + n("recovered");
-    const broken = n("failed") + n("missed");
-
-    // 判词只说落地了多少、坏了多少。把「兜底补上」单列，因为它和「首次即成」
-    // 是两件事：都送到了，但一个烧掉了一次尝试。
-    // 判词只能说到证据为止：有降级就不许说「正常」，有兜底就点出来——都送到了，
-    // 但一个是首次即成、一个烧掉了一次尝试，混成一句话就把区别抹掉了。
-    const verdictEl = root.querySelector(".cb-verdict");
-    if (verdictEl) {
-      verdictEl.textContent =
-        broken ? `${broken} 槽没落地`
-        : n("degraded") ? `${n("degraded")} 槽降级送达`
-        : n("recovered") ? `${n("recovered")} 槽靠兜底补上`
-        : (n("upcoming") + n("running") ? "已跑的都正常" : "今天全部正常");
-    }
-    root.dataset.tone = broken ? "bad" : (n("degraded") || n("recovered") ? "warn" : "ok");
-
-    const bits = [];
-    if (landed) bits.push(`${landed} 落地`);
-    if (n("recovered")) bits.push(`其中 ${n("recovered")} 靠兜底`);
-    if (n("degraded")) bits.push(`${n("degraded")} 降级`);
-    if (broken) bits.push(`${broken} 没落地`);
-    if (n("running")) bits.push(`${n("running")} 进行中`);
-    if (n("upcoming")) bits.push(`${n("upcoming")} 待跑`);
-    const metaEl = document.getElementById("cb-meta");
-    if (metaEl) {
-      metaEl.textContent = `${cs.date || ""} · 共 ${scheduled} 槽` +
-        (bits.length ? ` · ${bits.join(" · ")}` : "");
-    }
-
-    const legendEl = document.getElementById("cb-legend");
-    if (legendEl) {
-      legendEl.innerHTML = ["ok", "recovered", "degraded", "missed", "upcoming"]
-        .map(k => `<span class="cb-key"><i class="cb-dot" data-tone="${CRON_STATES[k].tone}"></i>`
-          + `${escapeHtml(CRON_STATES[k].cn)}</span>`).join("");
-    }
-
-    if (rowsEl) {
-      rowsEl.innerHTML = jobs.map(j => {
-        const slots = (j.slots || []).map(s => {
-          const st = CRON_STATES[s.state] ? s.state : "unknown";
-          const label = `${j.job} ${s.at} ${CRON_STATES[st].cn}`;
-          return `<span class="cb-slot" data-tone="${CRON_STATES[st].tone}" title="${escapeHtml(label)}"`
-            + ` aria-label="${escapeHtml(label)}"><i class="cb-dot" data-tone="${CRON_STATES[st].tone}"></i>`
-            + `${escapeHtml(s.at)}</span>`;
-        }).join("");
-        return `<div class="cb-row"${j.unmonitored ? ' data-unmonitored="1"' : ""}>`
-          + `<span class="cb-job">${escapeHtml(j.job)}</span>`
-          + `<span class="cb-slots">${slots}</span></div>`;
-      }).join("");
     }
   }
 

--- a/site/index.html
+++ b/site/index.html
@@ -309,25 +309,25 @@ layout: null
             <span class="dh-chip" id="dh-delivery-chip"></span>
           </div>
         </div></div>
+        <!-- 今天的槽位轨。投递泳道给的是 36 小时里成品落地的比例，这条给
+             同一件事加上时间轴：按 24 小时刻度摆位，于是场次和空档也读得出来。
+             它**没有自己的判词** —— 判词归投递泳道，同一个主题两处各说一句，
+             就是两个答案开始互相漂移的地方（#1270 拆开这块牌的原因）。 -->
+        <div class="dh-rail" id="dh-rail" hidden>
+          <div class="dh-rail-head">
+            <span class="dh-rail-name" id="dh-rail-name">今天</span>
+            <span class="dh-rail-keys" id="dh-rail-keys" aria-hidden="true"></span>
+          </div>
+          <div class="dh-rail-track" id="dh-rail-track" role="img"
+               aria-label="今天每个定时任务槽位的结果，按时刻摆放"></div>
+          <div class="dh-rail-axis" aria-hidden="true">
+            <span>00</span><span>06</span><span>12</span><span>18</span><span>24</span>
+          </div>
+        </div>
         <div class="dh-caption" id="dh-caption"></div>
         <div class="dh-files" id="dh-files" hidden></div>
       </section>
 
-      <!-- 定时任务时刻表：数据健康卡回答「页面上的数字能不能信」，这张回答
-           「今天每个槽有没有按时跑成」。判定不在前端算——直接印
-           workflow-outcomes 账本里 final_product 的定论，前端只负责上色，
-           否则面板会和账本各说各话。 -->
-      <section class="card cron-board is-pending" id="cron-board" aria-labelledby="cb-title" hidden>
-        <div class="cb-head">
-          <div>
-            <div class="overview-card-kicker">定时任务</div>
-            <h3 id="cb-title" class="cb-verdict">&mdash;</h3>
-            <div class="cb-meta" id="cb-meta">&mdash;</div>
-          </div>
-          <div class="cb-legend" id="cb-legend" aria-hidden="true"></div>
-        </div>
-        <div class="cb-rows" id="cb-rows"></div>
-      </section>
 
       <div class="card hero-gold-card is-pending" id="gold-dca-card">
         <h3>Gold DCA <span class="muted" id="gold-sub" style="text-transform:none;letter-spacing:0;font-weight:500;font-size:var(--fs-xs)"></span></h3>

--- a/tests/dashboard_tab_runtime.spec.js
+++ b/tests/dashboard_tab_runtime.spec.js
@@ -1144,6 +1144,76 @@ async function testVerdictDeckFillsItsBoxAndRanksGatesBySeverity(browser, base) 
 // 点名的位置从判词挪到了「投递」泳道（kcn 2026-09-01：「我也不知道该怎么看」
 // ⇒ 判词只回答「页面上的数字能不能信」，一个任务没落地不改变这个答案）。
 // 断言跟着挪，但要求不变：**不展开就能读到是哪一档、发生了什么**。
+async function testCronRailAccountsForEverySlotWithoutASecondVerdict(browser, base) {
+  // #1270 拆开这块牌的判据是「某个任务挂了」和「页面上的数字不可信」不能共用
+  // 一行判词。时刻表折进来时最容易犯的错就是给它再配一句判词 —— 于是同一件事
+  // 在一张牌上有两个说法。这里钉三件事：每个槽都有一根针、摘要里的分项加起来
+  // 等于总数（有计数没分母是同一个病）、以及降级不会把判词读成数字不可信。
+  const context = await browser.newContext({ viewport: { width: 1280, height: 900 } });
+  const page = await context.newPage();
+  await stubLiveOrigin(page, {
+    patch: (name, json) => {
+      if (name !== "overview.json" && name !== "dashboard.json") return null;
+      json.build_status = json.build_status || {};
+      json.build_status.integrity = { error_count: 0, warn_count: 0 };
+      json.build_status.files = (json.build_status.files || []).map(f => ({
+        ...f, present: true, stale: false,
+      }));
+      json.workflow_outcomes = { counts: { success: 9, degraded: 1 }, degraded_slots: [] };
+      json.cron_schedule = {
+        date: "2026-09-03",
+        jobs: [
+          { job: "盘前深度简报", slots: [{ at: "08:03", state: "ok" }] },
+          { job: "盘中盯盘", slots: [
+            { at: "10:03", state: "degraded" }, { at: "10:33", state: "ok" },
+            { at: "14:03", state: "upcoming" },
+          ] },
+          { job: "Memory Dreaming Promotion", unmonitored: true,
+            slots: [{ at: "03:00", state: "unmonitored" }] },
+        ],
+      };
+      return json;
+    },
+  });
+  await page.goto(base, { waitUntil: "networkidle" });
+  await waitForData(page);
+  await page.waitForSelector("#data-health:not(.is-pending)", { timeout: 5000 });
+
+  const rail = await page.evaluate(() => ({
+    hidden: document.getElementById("dh-rail").hidden,
+    pips: document.querySelectorAll("#dh-rail-track .dh-pip").length,
+    summary: document.getElementById("dh-rail-name").textContent.trim(),
+    verdict: (document.getElementById("dh-verdict")
+      || document.getElementById("dh-title")).textContent.trim(),
+  }));
+
+  assert.equal(rail.hidden, false, "cron rail is hidden even though slots exist");
+  assert.equal(rail.pips, 5, `rail drew ${rail.pips} pips for 5 scheduled slots`);
+
+  const total = Number((rail.summary.match(/(\d+)\s*槽/) || [])[1]);
+  const parts = [...rail.summary.matchAll(/(\d+)\s*(落地|降级|没落地|进行中|待跑|账本看不到)/g)]
+    .filter(m => m[2] !== "落地" || true)
+    .reduce((sum, m) => sum + Number(m[1]), 0);
+  assert.equal(total, 5, `rail total says ${total}, expected 5`);
+  assert.equal(parts, total,
+    `rail breakdown sums to ${parts} but claims ${total} slots — a count with no denominator`);
+
+  // 一次降级不得把可信度那半读成存疑（#1270 的核心断言，折进来后仍须成立）。
+  assert.ok(rail.verdict.includes("页面数字可用"),
+    `a degraded cron slot moved the trust verdict: ${rail.verdict}`);
+
+  const cronRows = await page.evaluate(async () => {
+    document.getElementById("dh-toggle").click();
+    await new Promise(r => setTimeout(r, 50));
+    return [...document.querySelectorAll("#dh-files .dh-row.is-cron")]
+      .map(r => r.querySelector(".dh-name").textContent.trim());
+  });
+  assert.deepEqual(cronRows, ["盘前深度简报", "盘中盯盘", "Memory Dreaming Promotion"],
+    `逐项 is missing the per-job timetable rows: ${cronRows.join(", ")}`);
+
+  await context.close();
+}
+
 async function testDataHealthNamesTheDegradedSlotAndWeChatDrops(browser, base) {
   const context = await browser.newContext({ viewport: { width: 1280, height: 900 } });
   const page = await context.newPage();
@@ -1250,6 +1320,7 @@ async function main() {
     await testHoldingsAndHeroNeverTruncate(browser, base);
     await testVerdictDeckFillsItsBoxAndRanksGatesBySeverity(browser, base);
     await testDataHealthNamesTheDegradedSlotAndWeChatDrops(browser, base);
+    await testCronRailAccountsForEverySlotWithoutASecondVerdict(browser, base);
   } finally {
     await browser.close();
     await new Promise(resolve => server.close(resolve));


### PR DESCRIPTION
kcn：「定时任务能不能和数据健康合并看看怎么优化展示形式」

## 为什么不是把两张牌压成一张

#1270 才刚把这块牌拆开，判据写得很明确：

> **「某个任务挂了」和「页面上的数字不可信」是两件事，不能共用一行判词也不能共用一个颜色。**

把定时任务牌整块并进来再共用一句判词，等于把那个 bug 装回去。

**但重叠是真的存在**，而且正是 kcn 感觉到的那个：

| | 回答什么 | 窗口 | 判词 |
|---|---|---|---|
| 投递泳道 | 成品落地的**比例** | 36 小时 | 「N 档 · 观察」 |
| 独立的定时任务牌 | 今天每槽的**时间轴** | 今天 | 「4 槽降级送达」 |

同一个主题、两套判词、两个窗口 —— 读者无从判断该信哪个，两个答案迟早互相漂移。

⇒ 合并的正确形态：**时刻表降级成投递泳道的证据，不再有自己的判词**，并按这张牌已有的「概览 + 逐项」节奏分两层。

## 两层

**常驻** —— 泳道之下一条槽位轨，按 24 小时刻度**绝对定位**，不是等距排列。等距会把 `10:03` 和 `21:33` 画成邻居，而「一整个下午没有槽」正是该被看见的东西。现在港股场次、美股场次、中间的空档一眼可读。刻度线只给 06/12/18 三条——多了就从「看一眼」变成「读一张图」。

**逐项** —— 每个 job 一行，沿用这张牌已有的 `.dh-row` 五列语法（名/位置/条/说明/状态），灯就放在 `.dh-bar` 那一列，不另发明一张表。每行右侧是这个 job 今天的定论：`正常` / `3 降级送达` / `待跑` / `账本看不到`。

独立的 `cron-board` 牌与它 3.4KB 的样式一并删除。净 +387 / −260。

## 三处按「不知道就别染色」修正

| 问题 | 修正 |
|---|---|
| 「26 槽」后面的分项加起来只有 25，剩下那个无人认领 | 补上「N 账本看不到」——有计数没分母是 #1270 的病因之一 |
| 轨道上的针只有 3px 宽，`idle` 用描边等于不可见 | 换淡填充，否则一个还没开始的夜晚看起来像没排班 |
| 图例常驻列出「没跑」 | 只列今天真的出现过的状态，否则全绿的早晨也显得有红色可言 |

## 闸

`testCronRailAccountsForEverySlotWithoutASecondVerdict` 钉四件事：每个槽都有一根针；摘要分项之和等于总数；**一次 cron 降级不得把可信度那半读成存疑**（#1270 的核心断言，折进来后仍须成立）；逐项里 per-job 三行都在。

**已验非空转**：去掉「账本看不到」那一项，它报
`rail breakdown sums to 4 but claims 5 slots — a count with no denominator`。

## 验证

- 暗色 / 浅色 / 390px 三种都实截过。手机上泳道塌成单列，轨道 320px 仍摆得开 26 根针，**整页无横向溢出**（脚本断言，不是目测）。
- 新断言单跑通过；cron / dashboard / parity / overview / payload_size 全选 **406 passed**。
- `renderDataHealth` 是 hero.js / render.js 手工双份，两份都改了（`test_dashboard_bundle_parity` 会抓只改一份）。
- 本地跑整份 `dashboard_tab_runtime.spec.js` 会在两条**既有**断言上红（`−$2,309` vs `−$2,308` 之类），干净 master 用同一份本地数据同样红——那是我本地把仓库 sidecar 和 data-plane 混成了不同代次，不是这次改动；CI 自己抓匹配代次。

https://claude.ai/code/session_01XefDm27j51TFPdkC4qy71g