### PR TITLE
dashboard: let the OS motion setting reach the charts, and the keyboard reach the sort (#1315, #1316)

### DIFF
--- a/site/assets/css/dashboard.css
+++ b/site/assets/css/dashboard.css
@@ -1376,6 +1376,18 @@
     user-select: none; height: 44px;
   }
   .holdings-table thead th:hover { color: var(--text); }
+  /* The sort control is a <button> for the keyboard's sake (#1316); it has to
+     look like the header text it replaced, so it inherits everything and keeps
+     the cell's own alignment. `inherit` on font/color rather than a restatement:
+     the th above owns the type scale, and two copies of it drift. */
+  .holdings-table thead th .sort-btn {
+    font: inherit; color: inherit; letter-spacing: inherit; text-transform: inherit;
+    background: none; border: 0; padding: 0; margin: 0; cursor: pointer;
+    text-align: inherit; width: 100%;
+  }
+  .holdings-table thead th .sort-btn:focus-visible {
+    outline: 2px solid var(--accent); outline-offset: 2px; border-radius: 2px;
+  }
   .holdings-table thead th .arr { color: var(--accent); margin-left: 2px; }
   @media (hover: hover) and (pointer: fine) {
     .holdings-table tbody tr:hover { background: var(--surface-3); }

--- a/site/assets/js/dashboard.charts.js
+++ b/site/assets/js/dashboard.charts.js
@@ -270,11 +270,22 @@
     };
   }
 
+  // ECharts animates on a canvas, so the global `@media (prefers-reduced-motion:
+  // reduce)` block in dashboard.css cannot reach it, and the bundle reads the
+  // query nowhere itself (0 matchMedia references in echarts.min.js). Every
+  // other motion system on this page checks the preference — CSS through that
+  // block, both decks and the smooth scroll through matchMedia — so the chart
+  // intro was the one place where turning motion off in the OS did nothing
+  // (#1315). Queried live, not latched at load: the ECharts bundle is tab-lazy,
+  // so a chart is often built minutes after the page opened.
+  const CHART_RM = window.matchMedia("(prefers-reduced-motion: reduce)");
+
   function baseChartOpts() {
     return {
       textStyle: { color: chartTextColor(), fontFamily: getCSS("--font") },
       backgroundColor: "transparent",
-      animationDuration: 200,
+      // 0 is ECharts' documented "no animation": the series lands drawn.
+      animationDuration: CHART_RM.matches ? 0 : 200,
       // Animate the FIRST paint only. Data-only updates (the 60s background poll, a
       // scoped sidecar refresh, a US/HK toggle) reapply the option on the existing
       // instance; a non-zero update duration re-runs the intro animation and reads as

--- a/site/assets/js/dashboard.render.js
+++ b/site/assets/js/dashboard.render.js
@@ -2307,29 +2307,51 @@
       });
     }
 
