### PR TITLE
cron_health_check: snap heartbeat events to the grid like the dashboard panel does

### DIFF
--- a/ops/host/cron_health_check.py
+++ b/ops/host/cron_health_check.py
@@ -56,6 +56,17 @@ TERMINAL_HEARTBEAT_STATES = {
 }
 HEARTBEAT_GRACE_MINUTES = 25
 
+# How far a heartbeat event may sit from an expected slot and still count as
+# that slot's evidence. `cron_heartbeat.slot_for()` buckets every event onto
+# the half-hour grid (:00/:30) regardless of the minute the job actually fired
+# on; the contract's `expr` is the fire minute, not the bucket (#1278 moved
+# these three jobs to 3,33 specifically to dodge MiniMax's on-the-hour
+# congestion). An exact HH:MM join between the two therefore never matches —
+# same failure `clawock.publish.cron_schedule._records_by_slot` already snaps
+# around for the dashboard timetable panel; this constant and the matching
+# below mirror that fix (its SNAP_MINUTES) for the health check's own join.
+HEARTBEAT_SNAP_MINUTES = 15
+
 # Indexed directly (not .get) so a state added to check_dashboard_build without
 # an icon fails here loudly instead of printing a blank cell. Module-level so the
 # tests can index the real map rather than restate it.
@@ -324,14 +335,23 @@ def heartbeat_coverage(job_name, slots, tz_name, now, ledger, day=None):
         started = datetime.min.replace(tzinfo=timezone.utc)
     tz = ZoneInfo(tz_name)
     local_day = day or now.astimezone(tz).date()
+    grid = []
     monitored = []
     for slot in slots:
         hour, minute = map(int, slot.split(':'))
         slot_dt = datetime.combine(local_day, datetime.min.time(), tzinfo=tz).replace(
             hour=hour, minute=minute
         )
+        grid.append((slot, slot_dt))
         if slot_dt.astimezone(timezone.utc) >= started.astimezone(timezone.utc):
             monitored.append(slot)
+    # Snap each event to its nearest expected slot rather than an exact HH:MM
+    # join — see HEARTBEAT_SNAP_MINUTES. Tolerance is capped at half the gap
+    # between adjacent slots so two slots can never both claim one event.
+    tolerance = timedelta(minutes=HEARTBEAT_SNAP_MINUTES)
+    if len(grid) > 1:
+        gaps = [later[1] - earlier[1] for earlier, later in zip(grid, grid[1:])]
+        tolerance = min(tolerance, min(gaps) / 2)
     events = {}
     for event in ledger.get('events', []):
         if event.get('job') != job_name:
@@ -343,8 +363,11 @@ def heartbeat_coverage(job_name, slots, tz_name, now, ledger, day=None):
             event_local = event_dt.astimezone(tz)
         except Exception:
             continue
-        if event_local.date() == local_day:
-            events[event_local.strftime('%H:%M')] = event
+        if event_local.date() != local_day:
+            continue
+        nearest = min(grid, key=lambda cell: abs(cell[1] - event_local), default=None)
+        if nearest and abs(nearest[1] - event_local) <= tolerance:
+            events.setdefault(nearest[0], event)
     healthy, failed, missing, pending = [], [], [], []
     for slot in monitored:
         hour, minute = map(int, slot.split(':'))

--- a/tests/test_cron_health_check.py
+++ b/tests/test_cron_health_check.py
@@ -148,6 +148,70 @@ def test_backstop_covered_slots_ignores_a_stale_recovered_record_from_another_da
     assert covered == set()
 
 
