### PR TITLE
fix: follow dsh 0.1.2's client store module so the plugin still loads

### DIFF
--- a/docs/operations/release.md
+++ b/docs/operations/release.md
@@ -41,10 +41,12 @@ ops/host/install_clawock_launcher.sh to refresh this metadata)
 That drift is cosmetic and expected; it was still read as a missing feature once
 ([#745](https://github.com/KCNyu/clawock/issues/745)), which is why the string
 now names the checkout. `git -C /root/.openclaw/workspace log --oneline -1` is
-the real answer for the Python half, and for the plugin half it is
-`curl -s http://127.0.0.1:3081/plugins/clawock-dsh/client.js | cmp -
-examples/dsh/packages/clawock-dsh/lib/client.js` — `refresh_live.sh` runs both
-checks itself after it installs anything.
+the real answer for the Python half, and for the plugin half it is the served
+bundle: since dsh 0.1.2 a client bundle has no per-plugin URL, so read
+`clawock-dsh`'s entry out of the `/plugins/events` module graph and compare
+the served bytes against `examples/dsh/packages/clawock-dsh/lib/client.js`
+(the response carries a trailing `sourceMappingURL` comment the file does not)
+— `refresh_live.sh` runs both checks itself after it installs anything.
 
 Cut a release when the outside world needs the change — a PyPI/npm user, a
 documented install line, a version a skill contract names — and batch fixes into

--- a/examples/dsh/packages/clawock-dsh/lib/client.js
+++ b/examples/dsh/packages/clawock-dsh/lib/client.js
@@ -4,7 +4,7 @@ window.__ModuleLoader__.load({
     var module = { exports: {} };
     var exports = module.exports;
     Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
-const { defineStore } = require("@deepseek-ai/dsh-client-runtime/client");
+const { defineStore } = require("@deepseek-ai/dsh-client-store");
 const React = require("react");
 //#region node_modules/zod/v4/core/core.js
 var _a$1;

--- a/examples/dsh/packages/clawock-dsh/lib/types/client.d.ts
+++ b/examples/dsh/packages/clawock-dsh/lib/types/client.d.ts
@@ -45,7 +45,7 @@ export interface DecisionMindState {
  * Store factory — called once inside `apply`. Never a module-level handle:
  * the module cache would make it a singleton shared across plugin reloads.
  */
-export declare function createDecisionMindStore(): import("@deepseek-ai/dsh-client-runtime/client").EngineStoreHandle<DecisionMindState, {
+export declare function createDecisionMindStore(): import("@deepseek-ai/dsh-client-store").EngineStoreHandle<DecisionMindState, {
     setFilter: (draft: DecisionMindState, value: TraceFilter) => void;
     toggleOpen: (draft: DecisionMindState, key: string) => void;
     showMoreDates: (draft: DecisionMindState, count: number) => void;
@@ -174,7 +174,7 @@ export interface BalanceUiState {
     selected: string | null;
 }
 /** Store factory — called inside `apply`, never a module-level handle. */
-export declare function createBalanceStore(): import("@deepseek-ai/dsh-client-runtime/client").EngineStoreHandle<BalanceUiState, {
+export declare function createBalanceStore(): import("@deepseek-ai/dsh-client-store").EngineStoreHandle<BalanceUiState, {
     select: (draft: BalanceUiState, provider: string) => void;
 }>;
 /** The chip's registration store handle type (derived, like DecisionMind's). */

--- a/examples/dsh/packages/clawock-dsh/package-lock.json
+++ b/examples/dsh/packages/clawock-dsh/package-lock.json
@@ -13,7 +13,7 @@
         "zod": "^4.4.3"
       },
       "devDependencies": {
-        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-client-store": "^0.1.2-rc.1",
         "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.6",
         "@deepseek-ai/dsh-typert-generator": "0.1.0-rc.8",
         "@types/node": "^26.2.0",
@@ -28,21 +28,21 @@
       }
     },
     "node_modules/@deepseek-ai/cordis": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/cordis/-/cordis-4.0.1.tgz",
-      "integrity": "sha512-YBdskTU2Po1kru3GgcUWUbkTsPMA9LkSQDAY8rBkFJeajdgcQad3QPJZE26JyK99Xb6HaASvoXg2DSUTeN/0Nw==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/cordis/-/cordis-4.0.2.tgz",
+      "integrity": "sha512-asOnXP1TzFSFQlHb1iegDZp0z/8WD1c7YNrwJR/Tx2bzNuMXfcekE/I67Iv6SQXeLB4csxqCngzQKANP7gdw0g==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@deepseek-ai/cosmokit": "^1.8.2",
+        "@deepseek-ai/cosmokit": "^1.8.3",
         "@standard-schema/spec": "^1.1.0"
       },
       "bin": {
         "cordis": "bin.js"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis-plugin-include": "^1.0.6",
-        "@deepseek-ai/cordis-plugin-loader": "^1.0.2"
+        "@deepseek-ai/cordis-plugin-include": "^1.0.7",
+        "@deepseek-ai/cordis-plugin-loader": "^1.0.3"
       },
       "peerDependenciesMeta": {
         "@deepseek-ai/cordis-plugin-include": {
@@ -54,33 +54,33 @@
       }
     },
     "node_modules/@deepseek-ai/cordis-plugin-include": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/cordis-plugin-include/-/cordis-plugin-include-1.0.6.tgz",
-      "integrity": "sha512-i1VXrZCbv6tk/iUgedCNjrxxArbWT3IvRZGB5sdqJ3ectnihivXXQbRZ8JJ73DSmAPvlMGmrbtjFAfm10yvXRg==",
-      "devOptional": true,
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/cordis-plugin-include/-/cordis-plugin-include-1.0.7.tgz",
+      "integrity": "sha512-bZ4S1YuOmwOeE97HnslQ6ggVQbaWz4GejJ8OcY4P/DIyc1Qhu/3Szt1XSw6c/pd37kRkxxJXGwt4cmCxWSBBuw==",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
-        "@deepseek-ai/cosmokit": "^1.8.2",
+        "@deepseek-ai/cosmokit": "^1.8.3",
         "js-yaml": "^4.1.0"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/cordis-plugin-loader": "^1.0.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/cordis-plugin-loader": "^1.0.3"
       }
     },
     "node_modules/@deepseek-ai/cordis-plugin-loader": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/cordis-plugin-loader/-/cordis-plugin-loader-1.0.2.tgz",
-      "integrity": "sha512-RIW9hoVyhYDWdCI9BsvtZccPde1ECLC4OAxupwowGTak78vwVTVdb3HezTSOK1Y1/Ax3Ru0LA1pYOB04CnTxIQ==",
-      "devOptional": true,
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/cordis-plugin-loader/-/cordis-plugin-loader-1.0.3.tgz",
+      "integrity": "sha512-YNcHiH7TRFrgnRbQU7qdS1spABUFFHg04QpB9DdboPEjgKLTFfeEAvr6Y7qll3/nGgqywDQdk1tYshqKO0p1WQ==",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
-        "@deepseek-ai/cosmokit": "^1.8.2"
+        "@deepseek-ai/cosmokit": "^1.8.3"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
+        "@deepseek-ai/cordis": "^4.0.2",
         "node-addon-require-builtin": "^0.1.4"
       },
       "peerDependenciesMeta": {
@@ -90,184 +90,16 @@
       }
     },
     "node_modules/@deepseek-ai/cosmokit": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/cosmokit/-/cosmokit-1.8.2.tgz",
-      "integrity": "sha512-muBOKtSrUKU5m/xpq8ZXWL6hQ/jgd4PhU2PqH97bcxIiLEJfNwZOGQEx4t/aS/GgxRAR+ra9pMHPMtTHU4sqqA==",
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/cosmokit/-/cosmokit-1.8.3.tgz",
+      "integrity": "sha512-qBo+ronVM6Eu2WNVJXi8JcMiqZ19T9BRIpV+5qJUFPXjGH/Z0QKcQMC/IZJ7L394YTOtJgcovbk9qP0w2GsBXQ==",
       "license": "MIT",
       "peer": true
     },
