### PR TITLE
ci: probe argparse from the phase registry in both workflows (#1317)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -466,27 +466,7 @@ jobs:
 
       - name: argparse-check harness CLIs
         if: steps.changes.outputs.code == 'true'
-        run: |
-          set -e
-          # `timeout` is the point of this step as much as the exit code. The two
-          # brief scripts used to be wrapped in `|| true`, which reads like the
-          # case was handled: it is not, because `|| true` catches a non-zero
-          # exit and what actually happened was a HANG. brief_preflight took no
-          # arguments at all, so --help ran the whole preflight — live fetches,
-          # EDGAR, Tavily — and ate the job's entire 10-minute budget, failing an
-          # unrelated PR. A probe must cost nothing, and if it ever stops being
-          # free this fails in seconds instead of taking the job down with it.
-          # The list is asserted against `harness.runner.PHASE_MODULES` by
-          # tests/test_ci_consolidation_contract.py: a phase added to the
-          # registry without being added here fails `validate`, so this cannot
-          # silently fall behind again (#1312, `brief render` was missing).
-          for cli in report_preflight report_postflight \
-                     intraday_preflight intraday_postflight \
-                     brief_preflight brief_postflight brief_render; do
-            timeout 30 env CLAWOCK_PROFILE=kcnyu clawock "${cli%%_*}" "${cli##*_}" --help > /dev/null \
-              || { echo "::error::$cli.py --help did not exit 0 within 30s"; exit 1; }
-          done
-          echo "OK: all argparse parsers loadable"
+        run: python3 ops/ci/argparse_probe.py
 
       - name: Schema-validate portfolio.json
         if: steps.changes.outputs.code == 'true'

--- a/.github/workflows/weekly-health.yml
+++ b/.github/workflows/weekly-health.yml
@@ -35,12 +35,9 @@ jobs:
         run: python3 ops/host/generate_cron_docs.py --check
 
       - name: argparse contracts unchanged
-        run: |
-          set -e
-          CLAWOCK_PROFILE=kcnyu clawock report preflight --help > /dev/null
-          CLAWOCK_PROFILE=kcnyu clawock report postflight --help > /dev/null
-          CLAWOCK_PROFILE=kcnyu clawock intraday preflight --help > /dev/null
-          CLAWOCK_PROFILE=kcnyu clawock intraday postflight --help > /dev/null
+        # Same probe as ci.yml, from the same registry. Two hand-written lists
+        # is how this step spent its life four phases behind (#1317).
+        run: python3 ops/ci/argparse_probe.py
 
       - name: Public data sources reachable
         continue-on-error: true

--- a/ops/ci/argparse_probe.py
+++ b/ops/ci/argparse_probe.py
@@ -23,15 +23,28 @@ import argparse
 import os
 import subprocess
 import sys
+from pathlib import Path
+
+# Importing clawock must not depend on how this script happened to be started
+# (tests/test_harness_import_independence.py), and spawning the CLI must not
+# depend on the caller's PATH: under the user crontab that is /usr/bin:/bin,
+# where the console script in ~/.local/bin does not exist. `clawock_argv` is
+# the one resolver for that, shared with system_check.
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_REPO_ROOT))
+sys.path.insert(0, str(_REPO_ROOT / "src"))
+sys.path.insert(0, str(_REPO_ROOT / "ops"))
+
+from system_check import clawock_argv  # noqa: E402
 
 
 def probe(command: str, timeout: float, env: dict[str, str]) -> tuple[bool, str]:
     """Run `clawock <workflow> <phase> --help`. Returns (ok, reason)."""
     workflow, phase = command.split(" ", 1)
+    argv, spawn_env = clawock_argv(workflow, phase, "--help", env=env)
     try:
         done = subprocess.run(
-            ["clawock", workflow, phase, "--help"],
-            capture_output=True, text=True, timeout=timeout, env=env,
+            argv, capture_output=True, text=True, timeout=timeout, env=spawn_env,
         )
     except subprocess.TimeoutExpired:
         return False, f"--help did not return within {timeout:g}s (it is doing real work)"