+# ── #1278 follow-up: a schedule move must not paint every heartbeat slot red ──
+# `cron_heartbeat.slot_for()` buckets every event onto the half-hour grid
+# (:00/:30), independent of the minute the job actually fired on. #1278 moved
+# 盘中盯盘/美股盘中盯盘/美股盘中盯盘-overnight's `expr` to `3,33` specifically to
+# dodge MiniMax's on-the-hour congestion, so the slots this check expects are
+# now minutes off that grid. An exact HH:MM join (the pre-fix behaviour) would
+# never match a single event, painting the whole day red for a job that ran
+# fine — the same failure `cron_schedule._records_by_slot` was already fixed
+# for on the dashboard timetable panel; these tests hold the health check to
+# the same standard.
+def _heartbeat_ledger(events):
+    return {
+        "schema_version": 1,
+        "monitoring_started_at": "2026-09-01T00:00:00+08:00",
+        "events": events,
+    }
+
+
+def _heartbeat_event(job, slot_iso, state="completed"):
+    return {"job": job, "slot": slot_iso, "state": state}
+
+
+def test_heartbeat_events_snap_to_the_grid_so_a_schedule_move_is_not_all_missed():
+    from datetime import date
+    ledger = _heartbeat_ledger([
+        _heartbeat_event("美股盘中盯盘-overnight", "2026-09-04T00:00:00+08:00"),
+        _heartbeat_event("美股盘中盯盘-overnight", "2026-09-04T00:30:00+08:00"),
+    ])
+    now = datetime(2026, 9, 4, 1, 0, tzinfo=timezone.utc)  # 09:00 HKT
+    coverage = cron_health_check.heartbeat_coverage(
+        "美股盘中盯盘-overnight", ["00:03", "00:33"], "Asia/Hong_Kong", now, ledger,
+        day=date(2026, 9, 4))
+    assert coverage["missing"] == []
+    assert sorted(coverage["healthy"]) == ["00:03", "00:33"]
+
+
+def test_heartbeat_snapping_never_lets_one_event_answer_for_two_slots():
+    from datetime import date
+    # A single event exactly between two expected slots must not satisfy both.
+    ledger = _heartbeat_ledger([
+        _heartbeat_event("盘中盯盘", "2026-09-04T10:15:00+08:00"),
+    ])
+    now = datetime(2026, 9, 4, 3, 0, tzinfo=timezone.utc)  # 11:00 HKT
+    coverage = cron_health_check.heartbeat_coverage(
+        "盘中盯盘", ["10:03", "10:33"], "Asia/Hong_Kong", now, ledger,
+        day=date(2026, 9, 4))
+    assert len(coverage["healthy"]) == 1
+    assert len(coverage["missing"]) == 1
+
+
+def test_a_heartbeat_slot_with_no_event_anywhere_near_it_still_reports_missing():
+    from datetime import date
+    ledger = _heartbeat_ledger([
+        _heartbeat_event("盘中盯盘", "2026-09-04T10:00:00+08:00"),
+        # 10:30 never ran — nothing within tolerance of it.
+    ])
+    now = datetime(2026, 9, 4, 3, 0, tzinfo=timezone.utc)  # 11:00 HKT
+    coverage = cron_health_check.heartbeat_coverage(
+        "盘中盯盘", ["10:03", "10:33"], "Asia/Hong_Kong", now, ledger,
+        day=date(2026, 9, 4))
+    assert coverage["healthy"] == ["10:03"]
+    assert coverage["missing"] == ["10:33"]
+
+
 def test_a_closed_weekend_is_silence_by_design():
     # 2026-08-09 12:00 HKT is a Sunday: no session to publish into, so an old
     # generation is correct and must not be reported as a stalled publisher.


### PR DESCRIPTION
## What's broken

#1278 moved `盘中盯盘` / `美股盘中盯盘` / `美股盘中盯盘-overnight`'s cron `expr` to
`3,33` (off the hour/half-hour) to dodge MiniMax's on-the-hour congestion. But
`cron_heartbeat.slot_for()` still buckets every heartbeat event onto the
half-hour grid (`:00`/`:30`), independent of the minute the job actually fired
on. `cron_health_check.heartbeat_coverage()` was joining the expected slots
(derived from `expr`, e.g. `"00:03"`) against the ledger's event slots (the
grid, `"00:00"`) with an **exact** `HH:MM` string match — which can now never
succeed.

Result: every `Cron Health Check` run since the #1278 move landed reports
these three jobs as **fully missing** (`heartbeat 0/6`, `0/8`, `0/4`), even
though `assets/data/cron-heartbeats.json` shows every one of those slots
`completed` with `watchdog_state: ok`. Confirmed against the actual failing
run (`2026-09-03T13:34 UTC`, run 33761867734) — its exact inputs, replayed
locally, reproduce `missing=00:03,00:33,01:03,01:33,02:03,02:33`.

## The fix

`clawock.publish.cron_schedule._records_by_slot` already solved this same
mismatch for the dashboard timetable panel — its own docstring calls out
#1278 by number. It snaps each record to its nearest expected slot, tolerance
capped at half the adjacent-slot gap, instead of an exact join. This PR ports
the same snapping to `heartbeat_coverage()` so the health check agrees with
the panel that already reads the identical ledger correctly.

Verified against the live ledger: the fixed function now reports all 6/6, 8/8,
4/4 slots healthy for the same inputs that previously read 0/6, 0/8, 0/4.

## Tests

Added three regression tests mirroring the panel's existing
`test_records_snap_to_the_grid_so_a_schedule_move_is_not_nine_outages`:
- a schedule move snaps cleanly (the #1278 scenario)
- one event never satisfies two slots
- a genuinely missing slot (nothing within tolerance) still reads as missing

`tests/test_cron_health_check.py`, `tests/test_cron_schedule_panel.py`,
`tests/test_cron_contracts.py` all pass locally (77 passed).

https://claude.ai/code/session_012DHHiwnamJXqkwRENotv6N