-    "node_modules/@deepseek-ai/dsh-agent": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-agent/-/dsh-agent-0.1.0-rc.8.tgz",
-      "integrity": "sha512-fOl46ZvzoYHalrlyfOJAHNhzyKeVDTUnZZKNSJEr9GY/98WJTjcV21agVEofTXldkJ7a/ws2HpJkVNJVFMtslg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-scope": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.0-rc.8"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-agent-default-model": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-agent-default-model/-/dsh-agent-default-model-0.1.0-rc.8.tgz",
-      "integrity": "sha512-FSmgVy8yeVYx3krUwfWZR3JokLD202FSuEd/ZfGdxA+BhOKAOfhNv539kujatVqXyzCG3XiRNda7zWxCh2h7/A==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-settings": "^0.1.0-rc.8"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-agent-presets": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-agent-presets/-/dsh-agent-presets-0.1.0-rc.8.tgz",
-      "integrity": "sha512-7h+kE0KDrJCk2Y8GAqF4fu4YqZmFi5U8/AarFkGUqRI3HDugD6oYf05c7ZWNF7lQXh1OmwmrSbuPhT/YXJapOg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1",
-        "js-yaml": "^4.1.0"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/cordis-plugin-include": "^1.0.6",
-        "@deepseek-ai/cordis-plugin-loader": "^1.0.2",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-atomic-write": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-home-paths": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-scope": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-settings": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.8"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-api-gateway": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-api-gateway/-/dsh-api-gateway-0.1.0-rc.8.tgz",
-      "integrity": "sha512-rNA9+Sq3lXFDmyoFLpXNbcuWg7iFeepCwDi+jt1oGjwZTdZJ2nEWpU6GKlOiqadQjHYzfwEbCqmcuJy32qke/A==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.0-rc.8"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-client-connection": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-typert-registry": "^0.1.0-rc.8"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-api-remotes": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-api-remotes/-/dsh-api-remotes-0.1.0-rc.8.tgz",
-      "integrity": "sha512-s/zmFmU6R+dDxUWbHucIyfVgJG4v8kXa3YRjwjMO+Bu871ZG5Zsht6cvRqeSyu0A/Gs06ZfKYeKE0sdbCZ1NiA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.0-rc.8"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-agent-presets": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-api-gateway": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-commands": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-cordis-host-runner": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-credentials": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-file-reference": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-goal": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-host-plugin-inventory": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-message-feedback": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session-persistence": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session-reference": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-settings": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-typert-registry": "^0.1.0-rc.8"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-atomic-write": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-atomic-write/-/dsh-atomic-write-0.1.0-rc.8.tgz",
-      "integrity": "sha512-SWP+NAat3oteaPi47zLPz4vxeYCHNVmFpN1aeKDuPHpe/ouNTl+WcyIONAJ+1MbZ+8APWhSaJIVu6ORJEUhVGw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-attachment": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-attachment/-/dsh-attachment-0.1.0-rc.8.tgz",
-      "integrity": "sha512-cCrg4WWiav7pGtbdU8dJTpAG28cPnkWVB2YPOrlBCgBbhQziGcG9Dv67Ti6L3PI4OQKC55gYBFinQghFO/7FGg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-brand": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-brand": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-brand/-/dsh-brand-0.1.0-rc.8.tgz",
-      "integrity": "sha512-402aUAfHxIZJrArBV4gDf0I/A/69A/By26FX6HTIOyFmCnB4wUBKh8jnglz1CorKWdZy8AKldAhh8HQhQEbGOQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-client-connection": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-connection/-/dsh-client-connection-0.1.0-rc.8.tgz",
-      "integrity": "sha512-O1Y1NmkvJjpR/rCYkzulRrKbFwUbpMlINR4G6fbpGXaLy0VzTqN+ptk0b3wJ4RrnKPi4WWLKNNdV647Fg/1sCw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1",
-        "ws": "^8.21.0"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-attachment": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-commands": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-host-apiproxy": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-host-webserver": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.8"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-client-runtime": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-runtime/-/dsh-client-runtime-0.1.0-rc.8.tgz",
-      "integrity": "sha512-wW/nktO/GVbGO/k163NlyJab/rK4D6xS5EL0bhYw4ojF1mxmWfrb3RUEYR5LcEUpFx/yXUHsUSgeO1ezmgIrvw==",
+    "node_modules/@deepseek-ai/dsh-client-store": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-store/-/dsh-client-store-0.1.2-rc.1.tgz",
+      "integrity": "sha512-tDtAkfYb3URpASDP2fJFOZhGINtVVoUlQQqTSHtTF2L9N+7Tqij/PrSPXawBijBCkVdwaYsXdbzfLLjsh2SBqQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -275,22 +107,7 @@
         "zustand": "~4.4.7"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-attachment": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-client-connection": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-commands": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-host-apiproxy": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-llm-retry": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session-projection": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session-title": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-typert-registry": "^0.1.0-rc.8"