--- a/ops/ci/argparse_probe.py
+++ b/ops/ci/argparse_probe.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Prove every registered harness phase still has a free `--help`.
+
+Two workflows want this probe: `ci.yml` on every code push and
+`weekly-health.yml` as the Monday-morning backstop. They used to each carry
+their own hand-written list of CLIs, and the lists disagreed — `ci.yml` grew
+`brief render` in #1312 while `weekly-health.yml` stayed on the four it was
+born with (#1317). A copy of a registry ages; the registry does not. This
+script reads `harness.runner.PHASE_MODULES` directly, so a phase added there
+is probed by both workflows the day it lands, with nothing to remember.
+
+`timeout` is the point of the probe as much as the exit code. The two brief
+scripts were once wrapped in `|| true`, which reads like the case was handled:
+it is not, because what actually happened was a HANG. `brief_preflight` took no
+arguments at all, so `--help` ran the whole preflight — live fetches, EDGAR,
+Tavily — and ate the job's entire 10-minute budget, failing an unrelated PR. A
+probe must cost nothing, and if it ever stops being free this fails in seconds
+instead of taking the job down with it.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+
+
+def probe(command: str, timeout: float, env: dict[str, str]) -> tuple[bool, str]:
+    """Run `clawock <workflow> <phase> --help`. Returns (ok, reason)."""
+    workflow, phase = command.split(" ", 1)
+    try:
+        done = subprocess.run(
+            ["clawock", workflow, phase, "--help"],
+            capture_output=True, text=True, timeout=timeout, env=env,
+        )
+    except subprocess.TimeoutExpired:
+        return False, f"--help did not return within {timeout:g}s (it is doing real work)"
+    except OSError as exc:
+        return False, f"could not run the clawock entry point: {exc}"
+    if done.returncode != 0:
+        tail = (done.stderr or done.stdout or "").strip().splitlines()
+        return False, f"--help exited {done.returncode}: {tail[-1] if tail else 'no output'}"
+    return True, ""
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--timeout", type=float, default=30.0,
+                        help="seconds one --help may take before it counts as a hang")
+    args = parser.parse_args(argv)
+
+    from clawock.harness.runner import PHASE_MODULES
+
+    env = dict(os.environ)
+    env.setdefault("CLAWOCK_PROFILE", "kcnyu")
+
+    failures = []
+    for workflow, phase in sorted(PHASE_MODULES):
+        ok, reason = probe(f"{workflow} {phase}", args.timeout, env)
+        if ok:
+            print(f"  ok: clawock {workflow} {phase} --help")
+        else:
+            print(f"::error::clawock {workflow} {phase} --help {reason}")
+            failures.append(f"{workflow} {phase}")
+
+    if failures:
+        print(f"FAIL: {len(failures)} of {len(PHASE_MODULES)} parsers unloadable: "
+              f"{', '.join(failures)}")
+        return 1
+    print(f"OK: all {len(PHASE_MODULES)} argparse parsers loadable")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_ci_consolidation_contract.py
+++ b/tests/test_ci_consolidation_contract.py
@@ -121,26 +121,53 @@ def test_no_inline_lane_classification_left_in_the_workflow():
             "where tests can drive it")
 
 
-def test_the_argparse_check_covers_every_registered_harness_phase():
-    """The probe list must be the registry, not a copy of it that ages.
+def test_every_workflow_probing_argparse_goes_through_the_shared_script():
+    """The probe list must be the registry, not two copies of it that age.
 