-    // Wire sort headers
-    document.querySelectorAll("#book-table thead th").forEach(th => {
-      th.onclick = () => {
-        const k = th.dataset.sort;
-        if (!k) return;
-        if (bookSort && bookSort.key === k) bookSort.dir = bookSort.dir === "asc" ? "desc" : "asc";
-        else bookSort = { key: k, dir: "desc" };
-        document.querySelectorAll("#book-table thead th").forEach(x => {
-          const isActive = bookSort && x.dataset.sort === bookSort.key;
-          x.classList.toggle("active-sort", !!isActive);
-          const label = x.textContent.replace(/[▲▼]/g, "").trim();
-          x.replaceChildren();
-          x.append(label);
-          if (isActive) {
-            const arrow = document.createElement("span");
-            arrow.className = "arr";
-            arrow.textContent = bookSort.dir === "asc" ? "▲" : "▼";
-            x.append(" ", arrow);
-          }
+    // Wire sort headers. The clickable thing is a real <button> inside the
+    // <th> (the ARIA sortable-table pattern): the header keeps its columnheader
+    // role and carries aria-sort, while focus, Enter/Space and "this is
+    // operable" come free from the button instead of being re-implemented. The
+    // previous `th.onclick` had none of the three — no tabindex, no key
+    // handler, no exposed sort state — in the same table whose rows already had
+    // all of them (#1316), so the column order was mouse-only.
+    const sortHeads = document.querySelectorAll("#book-table thead th[data-sort]");
+    const paintSortState = () => {
+      sortHeads.forEach(th => {
+        const isActive = !!bookSort && th.dataset.sort === bookSort.key;
+        th.classList.toggle("active-sort", isActive);
+        // Only a real sort may claim one. The markup used to ship `active-sort`
+        // plus a ▼ on 市值 while the default order is the verdict rank, which
+        // aria-sort would now read out as a sort that is not happening.
+        th.setAttribute("aria-sort", !isActive ? "none"
+          : bookSort.dir === "asc" ? "ascending" : "descending");
+        const btn = th.querySelector("button.sort-btn");
+        if (!btn) return;
+        btn.replaceChildren(btn.textContent.replace(/[▲▼]/g, "").trim());
+        if (isActive) {
+          const arrow = document.createElement("span");
+          arrow.className = "arr";
+          arrow.setAttribute("aria-hidden", "true");
+          arrow.textContent = bookSort.dir === "asc" ? "▲" : "▼";
+          btn.append(" ", arrow);
+        }
+      });
+    };
+    const thead = document.querySelector("#book-table thead");
+    if (thead && thead.dataset.wired !== "1") {
+      thead.dataset.wired = "1";   // renderBook() runs on every refresh; listeners must not stack
+      sortHeads.forEach(th => {
+        const btn = th.querySelector("button.sort-btn");
+        if (!btn) return;
+        btn.addEventListener("click", () => {
+          const k = th.dataset.sort;
+          if (bookSort && bookSort.key === k) bookSort.dir = bookSort.dir === "asc" ? "desc" : "asc";
+          else bookSort = { key: k, dir: "desc" };
+          paintSortState();
+          renderBook();
         });
-        renderBook();
-      };
-    });
+      });
+    }
+    paintSortState();
     // end sort headers
   }
 

--- a/site/index.html
+++ b/site/index.html
@@ -370,16 +370,16 @@ layout: null
         <table class="holdings-table book-table" id="book-table">
           <thead>
             <tr>
-              <th data-sort="ticker">标的</th>
-              <th data-sort="name" class="col-p2">名称</th>
+              <th data-sort="ticker" aria-sort="none"><button type="button" class="sort-btn">标的</button></th>
+              <th data-sort="name" class="col-p2" aria-sort="none"><button type="button" class="sort-btn">名称</button></th>
               <th>状态</th>
-              <th data-sort="shares" class="num col-p2">股数</th>
-              <th data-sort="cost_basis" class="num col-p2">成本</th>
-              <th data-sort="current_price" class="num">现价</th>
-              <th data-sort="current_value" class="num active-sort">市值 <span class="arr">&#x25BC;</span></th>
+              <th data-sort="shares" class="num col-p2" aria-sort="none"><button type="button" class="sort-btn">股数</button></th>
+              <th data-sort="cost_basis" class="num col-p2" aria-sort="none"><button type="button" class="sort-btn">成本</button></th>
+              <th data-sort="current_price" class="num" aria-sort="none"><button type="button" class="sort-btn">现价</button></th>
+              <th data-sort="current_value" class="num" aria-sort="none"><button type="button" class="sort-btn">市值</button></th>
               <th class="num spark-col col-p3">8 日</th>
-              <th data-sort="today_change_pct" class="num">今日</th>
-              <th data-sort="pnl_percent" class="num">盈亏</th>
+              <th data-sort="today_change_pct" class="num" aria-sort="none"><button type="button" class="sort-btn">今日</button></th>
+              <th data-sort="pnl_percent" class="num" aria-sort="none"><button type="button" class="sort-btn">盈亏</button></th>
             </tr>
           </thead>
           <tbody id="book-tbody"></tbody>

--- a/tests/test_dashboard_motion_and_keyboard_contract.py
+++ b/tests/test_dashboard_motion_and_keyboard_contract.py
@@ -1,0 +1,99 @@
+"""Motion and keyboard reach every control on the dashboard, not most of them.
+
+Both halves here are gates on a *set*, not on the two lines that were wrong:
+
+* Reduced motion. `dashboard.css` has one global
+  `@media (prefers-reduced-motion: reduce)` block, and both decks and the smooth
+  scroll read the query in JS — so the preference looked handled while the
+  ECharts intro animated anyway, because ECharts paints on a canvas the CSS
+  block cannot reach and reads the query nowhere itself (#1315). Any *new*
+  JS-driven duration has the same blind spot, so the assertion is over every
+  duration in the bundle.
+* Keyboard. The holdings rows are `tabindex="0" role="button"` with an
+  Enter/Space handler; the sort headers of the same table were `th.onclick` and
+  nothing else, so the column order was mouse-only and its state was invisible
+  to a screen reader (#1316). The assertion is over every sortable column in
+  the markup, not over the eight that exist today.
+
+Static by construction: this host cannot render (see the loop's instrument
+rule — ~200 MB available, headless rAF at ~9 fps), so browser-level proof of
+the same properties belongs in tests/dashboard_tab_runtime.spec.js.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+JS_DIR = ROOT / "site" / "assets" / "js"
+INDEX = (ROOT / "site" / "index.html").read_text(encoding="utf-8")
+CSS = (ROOT / "site" / "assets" / "css" / "dashboard.css").read_text(encoding="utf-8")
+
+# Vendored bundles are not ours to edit; the application layer is what must
+# consult the preference on their behalf.
+OURS = sorted(p for p in JS_DIR.glob("dashboard.*.js") if not p.name.endswith(".min.js"))
+
+REDUCED_MOTION_READ = re.compile(r"prefers-reduced-motion|_RM\b|\bRM\.matches|REDUCED_MOTION")
+
+
+def test_every_js_animation_duration_is_gated_on_reduced_motion():
+    """A literal duration in JS is a motion the CSS media block cannot switch off."""
+    offenders = []
+    for path in OURS:
+        for number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+            match = re.search(r"animation\w*Duration\w*\s*:\s*(.+?),?\s*$", line)
+            if not match:
+                continue
+            value = match.group(1).rstrip(",")
+            if value.strip() == "0" or REDUCED_MOTION_READ.search(value):
+                continue
+            offenders.append(f"{path.name}:{number} → {value.strip()}")
+    assert not offenders, (
+        "these animation durations run whatever the OS motion preference says; "
+        "gate them on the reduced-motion query the way baseChartOpts() does, or "
+        f"set them to 0: {offenders}")
+
+
+def test_the_chart_layer_reads_the_preference_live():
+    """Latching `.matches` at load would miss every tab-lazy chart built later."""
+    charts = (JS_DIR / "dashboard.charts.js").read_text(encoding="utf-8")
+    assert 'matchMedia("(prefers-reduced-motion: reduce)")' in charts, (
+        "dashboard.charts.js no longer asks for the preference at all")
+    assert re.search(r"animationDuration:\s*\w+\.matches\s*\?", charts), (
+        "the duration must read `.matches` at option-build time, not a boolean "
+        "captured when the bundle loaded")
+
+
+def _sortable_headers() -> list[str]:
+    return re.findall(r"<th\b[^>]*\bdata-sort=[^>]*>.*?</th>", INDEX, re.DOTALL)
+
+
+def test_every_sortable_column_is_operable_from_the_keyboard():
+    headers = _sortable_headers()
+    assert headers, "no sortable headers found; this gate is looking at the wrong markup"
+    for header in headers:
+        column = re.search(r'data-sort="([^"]+)"', header).group(1)
+        assert "<button" in header, (
+            f"the `{column}` header sorts on click but has no button; a bare "
+            "<th onclick> cannot be focused or triggered from the keyboard (#1316)")
+        assert "aria-sort" in header, (
+            f"the `{column}` header does not expose its sort state via aria-sort")
+
+
+def test_no_dashboard_script_hangs_a_click_handler_on_a_bare_table_header():
+    offenders = [
+        f"{path.name}:{number}"
+        for path in OURS
+        for number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1)
+        if re.search(r"\bth\.onclick\s*=", line)
+    ]
+    assert not offenders, (
+        "a <th> got a click handler again; the control belongs in a button "
+        f"inside the header so the keyboard can reach it: {offenders}")
+
+
+def test_the_sort_button_has_a_visible_focus_ring():
+    """Focusable and invisible is not keyboard support."""
+    assert re.search(r"\.sort-btn:focus-visible\s*\{[^}]*outline:", CSS), (
+        "the sort button has no :focus-visible outline; the holdings rows next "
+        "to it have had one since they became focusable")


### PR DESCRIPTION
Closes #1315. Closes #1316.

Two controls that the page's own conventions had already solved everywhere else.

## #1315 — the chart intro ignored `prefers-reduced-motion`

ECharts paints on a canvas, so the global `@media (prefers-reduced-motion: reduce)` block in `dashboard.css` never reached it, and the bundle reads the query nowhere itself. CSS, both decks and the smooth scroll all check the preference; the 200ms chart intro was the one animation that did not. `baseChartOpts()` now reads the query **live** — the ECharts bundle is tab-lazy, so a chart is often built minutes after load, and a boolean latched at load would be stale — and passes `0`, which is ECharts' documented "land drawn".

## #1316 — the sort headers were mouse-only

`th.onclick` and nothing else, in the same table whose rows are `tabindex="0" role="button"` with an Enter/Space handler. The control is now a real `<button>` inside the `<th>` (the ARIA sortable-table pattern) rather than `tabindex`+`role="button"` on the header itself: that keeps the `columnheader` role for table navigation, puts `aria-sort` where a screen reader looks for it, and gets focus and Enter/Space from the platform instead of a second hand-rolled key handler. Wiring moved under a `thead` guard — `renderBook()` runs on every refresh, and `addEventListener` stacks where `onclick =` did not.

**One visible change beyond the two issues:** the markup shipped `active-sort` and a ▼ on 市值 while the default order is the verdict rank, not that column. With `aria-sort` now attached, that would be read out as a sort that is not happening, so the indicator appears only once a real sort exists.

## Gate

`tests/test_dashboard_motion_and_keyboard_contract.py` — over the sets, not these two lines:

- every `animation*Duration` in our JS is `0` or gated on the reduced-motion query;
- the chart layer reads `.matches` at option-build time, not at load;
- every `data-sort` header in the markup contains a button and exposes `aria-sort`;
- no dashboard script hangs a click handler on a bare `<th>` again;
- the sort button has a `:focus-visible` outline.

All five verified red against master's assets, green here. `pytest -k "dashboard or render or hero or holdings or book or site or asset"` → 423 passed. Static by construction: this host cannot render (~200 MB available, headless rAF ~9 fps), so browser-level proof stays in `tests/dashboard_tab_runtime.spec.js`.

https://claude.ai/code/session_01RnEpMv8MLR9cHv6H3TCDKc