+        "@deepseek-ai/cordis": "^4.0.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-slots": {
@@ -299,233 +116,6 @@
       "integrity": "sha512-mwmSDuUG2BTcmPSL/o6esCYmjiwlW+uV3+ZZKIHzCxNVZ0AFMsfPQNZLhNSC2SYYw3SuIPb2R1W9DorB++KVyQ==",
       "dev": true,
       "license": "MIT",
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-code-runtime": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-code-runtime/-/dsh-code-runtime-0.1.0-rc.8.tgz",
-      "integrity": "sha512-6ZKyEE7dHH1UkKe5b0lg18Byww/7ocZyrNMVjAoUWEWp5i96Brf9Eavu9q3zepBMDMZJErCfV0pyt7KDhBJSig==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-commands": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-commands/-/dsh-commands-0.1.0-rc.8.tgz",
-      "integrity": "sha512-/i99EDLrUyd4bUVn4d7XS46vg09ZE0ervbE/aQaVUWLjDYKrarb7hPx9slADAg5/cUlJsN6L6CP544h9qlUo4g==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "zod": "^4.4.3"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-attachment": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-brand": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-scope": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.0-rc.8"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-compaction": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-compaction/-/dsh-compaction-0.1.0-rc.8.tgz",
-      "integrity": "sha512-sWNqZqejzpKsnEMPsNVA/WYK4S59XlYJtnWw8wCPushzQdUt5zhf+g7LVx0cStSozEfwurxRvaZdOmNaa4WhNQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-brand": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-commands": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.8"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-cordis-host-runner": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-cordis-host-runner/-/dsh-cordis-host-runner-0.1.0-rc.8.tgz",
-      "integrity": "sha512-DCJr6INHCI0Dypr1JAJj/BnvN31tpIt3Y8+KQ3GDfHW6pUBsc9GnXHpKsuQ4sK/fTj80GjaDYPGdWeB/uKMMdw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1",
-        "zod": "^4.4.3"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-brand": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-scope": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.0-rc.8"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-credentials": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-credentials/-/dsh-credentials-0.1.0-rc.8.tgz",
-      "integrity": "sha512-VopOhtUEa/fSmJr3fyKbsEG043kX1oGuBrmELAbkhmuDigl1cN88g0VPb9rMG2/dJ1h08wg+h0RJP+Ex4LjRWw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-brand": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-file-reference": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-file-reference/-/dsh-file-reference-0.1.0-rc.8.tgz",
-      "integrity": "sha512-SoU4Zm7L8E9ud5nTs1tVAINFrgKvIKypCdOOMLBjJkjLUvXMYmKFxfCM7xaJjOmK/C5suEVUtpukZhZZvZALNA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "zod": "^4.4.3"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.0-rc.8"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-goal": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-goal/-/dsh-goal-0.1.0-rc.8.tgz",
-      "integrity": "sha512-PR/9JjRn2H/33eyAVbtYBxzRWQhFO5N0S/188eAV9gjUTtHe5oSOnPxYy8iNkkMXxr+VE8Nno25Sun8WYmS8lQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1",
-        "zod": "^4.4.3"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-brand": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-scope": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session-projection": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.0-rc.8"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-home-paths": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-home-paths/-/dsh-home-paths-0.1.0-rc.8.tgz",
-      "integrity": "sha512-9cQhH9CZsw7Zi73VnZk7CcuEVA6yR/Ox+7lp3VHq53fFYSPi0RL+kMWmh5XCrZB4U1OM3+PVsWsA5II9tB+t0Q==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-host-apiproxy": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-host-apiproxy/-/dsh-host-apiproxy-0.1.0-rc.8.tgz",
-      "integrity": "sha512-viq2CoS6bRavSe1t9sLjgunykO+Vn/m83uSgONMH8O7QN0Pk3+FnZGHlPZ1lQ4auNJTwQjxFG6w372cGq9usWw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-agent-default-model": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-attachment": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-brand": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-commands": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-credentials": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-goal": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-host-directory-picker": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-jobs": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-native-command": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session-persistence": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session-projection": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session-projection-cache": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session-query": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session-title": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-settings": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-skill": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-subagent": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-user-approval": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-user-questions": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-workspace": "^0.1.0-rc.8",
-        "@deepseek-ai/schemastery": "^3.18.1",
-        "fflate": "^0.8.2",
-        "zod": "^4.4.3"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent-presets": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-cordis-host-runner": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-host-directory-picker": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-host-directory-picker/-/dsh-host-directory-picker-0.1.0-rc.8.tgz",
-      "integrity": "sha512-aOUaUX0MTl8oLIuL27OkATMm+x2oTANuhhHpeGizn7+kfOX5bRKB3tyi7h6lGZ9O7WDiDLl2JajRqzBXlIPAAg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-host-plugin-inventory": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-host-plugin-inventory/-/dsh-host-plugin-inventory-0.1.0-rc.8.tgz",
-      "integrity": "sha512-knPtxCDZn1jbwRfOUnskjaj8hSXUCfBcjD9LPFXnKffsM6TFOeQrFGhkNKlZteXAMSChtY6pV9bpJj17y3SPNg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "zod": "^4.4.3"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/cordis-plugin-loader": "^1.0.2",
-        "@deepseek-ai/dsh-brand": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.0-rc.8"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-host-webserver": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-host-webserver/-/dsh-host-webserver-0.1.0-rc.8.tgz",
-      "integrity": "sha512-MEKFrhvsYfj970QHLaKPpF/sIBpCe8NuSA0HGiWYJctX6TM9N3rLRhXx5p3zATDmXZclu1rbYhIbsqWw/twPig==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
-      },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
         "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8"