-    `argparse-check harness CLIs` hardcodes the phases it loads. `brief render`
-    shipped in `harness.runner.PHASE_MODULES` and never made it into that list,
-    so for the whole life of the step a broken `render` parser was invisible to
-    CI (#1312) — the same shape as every other gate that enumerates its own
-    members by hand. Asserting the two lists against each other is what stops
-    the next phase from landing outside the probe.
+    `brief render` shipped in `harness.runner.PHASE_MODULES` and never made it
+    into ci.yml's hand-written list, so a broken `render` parser was invisible
+    to CI for the life of the step (#1312). Fixing that list left the second
+    copy — weekly-health.yml — four phases behind instead (#1317). Both now run
+    `ops/ci/argparse_probe.py`, which reads the registry, so the only thing
+    these assertions have to hold is that no workflow grows a third list.
     """
-    from clawock.harness.runner import PHASE_MODULES
     from workflow_contract_helpers import step_block
 
-    block = step_block(CI, "argparse-check harness CLIs")
-    listed = re.search(r"for cli in (.+?); do", block, re.DOTALL)
-    assert listed, "the step no longer loops over an explicit CLI list"
-    probed = {tuple(token.split("_", 1))
-              for token in listed.group(1).replace("\\", " ").split()}
+    probe = ROOT / "ops" / "ci" / "argparse_probe.py"
+    assert probe.exists(), "the shared probe is gone; both workflows call it"
 
-    assert probed == set(PHASE_MODULES), (
-        "argparse-check and PHASE_MODULES disagree; "
-        f"only in the registry: {sorted(set(PHASE_MODULES) - probed)}, "
-        f"only in ci.yml: {sorted(probed - set(PHASE_MODULES))}")
+    for workflow, step in ((CI, "argparse-check harness CLIs"),
+                           (WORKFLOWS / "weekly-health.yml",
+                            "argparse contracts unchanged")):
+        block = step_block(workflow, step)
+        assert "ops/ci/argparse_probe.py" in block, (
+            f"{workflow.name}'s `{step}` no longer runs the shared probe")
+        assert "--help" not in block, (
+            f"{workflow.name}'s `{step}` grew its own CLI list again; the list "
+            "belongs in harness.runner.PHASE_MODULES, which the probe reads")
+
+
+def test_the_shared_probe_reads_the_phase_registry():
+    """The probe is only a fix while it derives its members from the registry.
+
+    A probe that hardcodes the same seven phases is the bug with one more file
+    in it, and nothing else in this suite would notice.
+    """
+    from clawock.harness.runner import PHASE_MODULES
+    import argparse_probe as probe_module
+
+    ran = []
+
+    def fake_probe(command, timeout, env):
+        ran.append(command)
+        return True, ""
+
+    original = probe_module.probe
+    probe_module.probe = fake_probe
+    try:
+        assert probe_module.main([]) == 0
+    finally:
+        probe_module.probe = original
+
+    assert set(ran) == {f"{w} {p}" for w, p in PHASE_MODULES}, (
+        "the probe does not walk PHASE_MODULES; a new phase would land unprobed")


### PR DESCRIPTION
Closes #1317.

## What was wrong

`ci.yml` and `weekly-health.yml` each carried a hand-written list of harness CLIs to run `--help` against, and the lists disagreed: ci.yml was corrected to the full seven in #1312, weekly-health.yml stayed on the four it was born with. A broken `brief render` / `brief preflight` / `brief postflight` parser turned ci.yml red and left the Monday backstop green.

## Why not just add the missing three

That ships a third copy of the aging problem. Both steps now run `ops/ci/argparse_probe.py`, which walks `harness.runner.PHASE_MODULES` itself — a phase added to the registry is probed by both workflows the day it lands. The per-CLI 30s timeout that is the real point of the probe (#506: a `--help` that ran the whole preflight and ate a 10-minute job) moved into the script unchanged.

## Gate

`test_the_argparse_check_covers_every_registered_harness_phase` (which asserted one hardcoded list equals the registry) is replaced by two:

- `test_every_workflow_probing_argparse_goes_through_the_shared_script` — both steps call the script and neither contains `--help`, so a third hand-written list fails `validate`.
- `test_the_shared_probe_reads_the_phase_registry` — stubs `probe()` and asserts the script visits exactly `set(PHASE_MODULES)`; a probe that hardcodes the same seven would be the bug with one more file in it.

Local: `pytest tests/test_ci_consolidation_contract.py` 13 passed; `python3 ops/ci/argparse_probe.py` → `OK: all 7 argparse parsers loadable`.

https://claude.ai/code/session_01RnEpMv8MLR9cHv6H3TCDKc