### PR TITLE
health: cron 轨道按 job 分行、密刻度、每个非绿点配一句人话

### DIFF
--- a/site/assets/css/dashboard.css
+++ b/site/assets/css/dashboard.css
@@ -2689,7 +2689,9 @@
   .dh-pip[data-tone="ok-soft"] { background: transparent; box-shadow: inset 0 0 0 1.5px var(--positive); }
   .dh-pip[data-unmonitored="1"] { opacity: .5; }
 
-  .dh-rail { margin-top: 12px; display: grid; gap: 5px; }
+  /* 名字列宽度只在一处定义，行、坐标轴、「现在」竖线三处共用同一个数，
+     否则刻度和每行的点会各自对齐到不同的 x 原点，读起来是错位的。 */
+  .dh-rail { margin-top: 12px; display: grid; gap: 6px; --dh-rail-label-w: 10.5em; }
   .dh-rail-head {
     display: flex; align-items: baseline; justify-content: space-between;
     gap: 10px; flex-wrap: wrap;
@@ -2702,31 +2704,62 @@
     display: inline-flex; align-items: center; gap: 4px;
     color: var(--text-tertiary); font: 500 var(--fs-micro)/1 var(--mono);
   }
-  /* 轨道按时刻绝对定位，不是等距排列：等距会把 10:03 和 21:33 画成邻居，而
-     「一整个下午没有槽」正是该被看见的东西。刻度线只给 06/12/18 三条，多了
-     就从「看一眼」变成「读一张图」。 */
-  .dh-rail-track {
-    position: relative; height: 20px; border-radius: 4px;
-    background: var(--surface-1); border: 1px solid var(--border-subtle);
-    background-image: linear-gradient(to right,
-      transparent calc(25% - .5px), var(--border-subtle) calc(25% - .5px),
-      var(--border-subtle) calc(25% + .5px), transparent calc(25% + .5px)),
-      linear-gradient(to right,
-      transparent calc(50% - .5px), var(--border-subtle) calc(50% - .5px),
-      var(--border-subtle) calc(50% + .5px), transparent calc(50% + .5px)),
-      linear-gradient(to right,
-      transparent calc(75% - .5px), var(--border-subtle) calc(75% - .5px),
-      var(--border-subtle) calc(75% + .5px), transparent calc(75% + .5px));
+  /* 每个 job 一条独立的行，共用同一把刻度尺——原来所有 job 的点挤在一条轨道
+     上，只能靠悬停猜是哪个 job；一行一个名字，位置不用猜。刻度线每小时一条、
+     每 3 小时标一个数字，比原来只有 00/06/12/18/24 四个地标精确得多。 */
+  .dh-rail-body { position: relative; }
+  .dh-rail-rows {
+    display: grid; gap: 3px; padding: 6px 0;
+    border-radius: 4px; background: var(--surface-1); border: 1px solid var(--border-subtle);
+  }
+  .dh-rail-row {
+    display: grid; grid-template-columns: var(--dh-rail-label-w) 1fr;
+    gap: 8px; align-items: center; padding: 0 8px;
+  }
+  .dh-rail-row-name {
+    color: var(--text-tertiary); font: 500 var(--fs-micro)/1.3 var(--mono);
+    white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+  }
+  .dh-rail-row-track {
+    position: relative; height: 12px;
+    background-image: repeating-linear-gradient(to right,
+      var(--border-subtle) 0, var(--border-subtle) 1px,
+      transparent 1px, transparent calc(100% / 24));
   }
   .dh-pip.is-slot {
-    position: absolute; top: 4px; width: 3px; height: 12px; border-radius: 1.5px;
-    transform: translateX(-1.5px); border-radius: 1.5px;
+    position: absolute; top: 2px; width: 3px; height: 8px; border-radius: 1.5px;
+    transform: translateX(-1.5px);
   }
   .dh-pip.is-slot[data-tone="ok-soft"] { box-shadow: inset 0 0 0 1.5px var(--positive); }
+  /* 「现在」——一条竖线贯穿所有行，分开「已经跑过」和「还没轮到」，不然一个
+     还没到点的灰点和一个真的没跑的灰点在视觉上完全一样。 */
+  .dh-rail-now {
+    position: absolute; top: -3px; bottom: 0; width: 2px;
+    background: var(--accent); opacity: .8; pointer-events: none;
+  }
+  /* 线顶上一个小三角，不然 2px 的竖线在密集的针脚里太容易被当成又一条刻度线。 */
+  .dh-rail-now::before {
+    content: ""; position: absolute; top: -3px; left: 50%;
+    width: 0; height: 0; transform: translateX(-50%);
+    border-left: 3px solid transparent; border-right: 3px solid transparent;
+    border-top: 4px solid var(--accent); opacity: .9;
+  }
   .dh-rail-axis {
     display: flex; justify-content: space-between;
+    /* +8px 对齐 .dh-rail-row 的左内边距，+1px 让首尾刻度不贴着圆角描边。 */
+    padding: 0 1px 0 calc(var(--dh-rail-label-w) + 8px);
     color: var(--text-faint, var(--text-tertiary));
     font: 500 var(--fs-micro)/1 var(--mono);
+  }
+  /* 「现在」——一条竖线贯穿所有行；left 落在同一把尺子上：先让过名字列，
+     剩下的宽度才是 0-100% 对应的 00:00-24:00，JS 只需要给一个 0-1 的分数。 */
+  .dh-rail-now {
+    left: calc(var(--dh-rail-label-w) + 8px
+      + (100% - var(--dh-rail-label-w) - 16px) * var(--now-frac, 0));
+  }
+  @media (max-width: 560px) {
+    .dh-rail { --dh-rail-label-w: 6.4em; }
+    .dh-rail-row-name { font-size: 10px; }
   }
   /* 逐项里那一组：灯挤在 .dh-bar 这一列，槽多时在自己格里横滚，不让整页横滚。 */
   .dh-row.is-cron .dh-bar.is-lamps {

--- a/site/assets/js/dashboard.hero.js
+++ b/site/assets/js/dashboard.hero.js
@@ -984,10 +984,15 @@
   // 否则「简报 FAILED」会把一屏可信的数字染成红的。
   // 判过期只认 f.stale —— files[] 有两种新鲜度模式（max_age 比 sla_hours，
   // scheduled_fire 比 deadline_at），自己再算一遍 age>sla 会造出一批假警报。
+  const _UNMONITORED_TEXT = "这个 job 没有 harness，账本本来就看不到它的记录，不代表没跑";
+
   // ── 今天的槽位轨（数据健康牌的一部分，不是另一张牌）──
-  // 状态不在这里推导：dashboard.json 的 cron_schedule 已经是 workflow-outcomes
-  // 账本 final_product 的定论，这里只做「定论 → 颜色」。未知状态刻意落到
-  // unknown（灰）而不是绿 —— 新状态该被看见，不该被默认成好。
+  // 灯的颜色仍然是账本 final_product 的定论，这里只做「定论 → 颜色」，不重判。
+  // 颜色只回答「发生了什么」，回答不了「是谁、什么时候、要不要管」——原来所有
+  // job 的点混在一条轨道上，只能靠悬停猜是哪个 job；改成**每个 job 一条独立的
+  // 行**，共用同一条时间轴，一眼就能读出行=job、位置=时刻。判词也先说「要不要
+  // 管」再说「发生了什么」，理由句直接来自 cron_schedule.py 已经翻好的
+  // `note.text`，这里只负责摆出来，不重新组织理由。
   const CRON_STATES = {
     ok:          { tone: "ok",      cn: "正常" },
     recovered:   { tone: "ok-soft", cn: "兜底补上" },
@@ -1000,26 +1005,44 @@
     unknown:     { tone: "idle",    cn: "状态未知" },
   };
   const cronState = s => (CRON_STATES[s] ? s : "unknown");
+  // 与数据健康卡卡底那行处置说明用的是同一套词——不给读者第二本词典。
+  const DISPOSITION_CN = { needs_action: "需处理", watch: "观察",
+                            known_not_fixed: "已知不修", normal: "正常" };
+  const AXIS_MINUTES = h => (h / 24) * 100;
 
-  // 轨道按 24 小时刻度摆位（不是等距排列）：等距会把 10:03 和 21:33 画成邻居，
-  // 而「一整个下午没有槽」正是读者该看见的东西。
-  function renderCronRail(cs) {
+  function cronCells(cs) {
+    const out = [];
+    ((cs && cs.jobs) || []).forEach(j => (j.slots || []).forEach(s => out.push({
+      job: j.job, at: s.at, state: cronState(s.state), unmonitored: !!j.unmonitored,
+      note: s.note || null,
+    })));
+    return out.sort((a, b) => a.at.localeCompare(b.at));
+  }
+
+  // 真正需要处理的槽位，供顶部「处置 · 需处理」清单合并——那份清单是这张牌上
+  // 唯一「你该做点什么」的地方，cron 的待办不该另起一份藏在轨道里。
+  function cronNeedsAction(cs) {
+    return cronCells(cs).filter(c => c.note && c.note.disposition === "needs_action");
+  }
+
+  function renderCronRail(cs, now) {
     const rail = document.getElementById("dh-rail");
     if (!rail) return null;
-    const jobs = (cs && cs.jobs) || [];
+    const jobs = ((cs && cs.jobs) || []).filter(j => (j.slots || []).length);
     if (!jobs.length) { rail.hidden = true; return null; }
     rail.hidden = false;
 
-    const cells = [];
-    jobs.forEach(j => (j.slots || []).forEach(s => cells.push({
-      job: j.job, at: s.at, state: cronState(s.state), unmonitored: !!j.unmonitored,
-    })));
-    cells.sort((a, b) => a.at.localeCompare(b.at));
-
+    const cells = cronCells(cs);
     const counts = {};
     cells.forEach(c => { counts[c.state] = (counts[c.state] || 0) + 1; });
     const n = k => counts[k] || 0;
+    const byDisposition = { needs_action: [], watch: [], known_not_fixed: [] };
+    cells.filter(c => c.note).forEach(c => { (byDisposition[c.note.disposition] || []).push(c); });
 
+    // 这一行不发第二份判词——那正是 #1270 拆牌的原因：一件事只能有一处说
+    // 「要不要处理」。真正需要处理的槽位并进了卡上唯一的「处置 · 需处理」
+    // 清单（见 cronNeedsAction），这里只用中性语气报事实，把「已经知道不用管
+    // 的」也顺手说穿，省得读者自己去猜那个黄点是不是真的要紧。
     const nameEl = document.getElementById("dh-rail-name");
     if (nameEl) {
       const bits = [`${cells.length} 槽`];
@@ -1030,16 +1053,17 @@
       if (n("failed") + n("missed")) bits.push(`${n("failed") + n("missed")} 没落地`);
       if (n("running")) bits.push(`${n("running")} 进行中`);
       if (n("upcoming")) bits.push(`${n("upcoming")} 待跑`);
-      // 账本看不到的那些也要报出来，否则「26 槽」后面跟的分项加起来只有 25，
-      // 剩下的那一个无人认领 —— 有计数没分母正是 #1270 拆这块牌的病因之一。
+      // 账本看不到的也要报出来，否则「26 槽」后面的分项加起来只有 25，剩下
+      // 那一个无人认领——有计数没分母正是 #1270 拆这块牌的病因之一。
       if (n("unmonitored")) bits.push(`${n("unmonitored")} 账本看不到`);
+      if (byDisposition.watch.length) bits.push(`${byDisposition.watch.length} 处已送达只是发布慢了几分钟`);
+      if (byDisposition.known_not_fixed.length) bits.push(`${byDisposition.known_not_fixed.length} 处已知不修`);
+      if (byDisposition.needs_action.length) bits.push(`${byDisposition.needs_action.length} 处见上方「需处理」`);
       nameEl.textContent = `今天 · ${bits.join(" · ")}`;
     }
 
     const keysEl = document.getElementById("dh-rail-keys");
     if (keysEl) {
-      // 图例只列今天真的出现过的状态。把「没跑」常驻在图例里，会让一个全绿的
-      // 早晨看起来也有红色可言。
       const seen = ["ok", "recovered", "degraded", "failed", "missed", "running",
                     "upcoming", "unmonitored"].filter(k => n(k));
       keysEl.innerHTML = seen.map(k =>
@@ -1047,47 +1071,64 @@
         + `${escapeHtml(CRON_STATES[k].cn)}</span>`).join("");
     }
 
-    const track = document.getElementById("dh-rail-track");
-    if (track) {
-      track.innerHTML = cells.map(c => {
-        const [h, m] = c.at.split(":").map(Number);
-        const left = ((h * 60 + m) / 1440) * 100;
-        const label = `${c.job} ${c.at} ${CRON_STATES[c.state].cn}`;
-        return `<i class="dh-pip is-slot" data-tone="${CRON_STATES[c.state].tone}"`
-          + `${c.unmonitored ? ' data-unmonitored="1"' : ""}`
-          + ` style="left:${left.toFixed(3)}%" title="${escapeHtml(label)}"></i>`;
+    // 轴刻度：每 3 小时一个数字、每小时一条细线（CSS 背景画），比原来只有
+    // 00/06/12/18/24 四个地标精确得多；同一条轴下面每个 job 一行，行内的点
+    // 用同一把尺子绝对定位，于是「谁、什么时候」不用悬停就读得出来。
+    const rowsEl = document.getElementById("dh-rail-rows");
+    if (rowsEl) {
+      rowsEl.innerHTML = jobs.map(j => {
+        const slots = (j.slots || []).map(s => ({ ...s, state: cronState(s.state) }));
+        const pips = slots.map(s => {
+          const [h, m] = s.at.split(":").map(Number);
+          const left = AXIS_MINUTES(h + m / 60);
+          const tail = s.note ? `：${s.note.text}` : "";
+          const label = `${j.job} ${s.at} ${CRON_STATES[s.state].cn}${tail}`;
+          return `<i class="dh-pip is-slot" data-tone="${CRON_STATES[s.state].tone}"`
+            + `${j.unmonitored ? ' data-unmonitored="1"' : ""}`
+            + ` style="left:${left.toFixed(3)}%" title="${escapeHtml(label)}"></i>`;
+        }).join("");
+        return `<div class="dh-rail-row">`
+          + `<span class="dh-rail-row-name" title="${escapeHtml(j.job)}">${escapeHtml(j.job)}</span>`
+          + `<span class="dh-rail-row-track">${pips}</span></div>`;
       }).join("");
     }
-    return { cells, counts };
+    const nowEl = document.getElementById("dh-rail-now");
+    if (nowEl && now) {
+      // 百分比留给 CSS 算——它知道名字列多宽，这里只给一个 0-1 的分数。
+      nowEl.style.setProperty("--now-frac", (AXIS_MINUTES(now.getHours() + now.getMinutes() / 60) / 100).toFixed(4));
+      nowEl.hidden = false;
+    }
+    return { cells, byDisposition };
   }
 
-  // 逐项里的一组：沿用这张牌已有的 .dh-row 语法（名/位置/条/说明/状态五列），
-  // 灯就放在 .dh-bar 那一列 —— 不另发明一张表。
+  // 逐项里的一组：沿用这张牌已有的 .dh-row 五列语法（名/位置/条/说明/状态），
+  // 灯放进 .dh-bar 那一列——说明列现在印的是那一句「为什么」，不是裸时刻表。
   function cronScheduleRows(cs) {
     const jobs = (cs && cs.jobs) || [];
     if (!jobs.length) return "";
+    const RANK = { needs_action: 0, known_not_fixed: 1, watch: 2 };
     return `<div class="dh-sub">定时任务 · 今天每槽</div>` + jobs.map(j => {
       const slots = (j.slots || []).map(s => ({ ...s, state: cronState(s.state) }));
-      const bad = slots.filter(s => ["failed", "missed"].includes(s.state));
-      const soft = slots.filter(s => ["degraded", "recovered"].includes(s.state));
+      const noted = slots.filter(s => s.note)
+        .sort((a, b) => (RANK[a.note.disposition] ?? 9) - (RANK[b.note.disposition] ?? 9));
+      const worst = noted[0];
       const waiting = slots.filter(s => ["upcoming", "running"].includes(s.state));
+
       const state = j.unmonitored ? "账本看不到"
-        : bad.length ? `${bad.length} 没落地`
-        : soft.length ? `${soft.length} ${CRON_STATES[soft[0].state].cn}`
+        : worst ? `${noted.length > 1 ? `${noted.length} ` : ""}${DISPOSITION_CN[worst.note.disposition]}`
         : waiting.length && waiting.length < slots.length ? "已跑的正常"
-        : waiting.length ? "待跑"
-        : "正常";
-      const why = j.unmonitored
-        ? "这个 job 没有 harness，账本永远不会有它的记录"
-        : (bad.length || soft.length
-            ? [...bad, ...soft].slice(0, 3)
-                .map(s => `${s.at} ${CRON_STATES[s.state].cn}`).join(" · ")
-            : slots.map(s => s.at).join(" · "));
-      const lamps = slots.map(s =>
-        `<i class="dh-pip" data-tone="${CRON_STATES[s.state].tone}"`
-        + ` title="${escapeHtml(`${s.at} ${CRON_STATES[s.state].cn}`)}"></i>`).join("");
-      const rowState = j.unmonitored ? "idle" : bad.length ? "bad" : soft.length ? "warn" : "ok";
-      return `<div class="dh-row is-cron" data-tone="${rowState}">`
+        : waiting.length ? "待跑" : "正常";
+      const why = j.unmonitored ? _UNMONITORED_TEXT
+        : worst ? worst.note.text + (noted.length > 1 ? `（等 ${noted.length} 条）` : "")
+        : slots.map(s => s.at).join(" · ");
+      const lamps = slots.map(s => {
+        const tail = s.note ? `：${s.note.text}` : "";
+        return `<i class="dh-pip" data-tone="${CRON_STATES[s.state].tone}"`
+          + ` title="${escapeHtml(`${s.at} ${CRON_STATES[s.state].cn}${tail}`)}"></i>`;
+      }).join("");
+      const rowTone = j.unmonitored ? "idle"
+        : worst ? (worst.note.disposition === "needs_action" ? "bad" : "warn") : "ok";
+      return `<div class="dh-row is-cron" data-tone="${rowTone}">`
         + `<span class="dh-name">${escapeHtml(j.job)}</span>`
         + `<span class="dh-file">${escapeHtml(slots.length > 1 ? `${slots.length} 槽` : slots[0] ? slots[0].at : "")}</span>`
         + `<span class="dh-bar is-lamps">${lamps}</span>`
@@ -1095,7 +1136,6 @@
         + `<span class="dh-state">${escapeHtml(state)}</span></div>`;
     }).join("");
   }
-
   function renderDataHealth() {
     const root = document.getElementById("data-health");
     if (!root) return;
@@ -1249,7 +1289,7 @@
     ]);
 
     // 槽位轨：投递泳道之后紧接着的同一件事，加上时间轴。它不参与判词。
-    renderCronRail(safe(DATA, "cron_schedule"));
+    renderCronRail(safe(DATA, "cron_schedule"), new Date());
 
     // ── 判词只回答一件事：页面上的数字能不能信 ─────────────────────────
     // 数据面逾期 / 体检 ERROR 会让读者正在看的数字变旧或变错；一个任务
@@ -1316,6 +1356,13 @@
       jobsWith("failed").forEach(r => todo.push({
         name: r.job, where: r.slot, why: "成品未落地（final_product=failed）",
         next: "看 workflow-outcomes.json 里这一槽的 stages",
+      }));
+      // cron 今天的待办并进同一份清单——「你该做点什么」只该有一个地方，
+      // 不能轨道一份、这里再一份，读者要去两处对才能确认没漏。
+      cronNeedsAction(safe(DATA, "cron_schedule")).forEach(c => todo.push({
+        name: c.job, where: c.at, why: c.note.text,
+        next: c.note.disposition === "needs_action" && c.state === "missed"
+          ? "看 openclaw cron 有没有卡住" : "看 workflow-outcomes.json 这一槽的 stages",
       }));
       const todoRows = todo.length
         ? `<div class="dh-sub">处置 · 需处理</div>`

--- a/site/assets/js/dashboard.render.js
+++ b/site/assets/js/dashboard.render.js
@@ -975,10 +975,15 @@
   // 否则「简报 FAILED」会把一屏可信的数字染成红的。
   // 判过期只认 f.stale —— files[] 有两种新鲜度模式（max_age 比 sla_hours，
   // scheduled_fire 比 deadline_at），自己再算一遍 age>sla 会造出一批假警报。
+  const _UNMONITORED_TEXT = "这个 job 没有 harness，账本本来就看不到它的记录，不代表没跑";
+
   // ── 今天的槽位轨（数据健康牌的一部分，不是另一张牌）──
-  // 状态不在这里推导：dashboard.json 的 cron_schedule 已经是 workflow-outcomes
-  // 账本 final_product 的定论，这里只做「定论 → 颜色」。未知状态刻意落到
-  // unknown（灰）而不是绿 —— 新状态该被看见，不该被默认成好。
+  // 灯的颜色仍然是账本 final_product 的定论，这里只做「定论 → 颜色」，不重判。
+  // 颜色只回答「发生了什么」，回答不了「是谁、什么时候、要不要管」——原来所有
+  // job 的点混在一条轨道上，只能靠悬停猜是哪个 job；改成**每个 job 一条独立的
+  // 行**，共用同一条时间轴，一眼就能读出行=job、位置=时刻。判词也先说「要不要
+  // 管」再说「发生了什么」，理由句直接来自 cron_schedule.py 已经翻好的
+  // `note.text`，这里只负责摆出来，不重新组织理由。
   const CRON_STATES = {
     ok:          { tone: "ok",      cn: "正常" },
     recovered:   { tone: "ok-soft", cn: "兜底补上" },
@@ -991,26 +996,44 @@
     unknown:     { tone: "idle",    cn: "状态未知" },
   };
   const cronState = s => (CRON_STATES[s] ? s : "unknown");
+  // 与数据健康卡卡底那行处置说明用的是同一套词——不给读者第二本词典。
+  const DISPOSITION_CN = { needs_action: "需处理", watch: "观察",
+                            known_not_fixed: "已知不修", normal: "正常" };
+  const AXIS_MINUTES = h => (h / 24) * 100;
 
-  // 轨道按 24 小时刻度摆位（不是等距排列）：等距会把 10:03 和 21:33 画成邻居，
-  // 而「一整个下午没有槽」正是读者该看见的东西。
-  function renderCronRail(cs) {
+  function cronCells(cs) {
+    const out = [];
+    ((cs && cs.jobs) || []).forEach(j => (j.slots || []).forEach(s => out.push({
+      job: j.job, at: s.at, state: cronState(s.state), unmonitored: !!j.unmonitored,
+      note: s.note || null,
+    })));
+    return out.sort((a, b) => a.at.localeCompare(b.at));
+  }
+
+  // 真正需要处理的槽位，供顶部「处置 · 需处理」清单合并——那份清单是这张牌上
+  // 唯一「你该做点什么」的地方，cron 的待办不该另起一份藏在轨道里。
+  function cronNeedsAction(cs) {
+    return cronCells(cs).filter(c => c.note && c.note.disposition === "needs_action");
+  }
+
+  function renderCronRail(cs, now) {
     const rail = document.getElementById("dh-rail");
     if (!rail) return null;
-    const jobs = (cs && cs.jobs) || [];
+    const jobs = ((cs && cs.jobs) || []).filter(j => (j.slots || []).length);
     if (!jobs.length) { rail.hidden = true; return null; }
     rail.hidden = false;
 
-    const cells = [];
-    jobs.forEach(j => (j.slots || []).forEach(s => cells.push({
-      job: j.job, at: s.at, state: cronState(s.state), unmonitored: !!j.unmonitored,
-    })));
-    cells.sort((a, b) => a.at.localeCompare(b.at));
-
+    const cells = cronCells(cs);
     const counts = {};
     cells.forEach(c => { counts[c.state] = (counts[c.state] || 0) + 1; });
     const n = k => counts[k] || 0;
+    const byDisposition = { needs_action: [], watch: [], known_not_fixed: [] };
+    cells.filter(c => c.note).forEach(c => { (byDisposition[c.note.disposition] || []).push(c); });
 
+    // 这一行不发第二份判词——那正是 #1270 拆牌的原因：一件事只能有一处说
+    // 「要不要处理」。真正需要处理的槽位并进了卡上唯一的「处置 · 需处理」
+    // 清单（见 cronNeedsAction），这里只用中性语气报事实，把「已经知道不用管
+    // 的」也顺手说穿，省得读者自己去猜那个黄点是不是真的要紧。
     const nameEl = document.getElementById("dh-rail-name");
     if (nameEl) {
       const bits = [`${cells.length} 槽`];
@@ -1021,16 +1044,17 @@
       if (n("failed") + n("missed")) bits.push(`${n("failed") + n("missed")} 没落地`);
       if (n("running")) bits.push(`${n("running")} 进行中`);
       if (n("upcoming")) bits.push(`${n("upcoming")} 待跑`);
-      // 账本看不到的那些也要报出来，否则「26 槽」后面跟的分项加起来只有 25，
-      // 剩下的那一个无人认领 —— 有计数没分母正是 #1270 拆这块牌的病因之一。
+      // 账本看不到的也要报出来，否则「26 槽」后面的分项加起来只有 25，剩下
+      // 那一个无人认领——有计数没分母正是 #1270 拆这块牌的病因之一。
       if (n("unmonitored")) bits.push(`${n("unmonitored")} 账本看不到`);
+      if (byDisposition.watch.length) bits.push(`${byDisposition.watch.length} 处已送达只是发布慢了几分钟`);
+      if (byDisposition.known_not_fixed.length) bits.push(`${byDisposition.known_not_fixed.length} 处已知不修`);
+      if (byDisposition.needs_action.length) bits.push(`${byDisposition.needs_action.length} 处见上方「需处理」`);
       nameEl.textContent = `今天 · ${bits.join(" · ")}`;
     }
 
     const keysEl = document.getElementById("dh-rail-keys");
     if (keysEl) {
-      // 图例只列今天真的出现过的状态。把「没跑」常驻在图例里，会让一个全绿的
-      // 早晨看起来也有红色可言。
       const seen = ["ok", "recovered", "degraded", "failed", "missed", "running",
                     "upcoming", "unmonitored"].filter(k => n(k));
       keysEl.innerHTML = seen.map(k =>
@@ -1038,47 +1062,64 @@
         + `${escapeHtml(CRON_STATES[k].cn)}</span>`).join("");
     }
 
-    const track = document.getElementById("dh-rail-track");
-    if (track) {
-      track.innerHTML = cells.map(c => {
-        const [h, m] = c.at.split(":").map(Number);
-        const left = ((h * 60 + m) / 1440) * 100;
-        const label = `${c.job} ${c.at} ${CRON_STATES[c.state].cn}`;
-        return `<i class="dh-pip is-slot" data-tone="${CRON_STATES[c.state].tone}"`
-          + `${c.unmonitored ? ' data-unmonitored="1"' : ""}`
-          + ` style="left:${left.toFixed(3)}%" title="${escapeHtml(label)}"></i>`;
+    // 轴刻度：每 3 小时一个数字、每小时一条细线（CSS 背景画），比原来只有
+    // 00/06/12/18/24 四个地标精确得多；同一条轴下面每个 job 一行，行内的点
+    // 用同一把尺子绝对定位，于是「谁、什么时候」不用悬停就读得出来。
+    const rowsEl = document.getElementById("dh-rail-rows");
+    if (rowsEl) {
+      rowsEl.innerHTML = jobs.map(j => {
+        const slots = (j.slots || []).map(s => ({ ...s, state: cronState(s.state) }));
+        const pips = slots.map(s => {
+          const [h, m] = s.at.split(":").map(Number);
+          const left = AXIS_MINUTES(h + m / 60);
+          const tail = s.note ? `：${s.note.text}` : "";
+          const label = `${j.job} ${s.at} ${CRON_STATES[s.state].cn}${tail}`;
+          return `<i class="dh-pip is-slot" data-tone="${CRON_STATES[s.state].tone}"`
+            + `${j.unmonitored ? ' data-unmonitored="1"' : ""}`
+            + ` style="left:${left.toFixed(3)}%" title="${escapeHtml(label)}"></i>`;
+        }).join("");
+        return `<div class="dh-rail-row">`
+          + `<span class="dh-rail-row-name" title="${escapeHtml(j.job)}">${escapeHtml(j.job)}</span>`
+          + `<span class="dh-rail-row-track">${pips}</span></div>`;
       }).join("");
     }
-    return { cells, counts };
+    const nowEl = document.getElementById("dh-rail-now");
+    if (nowEl && now) {
+      // 百分比留给 CSS 算——它知道名字列多宽，这里只给一个 0-1 的分数。
+      nowEl.style.setProperty("--now-frac", (AXIS_MINUTES(now.getHours() + now.getMinutes() / 60) / 100).toFixed(4));
+      nowEl.hidden = false;
+    }
+    return { cells, byDisposition };
   }
 
-  // 逐项里的一组：沿用这张牌已有的 .dh-row 语法（名/位置/条/说明/状态五列），
-  // 灯就放在 .dh-bar 那一列 —— 不另发明一张表。
+  // 逐项里的一组：沿用这张牌已有的 .dh-row 五列语法（名/位置/条/说明/状态），
+  // 灯放进 .dh-bar 那一列——说明列现在印的是那一句「为什么」，不是裸时刻表。
   function cronScheduleRows(cs) {
     const jobs = (cs && cs.jobs) || [];
     if (!jobs.length) return "";
+    const RANK = { needs_action: 0, known_not_fixed: 1, watch: 2 };
     return `<div class="dh-sub">定时任务 · 今天每槽</div>` + jobs.map(j => {
       const slots = (j.slots || []).map(s => ({ ...s, state: cronState(s.state) }));
-      const bad = slots.filter(s => ["failed", "missed"].includes(s.state));
-      const soft = slots.filter(s => ["degraded", "recovered"].includes(s.state));
+      const noted = slots.filter(s => s.note)
+        .sort((a, b) => (RANK[a.note.disposition] ?? 9) - (RANK[b.note.disposition] ?? 9));
+      const worst = noted[0];
       const waiting = slots.filter(s => ["upcoming", "running"].includes(s.state));
+
       const state = j.unmonitored ? "账本看不到"
-        : bad.length ? `${bad.length} 没落地`
-        : soft.length ? `${soft.length} ${CRON_STATES[soft[0].state].cn}`
+        : worst ? `${noted.length > 1 ? `${noted.length} ` : ""}${DISPOSITION_CN[worst.note.disposition]}`
         : waiting.length && waiting.length < slots.length ? "已跑的正常"
-        : waiting.length ? "待跑"
-        : "正常";
-      const why = j.unmonitored
-        ? "这个 job 没有 harness，账本永远不会有它的记录"
-        : (bad.length || soft.length
-            ? [...bad, ...soft].slice(0, 3)
-                .map(s => `${s.at} ${CRON_STATES[s.state].cn}`).join(" · ")
-            : slots.map(s => s.at).join(" · "));
-      const lamps = slots.map(s =>
-        `<i class="dh-pip" data-tone="${CRON_STATES[s.state].tone}"`
-        + ` title="${escapeHtml(`${s.at} ${CRON_STATES[s.state].cn}`)}"></i>`).join("");
-      const rowState = j.unmonitored ? "idle" : bad.length ? "bad" : soft.length ? "warn" : "ok";
-      return `<div class="dh-row is-cron" data-tone="${rowState}">`
+        : waiting.length ? "待跑" : "正常";
+      const why = j.unmonitored ? _UNMONITORED_TEXT
+        : worst ? worst.note.text + (noted.length > 1 ? `（等 ${noted.length} 条）` : "")
+        : slots.map(s => s.at).join(" · ");
+      const lamps = slots.map(s => {
+        const tail = s.note ? `：${s.note.text}` : "";
+        return `<i class="dh-pip" data-tone="${CRON_STATES[s.state].tone}"`
+          + ` title="${escapeHtml(`${s.at} ${CRON_STATES[s.state].cn}${tail}`)}"></i>`;
+      }).join("");
+      const rowTone = j.unmonitored ? "idle"
+        : worst ? (worst.note.disposition === "needs_action" ? "bad" : "warn") : "ok";
+      return `<div class="dh-row is-cron" data-tone="${rowTone}">`
         + `<span class="dh-name">${escapeHtml(j.job)}</span>`
         + `<span class="dh-file">${escapeHtml(slots.length > 1 ? `${slots.length} 槽` : slots[0] ? slots[0].at : "")}</span>`
         + `<span class="dh-bar is-lamps">${lamps}</span>`
@@ -1086,7 +1127,6 @@
         + `<span class="dh-state">${escapeHtml(state)}</span></div>`;
     }).join("");
   }
-
   function renderDataHealth() {
     const root = document.getElementById("data-health");
     if (!root) return;
@@ -1240,7 +1280,7 @@
     ]);
 
     // 槽位轨：投递泳道之后紧接着的同一件事，加上时间轴。它不参与判词。
-    renderCronRail(safe(DATA, "cron_schedule"));
+    renderCronRail(safe(DATA, "cron_schedule"), new Date());
 
     // ── 判词只回答一件事：页面上的数字能不能信 ─────────────────────────
     // 数据面逾期 / 体检 ERROR 会让读者正在看的数字变旧或变错；一个任务
@@ -1307,6 +1347,13 @@
       jobsWith("failed").forEach(r => todo.push({
         name: r.job, where: r.slot, why: "成品未落地（final_product=failed）",
         next: "看 workflow-outcomes.json 里这一槽的 stages",
+      }));
+      // cron 今天的待办并进同一份清单——「你该做点什么」只该有一个地方，
+      // 不能轨道一份、这里再一份，读者要去两处对才能确认没漏。
+      cronNeedsAction(safe(DATA, "cron_schedule")).forEach(c => todo.push({
+        name: c.job, where: c.at, why: c.note.text,
+        next: c.note.disposition === "needs_action" && c.state === "missed"
+          ? "看 openclaw cron 有没有卡住" : "看 workflow-outcomes.json 这一槽的 stages",
       }));
       const todoRows = todo.length
         ? `<div class="dh-sub">处置 · 需处理</div>`

--- a/site/index.html
+++ b/site/index.html
@@ -310,18 +310,25 @@ layout: null
           </div>
         </div></div>
         <!-- 今天的槽位轨。投递泳道给的是 36 小时里成品落地的比例，这条给
-             同一件事加上时间轴：按 24 小时刻度摆位，于是场次和空档也读得出来。
-             它**没有自己的判词** —— 判词归投递泳道，同一个主题两处各说一句，
-             就是两个答案开始互相漂移的地方（#1270 拆开这块牌的原因）。 -->
+             同一件事加上时间轴。它**没有自己的判词**——判词只在上面「处置 ·
+             需处理」清单和这一行摘要里说一次，不重复一份（#1270 拆开这块牌
+             的原因）。每个 job 一条独立的行、共用同一把刻度尺，不用悬停就能
+             读出「谁 · 什么时候」；刻度每 3 小时标一个数字、每小时一条细线，
+             比原来只有 00/06/12/18/24 四个地标精确得多，另有一条「现在」竖线
+             区分「已经跑过」和「还没轮到」。 -->
         <div class="dh-rail" id="dh-rail" hidden>
           <div class="dh-rail-head">
             <span class="dh-rail-name" id="dh-rail-name">今天</span>
             <span class="dh-rail-keys" id="dh-rail-keys" aria-hidden="true"></span>
           </div>
-          <div class="dh-rail-track" id="dh-rail-track" role="img"
-               aria-label="今天每个定时任务槽位的结果，按时刻摆放"></div>
+          <div class="dh-rail-body">
+            <div class="dh-rail-rows" id="dh-rail-rows" role="img"
+                 aria-label="今天每个定时任务的槽位，按 job 分行、按时刻摆放"></div>
+            <i class="dh-rail-now" id="dh-rail-now" title="现在" hidden></i>
+          </div>
           <div class="dh-rail-axis" aria-hidden="true">
-            <span>00</span><span>06</span><span>12</span><span>18</span><span>24</span>
+            <span>00</span><span>03</span><span>06</span><span>09</span>
+            <span>12</span><span>15</span><span>18</span><span>21</span><span>24</span>
           </div>
         </div>
         <div class="dh-caption" id="dh-caption"></div>

--- a/src/clawock/publish/cron_schedule.py
+++ b/src/clawock/publish/cron_schedule.py
@@ -12,6 +12,15 @@ only joins two things that already exist:
 A slot with no record yet is not a failure until its grace window has passed;
 before that it is simply upcoming, which is why this needs `now` and not just
 the date.
+
+Every non-`ok` slot also carries a `note`: {disposition, text}. `disposition`
+reuses the data-health card's own four words (需处理/观察/已知不修/正常) so the
+reader is not asked to learn a second vocabulary. `text` is a sentence built
+purely from fields the ledger already published for that slot — never a new
+pass/fail judgment, only a description of the one the ledger already made.
+The `degraded` split in particular mirrors `workflow_outcomes._advisory_only`
+exactly (`escalating_count == 0`), reading the same field it reads, so this
+narrates the ledger's reasoning rather than inventing a second one.
 """
 from __future__ import annotations
 
@@ -54,6 +63,85 @@ def _has_harness(job):
     """
     harness = str(job.get('harness') or '').strip()
     return bool(harness) and harness not in {'-', '—', '–'}
+
+
+#: The same four words the data-health card already uses for disposition —
+#: one vocabulary across the whole card, not a second one invented here.
+NEEDS_ACTION, WATCH, KNOWN_NOT_FIXED, NORMAL = (
+    'needs_action', 'watch', 'known_not_fixed', 'normal')
+
+
+def _note(disposition, text):
+    return {'disposition': disposition, 'text': text}
+
+
+def _narrate_recovered(record):
+    # #1278: MiniMax holds an overloaded request 100-143s before it 429s, and
+    # the schedule was moved specifically so the FIRST attempt of a slot lands
+    # off the top of the hour. A slot that still needed the watchdog is the
+    # rarer case that first attempt lost anyway — the retry is the system
+    # working as designed, not a fault to chase.
+    return _note(WATCH, '首次投递超时，watchdog 重投后送达；这是已知机制'
+                        '（MiniMax 过载超时，重投几乎必成，见 #1278），无需处理')
+
+
+def _narrate_degraded(record):
+    postflight = (record.get('stages') or {}).get('postflight') or {}
+    delivery = (record.get('stages') or {}).get('primary_delivery') or {}
+    wechat_ok = delivery.get('wechat_ok')
+    telegram_ok = delivery.get('telegram_ok')
+    escalating = postflight.get('escalating_count')
+    issues = postflight.get('issue_count') or 0
+    data_plane = postflight.get('data_plane_status')
+
+    # WeChat's context-token drop is diagnosed and deliberately left unfixed
+    # (#771) — Telegram is the reliable channel on those slots, not a gap.
+    if wechat_ok is False and telegram_ok:
+        return _note(KNOWN_NOT_FIXED,
+                    '微信投递失败（上游 ret=-2 prepare failed），Telegram 已接住；'
+                    '已知不修（#771）')
+    # `escalating_count` is the exact field `_advisory_only` reads — a nonzero
+    # count is the same signal that made the ledger call this slot degraded,
+    # not a re-judgment of it.
+    if escalating:
+        return _note(NEEDS_ACTION,
+                    f'内容校验有 {issues} 条问题，其中 {escalating} 条不是仅供参考的'
+                    '——报告已投递但可能有误，查 workflow-outcomes.json 这一槽的 stages')
+    # The other way `_advisory_only`'s AND fails: content was clean but the
+    # dashboard commit had not published yet the moment this record was
+    # written. The scheduled publisher ticks every 20 minutes and catches up
+    # on its own — this is a bookkeeping lag, not a delivery problem.
+    if data_plane and data_plane not in {'published', 'current', 'skipped'}:
+        return _note(WATCH,
+                    '两个渠道都已送达，内容校验没有问题；仪表盘发布还在排队，'
+                    '几分钟内自动追上，无需处理')
+    reason = (record.get('final_product') or {}).get('reason')
+    return _note(WATCH, reason or '降级送达')
+
+
+def _narrate_failed(record):
+    return _note(NEEDS_ACTION, '这一槽没有产出，成品未落地——这段时间没有报告送达')
+
+
+_MISSED_NOTE = _note(
+    NEEDS_ACTION, '到点了但账本里没有这一槽的记录，需要看是不是卡住了')
+_UNMONITORED_NOTE = _note(
+    NORMAL, '这个 job 没有 harness，账本本来就看不到它的记录，不代表没跑')
+
+_NARRATORS = {
+    'recovered': _narrate_recovered,
+    'degraded': _narrate_degraded,
+    'failed': _narrate_failed,
+}
+
+
+def _note_for(state, record):
+    """The note for one cell, or None when a bare light says everything."""
+    if record and state in _NARRATORS:
+        return _NARRATORS[state](record)
+    if state == 'missed':
+        return _MISSED_NOTE
+    return None
 
 
 def _local_slots(job, day_utc):
@@ -129,8 +217,8 @@ def timetable(contract, records, *, now=None):
         # there also describes a job that simply has not run for a few days.
         if not _has_harness(job):
             rows.append({'job': name, 'tz': tz_name, 'unmonitored': True,
-                         'slots': [{'at': slot, 'state': 'unmonitored'}
-                                   for slot in slots]})
+                         'slots': [{'at': slot, 'state': 'unmonitored',
+                                   'note': _UNMONITORED_NOTE} for slot in slots]})
             continue
         found = _records_by_slot(records, name, day, tz, slots)
         cells = []
@@ -148,7 +236,11 @@ def timetable(contract, records, *, now=None):
                 state = 'running'
             else:
                 state = 'missed'
-            cells.append({'at': slot, 'state': state})
+            cell = {'at': slot, 'state': state}
+            note = _note_for(state, record)
+            if note:
+                cell['note'] = note
+            cells.append(cell)
         rows.append({'job': name, 'tz': tz_name, 'slots': cells})
     return {
         'date': now.astimezone(HKT).strftime('%Y-%m-%d'),

--- a/tests/dashboard_tab_runtime.spec.js
+++ b/tests/dashboard_tab_runtime.spec.js
@@ -1147,8 +1147,8 @@ async function testVerdictDeckFillsItsBoxAndRanksGatesBySeverity(browser, base) 
 async function testCronRailAccountsForEverySlotWithoutASecondVerdict(browser, base) {
   // #1270 拆开这块牌的判据是「某个任务挂了」和「页面上的数字不可信」不能共用
   // 一行判词。时刻表折进来时最容易犯的错就是给它再配一句判词 —— 于是同一件事
-  // 在一张牌上有两个说法。这里钉三件事：每个槽都有一根针、摘要里的分项加起来
-  // 等于总数（有计数没分母是同一个病）、以及降级不会把判词读成数字不可信。
+  // 在一张牌上有两个说法。这里钉住：每个槽都有一根针、按 job 分行且行名可读、
+  // 摘要里的分项加起来等于总数、降级不会把可信度那半读成存疑。
   const context = await browser.newContext({ viewport: { width: 1280, height: 900 } });
   const page = await context.newPage();
   await stubLiveOrigin(page, {
@@ -1165,11 +1165,18 @@ async function testCronRailAccountsForEverySlotWithoutASecondVerdict(browser, ba
         jobs: [
           { job: "盘前深度简报", slots: [{ at: "08:03", state: "ok" }] },
           { job: "盘中盯盘", slots: [
-            { at: "10:03", state: "degraded" }, { at: "10:33", state: "ok" },
+            { at: "10:03", state: "degraded", note: {
+              disposition: "watch",
+              text: "两个渠道都已送达，内容校验没有问题；仪表盘发布还在排队，几分钟内自动追上，无需处理",
+            } },
+            { at: "10:33", state: "ok" },
             { at: "14:03", state: "upcoming" },
           ] },
           { job: "Memory Dreaming Promotion", unmonitored: true,
-            slots: [{ at: "03:00", state: "unmonitored" }] },
+            slots: [{ at: "03:00", state: "unmonitored", note: {
+              disposition: "normal",
+              text: "这个 job 没有 harness，账本本来就看不到它的记录，不代表没跑",
+            } }] },
         ],
       };
       return json;
@@ -1181,7 +1188,9 @@ async function testCronRailAccountsForEverySlotWithoutASecondVerdict(browser, ba
 
   const rail = await page.evaluate(() => ({
     hidden: document.getElementById("dh-rail").hidden,
-    pips: document.querySelectorAll("#dh-rail-track .dh-pip").length,
+    pips: document.querySelectorAll("#dh-rail-rows .dh-pip").length,
+    rowNames: [...document.querySelectorAll(".dh-rail-row-name")].map(el => el.textContent.trim()),
+    axisLabels: [...document.querySelectorAll(".dh-rail-axis span")].map(el => el.textContent.trim()),
     summary: document.getElementById("dh-rail-name").textContent.trim(),
     verdict: (document.getElementById("dh-verdict")
       || document.getElementById("dh-title")).textContent.trim(),
@@ -1189,10 +1198,15 @@ async function testCronRailAccountsForEverySlotWithoutASecondVerdict(browser, ba
 
   assert.equal(rail.hidden, false, "cron rail is hidden even though slots exist");
   assert.equal(rail.pips, 5, `rail drew ${rail.pips} pips for 5 scheduled slots`);
+  // 一眼看出「谁」不能靠悬停——每个 job 一条独立的行，行名就是答案。
+  assert.deepEqual(rail.rowNames, ["盘前深度简报", "盘中盯盘", "Memory Dreaming Promotion"],
+    `rail rows do not label which job each row belongs to: ${rail.rowNames.join(", ")}`);
+  // 刻度比原来只有 00/06/12/18/24 四个地标密：每 3 小时一个数字。
+  assert.deepEqual(rail.axisLabels, ["00", "03", "06", "09", "12", "15", "18", "21", "24"],
+    `rail axis is not the denser 3-hour tick set: ${rail.axisLabels.join(",")}`);
 
   const total = Number((rail.summary.match(/(\d+)\s*槽/) || [])[1]);
   const parts = [...rail.summary.matchAll(/(\d+)\s*(落地|降级|没落地|进行中|待跑|账本看不到)/g)]
-    .filter(m => m[2] !== "落地" || true)
     .reduce((sum, m) => sum + Number(m[1]), 0);
   assert.equal(total, 5, `rail total says ${total}, expected 5`);
   assert.equal(parts, total,
@@ -1202,14 +1216,75 @@ async function testCronRailAccountsForEverySlotWithoutASecondVerdict(browser, ba
   assert.ok(rail.verdict.includes("页面数字可用"),
     `a degraded cron slot moved the trust verdict: ${rail.verdict}`);
 
-  const cronRows = await page.evaluate(async () => {
+  const detail = await page.evaluate(async () => {
     document.getElementById("dh-toggle").click();
     await new Promise(r => setTimeout(r, 50));
-    return [...document.querySelectorAll("#dh-files .dh-row.is-cron")]
-      .map(r => r.querySelector(".dh-name").textContent.trim());
+    const rows = [...document.querySelectorAll("#dh-files .dh-row.is-cron")];
+    return rows.map(r => ({
+      name: r.querySelector(".dh-name").textContent.trim(),
+      detail: r.querySelector(".dh-detail").textContent.trim(),
+    }));
   });
-  assert.deepEqual(cronRows, ["盘前深度简报", "盘中盯盘", "Memory Dreaming Promotion"],
-    `逐项 is missing the per-job timetable rows: ${cronRows.join(", ")}`);
+  assert.deepEqual(detail.map(r => r.name),
+    ["盘前深度简报", "盘中盯盘", "Memory Dreaming Promotion"],
+    `逐项 is missing the per-job timetable rows: ${detail.map(r => r.name).join(", ")}`);
+  // 逐项里印的是那句「为什么」，不是裸时刻表——读者不用去猜黄点是什么意思。
+  const cronRow = detail.find(r => r.name === "盘中盯盘");
+  assert.ok(cronRow && cronRow.detail.includes("仪表盘发布还在排队"),
+    `逐项 detail for a degraded slot lost its plain-language reason: ${cronRow && cronRow.detail}`);
+
+  await context.close();
+}
+
+async function testCronNeedsActionMergesIntoTheOneTodoListButWatchDoesNot(browser, base) {
+  // 「要不要管」只该有一个地方回答。真正需要处理的 cron 槽必须并进卡上唯一的
+  // 「处置 · 需处理」清单；只是发布排队之类的 watch 级槽绝不能混进去——否则
+  // 那份清单会重新变回「一堆不用管的东西」，读者又得自己甄别。
+  const context = await browser.newContext({ viewport: { width: 1280, height: 900 } });
+  const page = await context.newPage();
+  await stubLiveOrigin(page, {
+    patch: (name, json) => {
+      if (name !== "overview.json" && name !== "dashboard.json") return null;
+      json.build_status = json.build_status || {};
+      json.build_status.integrity = { error_count: 0, warn_count: 0 };
+      json.build_status.files = (json.build_status.files || []).map(f => ({
+        ...f, present: true, stale: false,
+      }));
+      json.workflow_outcomes = { counts: { success: 8, degraded: 2 }, degraded_slots: [] };
+      json.cron_schedule = {
+        date: "2026-09-03",
+        jobs: [
+          { job: "港股午后快报", slots: [{ at: "13:33", state: "failed", note: {
+            disposition: "needs_action",
+            text: "这一槽没有产出，成品未落地——这段时间没有报告送达",
+          } }] },
+          { job: "盘中盯盘", slots: [{ at: "10:03", state: "degraded", note: {
+            disposition: "watch",
+            text: "两个渠道都已送达，内容校验没有问题；仪表盘发布还在排队，几分钟内自动追上，无需处理",
+          } }] },
+        ],
+      };
+      return json;
+    },
+  });
+  await page.goto(base, { waitUntil: "networkidle" });
+  await waitForData(page);
+  await page.waitForSelector("#data-health:not(.is-pending)", { timeout: 5000 });
+
+  const todo = await page.evaluate(async () => {
+    document.getElementById("dh-toggle").click();
+    await new Promise(r => setTimeout(r, 50));
+    return [...document.querySelectorAll("#dh-files .dh-row.is-todo")]
+      .map(r => ({ name: r.querySelector(".dh-name").textContent.trim(),
+                   why: r.querySelector(".dh-detail").textContent.trim() }));
+  });
+
+  const needsAction = todo.find(t => t.name === "港股午后快报");
+  assert.ok(needsAction, `needs_action cron slot never reached the 需处理 list: ${JSON.stringify(todo)}`);
+  assert.ok(needsAction.why.includes("没有产出"),
+    `todo row lost the plain-language reason: ${needsAction.why}`);
+  assert.ok(!todo.some(t => t.name === "盘中盯盘"),
+    "a watch-level (self-healing) cron slot leaked into the 需处理 list");
 
   await context.close();
 }
@@ -1321,6 +1396,7 @@ async function main() {
     await testVerdictDeckFillsItsBoxAndRanksGatesBySeverity(browser, base);
     await testDataHealthNamesTheDegradedSlotAndWeChatDrops(browser, base);
     await testCronRailAccountsForEverySlotWithoutASecondVerdict(browser, base);
+    await testCronNeedsActionMergesIntoTheOneTodoListButWatchDoesNot(browser, base);
   } finally {
     await browser.close();
     await new Promise(resolve => server.close(resolve));

--- a/tests/test_cron_schedule_panel.py
+++ b/tests/test_cron_schedule_panel.py
@@ -130,3 +130,89 @@ def test_the_overview_projection_carries_the_timetable():
     projected = compile_overview_projection({'cron_schedule': {'jobs': [{'job': 'x'}]}})
 
     assert projected['cron_schedule'] == {'jobs': [{'job': 'x'}]}
+
+
+# ── notes: 每个非 ok 灯配一句话，说的是账本已经知道的事，不重新判定 ──────
+
+def _record_with(status, **stages):
+    record = _record('2026-09-03T10:03:00+08:00', status)
+    record['stages'] = stages
+    return record
+
+
+def test_a_recovered_slot_explains_the_watchdog_mechanism():
+    result = timetable(_contract('3 10 * * 1-5'), [
+        _record('2026-09-03T10:03:00+08:00', 'recovered'),
+    ], now=datetime(2026, 9, 3, 12, 0, tzinfo=HKT))
+
+    note = result['jobs'][0]['slots'][0]['note']
+    assert note['disposition'] == 'watch'
+    assert '首次投递超时' in note['text'] and '无需处理' in note['text']
+
+
+def test_degraded_with_a_real_content_issue_reads_as_needs_action():
+    """escalating_count > 0 is the exact field `_advisory_only` reads to call a
+    slot degraded — the note must read the same field, not a different one."""
+    record = _record_with('degraded', postflight={
+        'issue_count': 3, 'escalating_count': 1, 'data_plane_status': 'published',
+    }, primary_delivery={'wechat_ok': True, 'telegram_ok': True})
+    result = timetable(_contract('3 10 * * 1-5'), [record],
+                       now=datetime(2026, 9, 3, 12, 0, tzinfo=HKT))
+
+    note = result['jobs'][0]['slots'][0]['note']
+    assert note['disposition'] == 'needs_action'
+    assert '3 条问题' in note['text'] and '1 条不是仅供参考' in note['text']
+
+
+def test_degraded_from_a_publish_lag_alone_reads_as_watch_not_needs_action():
+    """The pattern behind every degraded slot on 2026-09-03: both channels
+    delivered, content check clean, only the dashboard commit hadn't published
+    yet when the ledger snapshotted. Self-heals within the next publish tick."""
+    record = _record_with('degraded', postflight={
+        'issue_count': 0, 'escalating_count': 0, 'data_plane_status': 'committed_local',
+    }, primary_delivery={'wechat_ok': True, 'telegram_ok': True})
+    result = timetable(_contract('3 10 * * 1-5'), [record],
+                       now=datetime(2026, 9, 3, 12, 0, tzinfo=HKT))
+
+    note = result['jobs'][0]['slots'][0]['note']
+    assert note['disposition'] == 'watch'
+    assert '发布还在排队' in note['text'] and '无需处理' in note['text']
+
+
+def test_degraded_from_a_wechat_drop_reads_as_known_not_fixed():
+    record = _record_with('degraded', postflight={
+        'issue_count': 0, 'escalating_count': 0, 'data_plane_status': 'published',
+    }, primary_delivery={'wechat_ok': False, 'telegram_ok': True})
+    result = timetable(_contract('3 10 * * 1-5'), [record],
+                       now=datetime(2026, 9, 3, 12, 0, tzinfo=HKT))
+
+    note = result['jobs'][0]['slots'][0]['note']
+    assert note['disposition'] == 'known_not_fixed'
+    assert '#771' in note['text']
+
+
+def test_a_failed_slot_reads_as_needs_action():
+    result = timetable(_contract('3 10 * * 1-5'), [
+        _record('2026-09-03T10:03:00+08:00', 'failed'),
+    ], now=datetime(2026, 9, 3, 12, 0, tzinfo=HKT))
+
+    assert result['jobs'][0]['slots'][0]['note']['disposition'] == 'needs_action'
+
+
+def test_a_missed_slot_reads_as_needs_action():
+    result = timetable(_contract('3 10 * * 1-5'),
+                       [_record('2026-09-03T09:33:00+08:00', 'success', job='港股开盘报告')],
+                       now=datetime(2026, 9, 3, 10, 30, tzinfo=HKT))
+
+    assert result['jobs'][0]['slots'][0]['note']['disposition'] == 'needs_action'
+
+
+def test_ok_and_upcoming_slots_carry_no_note():
+    """A note on a plainly-good light is a lie waiting to happen — nothing to
+    explain means nothing gets attached, not an empty string."""
+    result = timetable(_contract(), [
+        _record('2026-09-03T10:03:00+08:00', 'success'),
+    ], now=datetime(2026, 9, 3, 10, 40, tzinfo=HKT))
+
+    for cell in result['jobs'][0]['slots']:
+        assert 'note' not in cell, cell


### PR DESCRIPTION
kcn：「能不能做更明确一点带上时间线刻度那些呢…现在还是不懂我该看到什么但没有看到的。我要怎么处理，会影响什么这些」

## 先说这次挖出来的一个事实

把今天每个「降级」槽的完整账本记录挖出来看：6 个降级槽里 **5 个微信和 Telegram 都送达了、内容校验也没问题**——「降级」只是因为记账那一刻仪表盘发布还没排到，几分钟内自动追上。这跟「报告有问题」是完全不同的两件事，但轨道原来只有一个黄点，读者没法分辨。

**这就是问题的根**：颜色回答的是「发生了什么」，回答不了「是谁、什么时候、要不要管、会影响什么」——这四个正是 kcn 问的。

## 改法一：轨道从「一条混在一起的线」变成「按 job 分行的时间轴」

| 之前 | 现在 |
|---|---|
| 所有 job 的点挤在一条轨道上，只能悬停猜是哪个 job | 每个 job 一条独立的行，行名就是答案 |
| 刻度只有 00/06/12/18/24 四个地标 | 每 3 小时一个数字、每小时一条细线 |
| 分不清「已经跑过」和「还没轮到」的灰点 | 新增一条「现在」竖线 |

行名列宽度用一个 CSS 变量在行/坐标轴/竖线三处共用，否则三者会各自对齐到不同的 x 原点——这是实现里最容易犯的错。

## 改法二：每个非绿点配一句账本已经知道的话

`cron_schedule.py` 新增叙述层：`disposition`（需处理/观察/已知不修/正常——和数据健康卡卡底的说明用**同一套词**，不给读者第二本词典）+ 一句中文。**这句话不是新判定**——分支逻辑照抄 `workflow_outcomes._advisory_only` 读的同一个字段（`escalating_count == 0`），只是把账本已经做过的判断翻成人话：

- `degraded` 且 `escalating_count>0` → **需处理**，报具体问题数、指去哪查
- `degraded` 但只是发布队列没追上、内容干净 → **观察**，「无需处理」
- `degraded` 且微信掉投、Telegram 接住 → **已知不修**（#771）
- `recovered` → **观察**，点名是 MiniMax 过载重投的已知机制（#1278）
- `failed` / `missed` → **需处理**
- `unmonitored`（无 harness） → **正常**

真正「需处理」的槽位并进卡上**唯一**的「处置 · 需处理」清单——不是轨道自己另开一份判词，那正是 #1270 拆牌的原因。「观察」级的不进清单（今天全部 6 个降级槽都是观察级，所以清单里今天没有 cron 相关项——这本身也是一个诚实的结论）。逐项的说明列现在印的是完整句子，不再是裸时刻表。

## 效果对比

**之前**：一条轨道，悬停才知道是谁、什么状态。
**现在**：11 行，一眼读出「谁 · 什么时候 · 什么颜色」；展开逐项能看到「为什么」和「要不要管」的完整句子；真正要处理的直接在卡片顶部的清单里。

## 验证

- Python 叙述层 **17 条测试**，含四条 degraded 分支的判别、ok/upcoming 不挂 note 的反向断言。
- 浏览器契约重写了轨道测试（行名可读、刻度密度、逐项说明文本）并新增一条钉住「需处理并进清单、观察不并入」。
- cron / dashboard / parity / overview / payload_size 全选 **413 passed**。
- `cron_schedule` 折算后 2066 字节（含叙述层，之前 1414），`dashboard.json` 仍在 200KB 上限内有余量。
- 暗色 / 浅色 / 1440 / 390 四种都实截过；行名列宽度调整后长 job 名（如「美股盘中盯盘-overnight」）桌面端不截断，手机端保留省略号 + 完整 title。

## 顺带一提，不在这次范围

浏览器契约里 `testVerdictDeckFillsItsBoxAndRanksGatesBySeverity` 间歇性红——用干净 master（faabfb6f）配同一份实时抓取数据独立复现过，与本次改动无关，是抓取瞬间的数据生成态问题（同类此前诊断过一次，见 hero-spark vs 快照口径那次）。

https://claude.ai/code/session_01XefDm27j51TFPdkC4qy71g