@@ -542,415 +132,6 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-jobs": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-jobs/-/dsh-jobs-0.1.0-rc.8.tgz",
-      "integrity": "sha512-HqQudOA4VkjCMpxWiqTCMmuiTa/pehW6yG7dDsctO1vW5K48hWQ/h7czdJKgrh4SMuK4kchv3IipS1KaJmdaog==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-brand": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.8"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-llm": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-llm/-/dsh-llm-0.1.0-rc.8.tgz",
-      "integrity": "sha512-hf6RmX2Stn1UtzpktSHQLkIktQkBm9i/3yFfJlbGSkwyw5Cv9sTYJbyoHzsSnnh6i8nRRcMcBhvMgm23I00oIw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-attachment": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-brand": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-timeout": "^0.1.0-rc.8"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-llm-retry": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-llm-retry/-/dsh-llm-retry-0.1.0-rc.8.tgz",
-      "integrity": "sha512-DmcOajgiku5l7aa5hU9DtwnIZu+i/XCGdb+Wego5W9bAswYeBAwbceloRNE3O6+jdRzy+K5U7KQ9V+olBsNqRQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-brand": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-timeout": "^0.1.0-rc.8"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-message-feedback": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-message-feedback/-/dsh-message-feedback-0.1.0-rc.8.tgz",
-      "integrity": "sha512-5DYXVLcnvTRs74Att52LGNR+x+RCf1X5s5+gOSUddsjnQ0wn4f3pzfc0o4F+91aE2zX3xzQ3/LhlW5UOJdkB0Q==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1",
-        "zod": "^4.4.3"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-brand": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session-persistence": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-storage-domain": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.0-rc.8"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-native-command": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-native-command/-/dsh-native-command-0.1.0-rc.8.tgz",
-      "integrity": "sha512-bRaT8LOb2xmWQ88oSzM4+Y3N4Yy4J0tf15/kQTP53PY1FnOA5hGYWoRglQgfxIcJCrw4fEdUPie8Fff0dCOwdQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-output-retention": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-output-retention/-/dsh-output-retention-0.1.0-rc.8.tgz",
-      "integrity": "sha512-DeVjqZ9TtH2AEG57GBsHYT68274VygzuP9EqQLL01Ht1TrdK75xlVet1l3jdEbA7Eik4aSGDjAZD9/MsnlUIXg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-scope": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-scope/-/dsh-scope-0.1.0-rc.8.tgz",
-      "integrity": "sha512-/o+PxkVV2zUy9lYlMFr4TWSb+ESW4DE+fI891yIbsLzOJdFgfbmmLpGrlWgnz8/unIGJZxjeXdwyppV04Z277Q==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-session": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session/-/dsh-session-0.1.0-rc.8.tgz",
-      "integrity": "sha512-Qs5Mgn32WPPVB4rKHjsZBgLOkh0TQurUAcc9GaDVudK4dUkpno2HDh++qu/PrwRA3CZ/iwPAoFHCpB3AMMaoLg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-brand": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-scope": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.0-rc.8"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-session-persistence": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-persistence/-/dsh-session-persistence-0.1.0-rc.8.tgz",
-      "integrity": "sha512-JujorG/UCern0+zxJzNswyWl2tFG9sLzfVNvA5YkTLaRLZt7ZsEhxG4DxWZ6uj+3RJ8sf4bqdKqvpIn9t1pwUw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-brand": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-timeout": "^0.1.0-rc.8"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-session-projection": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-projection/-/dsh-session-projection-0.1.0-rc.8.tgz",
-      "integrity": "sha512-q00B+rl7WAuK0Bgh93SY2+ZpqaH2kJhfJ9n6Jg6R/m4plnH0Ip4oCAHl6u8rBzDgb1mniQGEQDz/7BN5Q3It8Q==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "zod": "^4.4.3"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.8"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-session-projection-cache": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-projection-cache/-/dsh-session-projection-cache-0.1.0-rc.8.tgz",
-      "integrity": "sha512-IPvO7k9FlekOJXn4XLWUwU5+JDQn7khu8Oa04GFDystU3c1CnOwoa7SGMHOfJau3r177M4ncXApwN5Ra6uhyXw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1",
-        "zod": "^4.4.3"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session-persistence": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session-projection": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-storage-domain": "^0.1.0-rc.8"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-session-query": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-query/-/dsh-session-query-0.1.0-rc.8.tgz",
-      "integrity": "sha512-q8eyfpgPuJx24l1fEevDkc3Dux3lNp/yDzVkDL4nSTGNaDx/h9Y6iG7SZdqWM5nxOET3iwxi4AkPM7lYyLg3cQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-brand": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session-persistence": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session-title": "^0.1.0-rc.8"
-      },
-      "peerDependenciesMeta": {
-        "@deepseek-ai/dsh-session-persistence": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-session-reference": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-reference/-/dsh-session-reference-0.1.0-rc.8.tgz",
-      "integrity": "sha512-meNS02BOkLc2SnF2qWvl5X1Psk59t0Q1vvwjfCkczD29g4nm7Y02EZ089HJKii0VAsSB39RYA2rf6MCSl6vhow==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1",
-        "zod": "^4.4.3"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-compaction": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-output-retention": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session-query": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.0-rc.8"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-session-title": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-title/-/dsh-session-title-0.1.0-rc.8.tgz",
-      "integrity": "sha512-OFG9kHFGnM5ND4LCkqg8oZr57qgF6xMkBxR/4MRaJJ42QrPI9QKzoZVRpNpXEl3v3uw8oR7Jj0jbc7WClNl3ow==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1",
-        "zod": "^4.4.3"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-brand": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session-projection": "^0.1.0-rc.8"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-settings": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-settings/-/dsh-settings-0.1.0-rc.8.tgz",
-      "integrity": "sha512-pqbMoiSP+Ieww9/4gcHYXcBCDlno1zYDu2OPq+5xdZ+McnK+5YBtHsiRpnR9cHQxGTH7lkfIv+adkOueQW0utg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-brand": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/schemastery": "^3.18.1"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-skill": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-skill/-/dsh-skill-0.1.0-rc.8.tgz",
-      "integrity": "sha512-MqcOzl4Y5pQEvFBNVAi5w0IZWH5kVbXmp1RYScrl+8HpVATZbgumDhztVnEc2kUrZu+o6LKb1hnbunK6JHUE5g==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-scope": "^0.1.0-rc.8"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-storage": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-storage/-/dsh-storage-0.1.0-rc.8.tgz",
-      "integrity": "sha512-KcxiNFAC1X0GhbS9yWGo7FLARBNsxoyU9JatxQtA23MuqOZaN4Nzy3bsMViK4/snzpPGwm//I+wfUywSjM6uBA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-storage-domain": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-storage-domain/-/dsh-storage-domain-0.1.0-rc.8.tgz",
-      "integrity": "sha512-rHphQ0jveKoCurwh9TX+VAVFsMQivBgghQBOAsWdVDZ3W6boeXNhMZWuGWZ7WjMPD3iJKgiFCx+650hhsao+LQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1",
-        "zod": "^4.4.3"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-storage": "^0.1.0-rc.8"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-subagent": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-subagent/-/dsh-subagent-0.1.0-rc.8.tgz",
-      "integrity": "sha512-EI94+hYMfAe8BQkkH/FTcciGxajFfAdQe66Jhy2/eyR3dssRAZ+oJsV6SzU20x3m2yd0gmMaXzO1iV3gwYhY+g==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "zod": "^4.4.3"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-agent-presets": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-brand": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-jobs": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-sandbox": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-sandbox-policy": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-scope": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session-persistence": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session-projection": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session-projection-cache": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-user-approval": "^0.1.0-rc.8"
-      },
-      "peerDependenciesMeta": {
-        "@deepseek-ai/dsh-agent-presets": {
-          "optional": true
-        },
-        "@deepseek-ai/dsh-jobs": {
-          "optional": true
-        },
-        "@deepseek-ai/dsh-sandbox": {
-          "optional": true
-        },
-        "@deepseek-ai/dsh-sandbox-policy": {
-          "optional": true
-        },
-        "@deepseek-ai/dsh-session-persistence": {
-          "optional": true
-        },
-        "@deepseek-ai/dsh-session-projection": {
-          "optional": true
-        },
-        "@deepseek-ai/dsh-session-projection-cache": {
-          "optional": true
-        },
-        "@deepseek-ai/dsh-user-approval": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-system-prompt": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-system-prompt/-/dsh-system-prompt-0.1.0-rc.8.tgz",
-      "integrity": "sha512-yk8Z85rzX2EwpKNWA5i+K3I3mqsIIUc9niwbDpXO8vlHvpC2qR3RNHjJIJN2EZYDqfSzTVtkbxHFsuMzDXIbew==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-scope": "^0.1.0-rc.8"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-timeout": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-timeout/-/dsh-timeout-0.1.0-rc.8.tgz",
-      "integrity": "sha512-RwOC/qHribE6b+LStAO7aAgweefLE5sqDO7Uz6/mnTDyJxCt7HNQnE/Op8sAvRa33d752aUkPfO9S0mgzVAoFQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-tools": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tools/-/dsh-tools-0.1.0-rc.8.tgz",
-      "integrity": "sha512-tvuGAVUS4yoPW9zH7CGWJgMlAzGjfu2UlRiricldlcwSKAaJZPZx/K/YfTivUyDTER6aK1DJUnIpVG7RD/DoHQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-code-runtime": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-scope": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-user-approval": "^0.1.0-rc.8"
       }
     },
     "node_modules/@deepseek-ai/dsh-typert-generator": {
@@ -990,77 +171,6 @@
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
         "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-typert-registry": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-typert-registry/-/dsh-typert-registry-0.1.0-rc.8.tgz",
-      "integrity": "sha512-pxfRE5f1y81h2lNqj0uooYrErTVgpzKfYm4W+ppRafN5s/+1jlLIYWiG3wWD3bnxyoD2NLcTEhi/GXoaqiwdaw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.0-rc.8",
-        "zod": "^4.4.3"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-user-approval": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-user-approval/-/dsh-user-approval-0.1.0-rc.8.tgz",
-      "integrity": "sha512-6SFCxp7dgNFEyzQIcs5i9C+5djgXsAeV0iKmZUCLlcIeVM1chcCMHyGcoXlw8yyB14qFMrMs+TPvhvpu2WWxAw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-brand": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-scope": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.8"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-user-questions": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-user-questions/-/dsh-user-questions-0.1.0-rc.8.tgz",
-      "integrity": "sha512-kiOAlpKKfB89iObWiiVpueD4XCaday203LGUs7+eGb2isolY6VppoGb7ZmcJQqsW63bjbAA7wZeJuN3CoxcvSQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.8"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-workspace": {
-      "version": "0.1.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-workspace/-/dsh-workspace-0.1.0-rc.8.tgz",
-      "integrity": "sha512-Uyw44WcYvXRQjb0kUstTEJmL83hkGQbWnJzglaGWcAvsZBjQHeBgKuLzOZin1yc/dRX2pKuk1InFwxKXpaHjBA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "zod": "^4.4.3"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-brand": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-session-persistence": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-storage": "^0.1.0-rc.8",
-        "@deepseek-ai/dsh-storage-domain": "^0.1.0-rc.8"
       }
     },
     "node_modules/@deepseek-ai/schemastery": {
@@ -2564,8 +1674,8 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "devOptional": true,
       "license": "Python-2.0",
+      "optional": true,
       "peer": true
     },
     "node_modules/cac": {
@@ -2693,14 +1803,6 @@
         }
       }
     },
