### PR TITLE
packaging: declare the yfinance fallback and retire the empty extra (#1321, #1325)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,7 +7,7 @@
   // package list, for the same reason the workflows stopped writing their own
   // `pip install` lines: a second source of truth drifts unseen. A CI assertion
   // holds this line and pyproject's extras together.
-  "postCreateCommand": "pip install --upgrade pip && pip install -e '.[compute,test]'",
+  "postCreateCommand": "pip install --upgrade pip && pip install -e '.[market,test]'",
 
   "postAttachCommand": {
     "next-steps": "bash .devcontainer/welcome.sh"

--- a/.github/actions/clawock-python/action.yml
+++ b/.github/actions/clawock-python/action.yml
@@ -23,8 +23,12 @@ inputs:
   install:
     description: >-
       pip target for the editable install. Pass an extras selector such as
-      `.[compute]` when the job needs the heavier dependency set, or `none` when
+      `.[market]` when the job needs an extra declared in pyproject.toml (that
+      one adds the yfinance fallback both quote chains end on), or `none` when
       the job only runs stdlib scripts and wants nothing but the pinned Python.
+      Only names that exist and are non-empty may be advertised here: this line
+      recommended a `compute` selector for "the heavier dependency set" for a
+      week after that extra became an empty list (#1321).
       `none` exists so those jobs still come through this door: the version has
       to be decided in one place even when the install is not.
     required: false

--- a/.github/workflows/brief-fallback.yml
+++ b/.github/workflows/brief-fallback.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Set up clawock (Python)
         uses: ./.github/actions/clawock-python
         with:
-          install: '.[compute]'
+          install: '.[market]'
 
       # Set git identity up front: brief_postflight commits internally (rebuild
       # dashboard + auto-commit), so it needs an identity well before the final

--- a/ops/host/install_clawock_launcher.sh
+++ b/ops/host/install_clawock_launcher.sh
@@ -14,7 +14,7 @@ TARGET_DIR="$(dirname "$TARGET")"
 [ -f "$CHECKOUT/src/clawock/cli.py" ] || { echo "not a clawock checkout: $CHECKOUT" >&2; exit 1; }
 mkdir -p "$TARGET_DIR"
 python3 -m venv "$VENV"
-"$VENV/bin/python" -m pip install --quiet -e "${CHECKOUT}[compute]"
+"$VENV/bin/python" -m pip install --quiet -e "${CHECKOUT}[market]"
 
 cat > "$TARGET" <<LAUNCHER
 #!/usr/bin/env bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,12 +58,22 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-# Kept as an alias, not a set: numpy and scipy are required dependencies as of
-# 2026-08-30, so `.[compute]` now installs the base package. The name stays
-# because three call sites use it (a workflow, the launcher installer, and the
-# composite action's documentation) and breaking those to delete an empty list
-# is a worse trade than one line of explanation.
-compute = []
+# `compute = []` lived here from 2026-08-30, when numpy and scipy became
+# required and the extra was kept as an alias so its three call sites would not
+# break. That trade stopped being cheap once the composite action's own docs
+# told users to pass a `compute` selector "when the job needs the heavier
+# dependency set" while the heavier set was nothing at all (#1321). The call sites now ask
+# for what they actually need, which is the market-data fallback below.
+#
+# yfinance is the last hop of both quote chains — tier 4 for HK
+# (market_data/hk_analysis.py, after Tencent / Eastmoney / stooq) and provider 5
+# for US (market_data/us_quotes.py). Both import it lazily inside a try, so a
+# missing package does not crash: it silently deletes the bottom of the fallback
+# chain, which is exactly the hop that only ever runs when the others are
+# already rate-limited (#1325). It is an extra rather than a required
+# dependency because that chain has four other hops and yfinance drags pandas
+# behind it; it is *declared* because a fallback nobody can install is not one.
+market = ["yfinance>=0.2"]
 evaluation = ["matplotlib>=3.8"]
 # Screenshot and social-card validation.
 imaging = ["Pillow>=10"]

--- a/tests/test_packaging_extras_contract.py
+++ b/tests/test_packaging_extras_contract.py
@@ -1,0 +1,134 @@
+"""Every third-party import is declared, and every extra we advertise exists.
+
+Two failures with the same shape, found the same week:
+
+* `yfinance` is the last hop of both quote chains and appears in no dependency
+  table at all, so `pip install clawock` produced a package whose bottom
+  fallback raises ImportError on the one day the other hops are rate-limited
+  (#1325). The import is lazy and inside a `try`, so nothing is loud about it.
+* `[project.optional-dependencies].compute` was an empty list that three call
+  sites asked for, one of them a composite action documenting it to users as
+  "the heavier dependency set" (#1321). pip installs an empty extra happily.
+
+Both are invisible to a green test run because neither changes behaviour on a
+machine that happens to have the package. What follows enumerates from the
+source in each direction — imports in the tree, extras named in the repo — so
+the next one fails here instead of in production.
+"""
+from __future__ import annotations
+
+import ast
+import re
+import sys
+import tomllib
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PYPROJECT = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+
+# Import name -> distribution name, for the few that differ. Kept explicit: a
+# guess ("PIL is probably a dist called PIL") is how a declaration gate passes
+# while the package is still missing.
+DISTRIBUTION = {
+    "PIL": "pillow",
+    "google": "google-auth",
+    "yaml": "pyyaml",
+}
+
+# Scanned trees. `tests/` is deliberately out: conftest puts ops/ci, ops/host
+# and ops/growth on sys.path, so a test importing `push_scope` looks like a
+# third-party root and the gate would be noise instead of a gate.
+SCANNED = ("src", "ops")
+
+
+def _declared_distributions() -> set[str]:
+    project = PYPROJECT["project"]
+    requirements = list(project.get("dependencies", []))
+    for extra in project.get("optional-dependencies", {}).values():
+        requirements.extend(extra)
+    # `name>=1.2`, `name[extra]>=1`, `name` -> `name`, normalised per PEP 503.
+    return {re.split(r"[<>=!~\[; ]", req, maxsplit=1)[0].strip().lower().replace("_", "-")
+            for req in requirements}
+
+
+def _imported_roots() -> dict[str, set[str]]:
+    roots: dict[str, set[str]] = {}
+    for tree in SCANNED:
+        base = ROOT / tree
+        local = {path.stem for path in base.rglob("*.py")}
+        for path in base.rglob("*.py"):
+            module = ast.parse(path.read_text(encoding="utf-8"), str(path))
+            for node in ast.walk(module):
+                if isinstance(node, ast.Import):
+                    names = [alias.name for alias in node.names]
+                elif isinstance(node, ast.ImportFrom) and node.level == 0 and node.module:
+                    names = [node.module]
+                else:
+                    continue
+                for name in names:
+                    root = name.split(".")[0]
+                    if root in sys.stdlib_module_names or root == "clawock" or root in local:
+                        continue
+                    roots.setdefault(root, set()).add(str(path.relative_to(ROOT)))
+    return roots
+
+
+def test_every_third_party_import_is_declared_somewhere_in_pyproject():
+    declared = _declared_distributions()
+    undeclared = {
+        root: sorted(files)
+        for root, files in _imported_roots().items()
+        if DISTRIBUTION.get(root, root).lower().replace("_", "-") not in declared
+    }
+    assert not undeclared, (
+        "these third-party imports are in the tree but in no dependency table, "
+        "so an install that follows pyproject.toml cannot run the code paths "
+        f"that reach them: {undeclared}. Add them to `dependencies` if the "
+        "package needs them to work, or to an extra if a caller can opt in "
+        "(#1325); the reason belongs in a comment next to the line.")
+
+
+def test_every_extras_selector_named_in_the_repo_resolves_to_a_real_extra():
+    """`.[name]` anywhere in the repo must be an extra that exists and installs something.
+
+    An empty extra is worse than a missing one: pip succeeds, CI stays green,
+    and whoever read the line believes they installed the heavier set (#1321).
+    """
+    extras = PYPROJECT["project"].get("optional-dependencies", {})
+    # Prose counts: the damage in #1321 was a composite action recommending an
+    # extra, not only the lines that ran pip. JSON is the exception — this repo
+    # keeps schemas in it, and a regex `"^\\d+\\.[0-9]{2}$"` is not a selector —
+    # so only the devcontainer, which really does name extras, is read.
+    tracked = [
+        path for path in ROOT.rglob("*")
+        if (path.suffix in {".sh", ".yml", ".yaml", ".toml", ".md", ".cfg"}
+            or (path.suffix == ".json" and "devcontainer" in path.name))
+        and ".git/" not in str(path) and "node_modules" not in str(path)
+    ]
+    offenders: dict[str, list[str]] = {}
+    for path in tracked:
+        text = path.read_text(encoding="utf-8", errors="ignore")
+        # `?.[x]` is JavaScript optional chaining in a heredoc, not an extra.
+        for match in re.finditer(r"(?<![\w?])\.\[([A-Za-z0-9_.,-]+)\]", text):
+            # `.[market,test]` is one selector naming two extras (devcontainer).
+            for name in match.group(1).split(","):
+                name = name.strip()
+                if extras.get(name):
+                    continue
+                reason = "is not an extra" if name not in extras else "is an empty list"
+                offenders.setdefault(f"{name} ({reason})", []).append(
+                    str(path.relative_to(ROOT)))
+    assert not offenders, (
+        f"these extras selectors install nothing they promise: {offenders}")
+
+
+def test_the_market_extra_carries_the_fallback_the_quote_chains_end_on():
+    """Named so the next person deleting it has to answer for the chain.
+
+    yfinance is tier 4 for HK and provider 5 for US — the hop that exists
+    precisely because the four above it are rate-limited that morning.
+    """
+    market = PYPROJECT["project"]["optional-dependencies"].get("market", [])
+    assert any(req.startswith("yfinance") for req in market), (
+        "the market extra no longer declares yfinance; both quote chains still "
+        "import it lazily, so removing it deletes their last hop silently")


### PR DESCRIPTION
Closes #1321. Closes #1325.

## Two halves of the same lie in the dependency table

**#1325 — `yfinance` is declared nowhere.** It is the last hop of both quote chains (tier 4 for HK in `market_data/hk_analysis.py` after Tencent/Eastmoney/stooq; provider 5 for US in `market_data/us_quotes.py`). Both import it lazily inside a `try`, so an install that follows pyproject.toml does not fail loudly — it silently deletes the bottom of the fallback chain, which is exactly the hop that only runs on the morning the hops above it are rate-limited.

**#1321 — `compute = []`.** Four call sites asked for it: the launcher installer, `brief-fallback.yml`, `.devcontainer/devcontainer.json`, and the composite action's own documentation, which told users to pass it "when the job needs the heavier dependency set". pip installs an empty extra happily, so all four were green while installing nothing.

The issue listed three call sites; the devcontainer is a fourth, found by `test_the_devcontainer_contract` when this change landed.

## What this does

One extra that means something — `market = ["yfinance>=0.2"]` — with all four call sites asking for it. An extra rather than a required dependency because that chain has four other hops and yfinance drags pandas behind it; declared, because a fallback nobody can install is not a fallback.

## Gate

`tests/test_packaging_extras_contract.py` enumerates in both directions instead of pinning today's names:

- every third-party import root under `src/` and `ops/` must resolve to a declared distribution (AST scan, explicit import→distribution map so a guess cannot pass);
- every `.[name]` selector written anywhere in the repo — prose included, since the damage here was a doc — must name an extra that exists and is non-empty;
- the `market` extra must still carry yfinance, named so a future deletion has to answer for the chain.

Verified red on master (yfinance undeclared; `compute` empty in pyproject, brief-fallback.yml, action.yml, devcontainer.json) and green here.

https://claude.ai/code/session_01RnEpMv8MLR9cHv6H3TCDKc