-    "node_modules/fflate": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
-      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -2775,7 +1877,6 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
       "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
-      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -2787,6 +1888,7 @@
         }
       ],
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "argparse": "^2.0.1"
@@ -3420,29 +2522,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sxzz"
-      }
-    },
-    "node_modules/ws": {
-      "version": "8.21.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
-      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
       }
     },
     "node_modules/yuku-ast": {

--- a/examples/dsh/packages/clawock-dsh/package.json
+++ b/examples/dsh/packages/clawock-dsh/package.json
@@ -87,7 +87,7 @@
     "@deepseek-ai/cordis": "^4.0.1"
   },
   "devDependencies": {
-    "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.6",
+    "@deepseek-ai/dsh-client-store": "^0.1.2-rc.1",
     "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.6",
     "@deepseek-ai/dsh-typert-generator": "0.1.0-rc.8",
     "@types/node": "^26.2.0",

--- a/examples/dsh/packages/clawock-dsh/src/client.ts
+++ b/examples/dsh/packages/clawock-dsh/src/client.ts
@@ -26,7 +26,7 @@ import { TYPERT_REMOTE } from 'clawock-dsh/remote'
 import type { Context } from '@deepseek-ai/cordis'
 import type { TypertClientRemote, TypertRemoteContribution } from '@deepseek-ai/dsh-typert-protocol'
 import type { PropsStore } from '@deepseek-ai/dsh-client-ui-slots'
-import { defineStore } from '@deepseek-ai/dsh-client-runtime/client'
+import { defineStore } from '@deepseek-ai/dsh-client-store'
 // The loader module table provides React at runtime; the types come from the
 // @types/react devDependency.
 import * as React from 'react'

--- a/ops/host/refresh_live.sh
+++ b/ops/host/refresh_live.sh
@@ -99,10 +99,28 @@ launcher="${CLAWOCK_LAUNCHER:-$HOME/.local/bin/clawock}"
 [ -x "$launcher" ] && "$launcher" --version
 if command -v dsh >/dev/null; then
   bundle="examples/dsh/packages/clawock-dsh/lib/client.js"
-  if curl -fs http://127.0.0.1:3081/plugins/clawock-dsh/client.js \
-      | cmp -s - "$bundle"; then
+  # dsh 0.1.2 retired the per-plugin URL this check used to fetch: client
+  # bundles are served only through the module loader's combo URL carrying the
+  # current graph rev (`/plugins/clawock-dsh/client.js` answers 404 now, and
+  # so does the combo shape with any other rev), and the body is the committed
+  # file plus a trailing sourceMappingURL comment. The `/plugins/events` graph
+  # is where that URL is published — and it is one of the few routes 0.1.2's
+  # new browser-session auth leaves open, so this check still needs no cookie.
+  # Both fetches land in a file: under `pipefail`, `head -c` closing the pipe
+  # early would fail the whole pipeline on SIGPIPE and read as "not serving".
+  graph="$(curl -sN --max-time 5 http://127.0.0.1:3081/plugins/events 2>/dev/null \
+           | grep -m1 '^data: ' || true)"
+  url="$(printf '%s' "${graph#data: }" | python3 -c 'import json, sys
+raw = sys.stdin.read().strip()
+entries = json.loads(raw)["graph"]["entries"] if raw else []
+print(next((e["url"] for e in entries if e["id"] == "clawock-dsh"), ""))' || true)"
+  served="$(mktemp)"
+  [ -n "$url" ] && curl -fs --max-time 30 -o "$served" "http://127.0.0.1:3081$url" || true
+  if [ -s "$served" ] && head -c "$(wc -c < "$bundle")" "$served" | cmp -s - "$bundle"; then
     echo "dsh serves the checkout's client bundle"
+    rm -f "$served"
   else
+    rm -f "$served"
     echo "dsh is NOT serving $bundle — investigate before trusting the desk" >&2
     exit 1
   fi

--- a/tests/decision_studio_plugin.spec.js
+++ b/tests/decision_studio_plugin.spec.js
@@ -294,7 +294,7 @@ test("client: registers the Decision Mind tab and mounts the remote face", async
   const loaded = await loadClient();
   assert.equal(loaded.id, "clawock-dsh");
   const api = loaded.factory((s) => {
-    if (s === "@deepseek-ai/dsh-client-runtime/client") return makeRuntimeStub();
+    if (s === "@deepseek-ai/dsh-client-store") return makeRuntimeStub();
     if (s === "react") return makeReactStub();
     throw new Error(`unexpected require: ${s}`);
   });
@@ -384,7 +384,7 @@ test("client: registers the Decision Mind tab and mounts the remote face", async
 test("client: _displayEntry projects a trace with its decision and T+1", async () => {
   const loaded = await loadClient();
   const api = loaded.factory((s) => {
-    if (s === "@deepseek-ai/dsh-client-runtime/client") return makeRuntimeStub();
+    if (s === "@deepseek-ai/dsh-client-store") return makeRuntimeStub();
     if (s === "react") return makeReactStub();
     throw new Error(`unexpected require: ${s}`);
   });
@@ -415,7 +415,7 @@ test("client: _displayEntry projects a trace with its decision and T+1", async (
 test("client: renders the single decision-trace view from the mounted remote", async () => {
   const loaded = await loadClient();
   const api = loaded.factory((s) => {
-    if (s === "@deepseek-ai/dsh-client-runtime/client") return makeRuntimeStub();
+    if (s === "@deepseek-ai/dsh-client-store") return makeRuntimeStub();
     if (s === "react") return makeReactStub();
     throw new Error(`unexpected require: ${s}`);
   });
@@ -587,7 +587,7 @@ test("T+1 reading: one host-side dead zone drives chip, node and verdict (#665/#
   const ledger = await import(pathToFileURL(path.join(PLUGIN, "lib", "ledger.js")).href);
   const loaded = await loadClient();
   const api = loaded.factory((s) => {
-    if (s === "@deepseek-ai/dsh-client-runtime/client") return makeRuntimeStub();
+    if (s === "@deepseek-ai/dsh-client-store") return makeRuntimeStub();
     if (s === "react") return makeReactStub();
     throw new Error(`unexpected require: ${s}`);
   });
@@ -640,7 +640,7 @@ test("T+1 reading: one host-side dead zone drives chip, node and verdict (#665/#
 test("client: trace list batches older days behind 'show earlier' and folds by day", async () => {
   const loaded = await loadClient();
   const api = loaded.factory((s) => {
-    if (s === "@deepseek-ai/dsh-client-runtime/client") return makeRuntimeStub();
+    if (s === "@deepseek-ai/dsh-client-store") return makeRuntimeStub();
     if (s === "react") return makeReactStub();
     throw new Error(`unexpected require: ${s}`);
   });
@@ -764,7 +764,7 @@ test("client: the bundle loads with no DOM and owns no module-level state (#729)
   const counter = { calls: 0 };
   const loaded = await loadClient();
   const api = loaded.factory((s) => {
-    if (s === "@deepseek-ai/dsh-client-runtime/client") return makeRuntimeStub(counter);
+    if (s === "@deepseek-ai/dsh-client-store") return makeRuntimeStub(counter);
     if (s === "react") return makeReactStub();
     throw new Error(`unexpected require: ${s}`);
   });
@@ -796,7 +796,7 @@ test("client: stylesheet is loader-owned and keeps the dark-theme and tone contr
   const injected = await withDocumentStub(async (collected) => {
     const loaded = await loadClient();
     loaded.factory((s) => {
-      if (s === "@deepseek-ai/dsh-client-runtime/client") return makeRuntimeStub();
+      if (s === "@deepseek-ai/dsh-client-store") return makeRuntimeStub();
       if (s === "react") return makeReactStub();
       throw new Error(`unexpected require: ${s}`);
     });
@@ -1398,7 +1398,7 @@ test("client: the header chip headlines one provider and the panel pins the rest
   const loaded = await loadClient();
   const reactStub = makeReactStub();
   const api = loaded.factory((s) => {
-    if (s === "@deepseek-ai/dsh-client-runtime/client") return makeRuntimeStub();
+    if (s === "@deepseek-ai/dsh-client-store") return makeRuntimeStub();
     if (s === "react") return reactStub;
     throw new Error(`unexpected require: ${s}`);
   });
@@ -1501,7 +1501,7 @@ test("client: the panel says each provider's story once, abnormal rows loudest",
   const loaded = await loadClient();
   const reactStub = makeReactStub();
   const api = loaded.factory((s) => {
-    if (s === "@deepseek-ai/dsh-client-runtime/client") return makeRuntimeStub();
+    if (s === "@deepseek-ai/dsh-client-store") return makeRuntimeStub();
     if (s === "react") return reactStub;
     throw new Error(`unexpected require: ${s}`);
   });
@@ -1680,7 +1680,7 @@ test("client: the panel says each provider's story once, abnormal rows loudest",
 test("client: _rowDisplay and _balanceNote project one provider's answer", async () => {
   const loaded = await loadClient();
   const api = loaded.factory((s) => {
-    if (s === "@deepseek-ai/dsh-client-runtime/client") return makeRuntimeStub();
+    if (s === "@deepseek-ai/dsh-client-store") return makeRuntimeStub();
     if (s === "react") return makeReactStub();
     throw new Error(`unexpected require: ${s}`);
   });
@@ -1768,7 +1768,7 @@ test("client: an exhausted quota row shows its 100% bars and resets instead of a
   const loaded = await loadClient();
   const reactStub = makeReactStub();
   const api = loaded.factory((s) => {
-    if (s === "@deepseek-ai/dsh-client-runtime/client") return makeRuntimeStub();
+    if (s === "@deepseek-ai/dsh-client-store") return makeRuntimeStub();
     if (s === "react") return reactStub;
     throw new Error(`unexpected require: ${s}`);
   });


### PR DESCRIPTION
## What broke

Upgrading the desk's DeepSeek Harness to `0.1.2-rc.1` took the whole dsh UI down: it renders **"Failed to load plugins"** with

```
failed to import loader entry (clawock-dsh): client-modules:
require("@deepseek-ai/dsh-client-runtime/client") missed the module table
```

0.1.2 retired `@deepseek-ai/dsh-client-runtime` (npm has no 0.1.2 of it, and the frontend bundle no longer seeds that id). `defineStore` now lives in `@deepseek-ai/dsh-client-store`, which is what every first-party client plugin requires in 0.1.2. One stale require id takes the desk's entire UI down, not just the Decision Mind tab.

## The change

- `src/client.ts` imports `defineStore` from `@deepseek-ai/dsh-client-store`; devDependency swapped and `lib/` rebuilt (the committed bundle diff is exactly the one `require` line).
- The lockfile loses 981 lines: `dsh-client-runtime` pulled the whole host package tree in as transitives, `dsh-client-store` does not.
- `tests/decision_studio_plugin.spec.js` stubs the new module id (23/23 pass).
- `ops/host/refresh_live.sh`: the post-install check fetched `/plugins/clawock-dsh/client.js`, which 0.1.2 answers **404**. Client bundles are served only through the module loader's combo URL carrying the current graph rev, so the check now resolves clawock-dsh's entry from the `/plugins/events` graph (still unauthenticated under 0.1.2's new browser-session auth) and compares the leading bytes — the served body is the committed file plus a trailing `sourceMappingURL` comment.
- `docs/operations/release.md` described the same retired one-liner.

## Verified on the desk

- Before: `Failed to load plugins`, 1 page error. After: app boots, sessions list renders, **0 page errors**.
- New serving check, both directions: passes against the served bundle, fails against a mismatched artifact, and returns empty (→ "not serving", no crash) when dsh is unreachable.
- `node --test tests/decision_studio_plugin.spec.js` 23/23; `pytest tests/test_refresh_live.py tests/test_runtime_coupling_ratchet.py` 13/13.

https://claude.ai/code/session_01Xf8FuM6gToBszWRuGmsc4C