### PR TITLE
gc: bound the workspace's append-only logs by tail, not by hope (#1324)

### DIFF
--- a/ops/host/gc_sessions.py
+++ b/ops/host/gc_sessions.py
@@ -13,6 +13,11 @@ This script removes:
   - sessions/bak-* / pre-cleanup-*  older than KEEP_BAK_DAYS
   - gateway-supervisor-restart-handoff.json if expired
 
+and trims (does not delete) the workspace's append-only cron logs back to their
+last KEEP_LOG_LINES lines once they pass KEEP_LOG_MB. Nothing rotated them:
+`logs/publish_dashboard.log` reached 10,484 lines and `logs/watchdog.jsonl`
+99 days of delivery evidence, both still growing (#1324).
+
 Defaults are conservative; tune via env vars if needed.
 Designed to run as a daily cron (~03:00 HKT, after overnight monitor ends 02:30
 and before US close 04:05 — see openclaw-intraday-cron-no-overlap memory).
@@ -35,11 +40,19 @@ _OPENCLAW_PATHS = runtime_paths()
 SESSIONS_DIR = _OPENCLAW_PATHS.sessions_dir
 HANDOFF_FILE = _OPENCLAW_PATHS.supervisor_handoff
 WORKSPACE_TMP = _OPENCLAW_PATHS.workspace_memory_tmp
+LOGS_DIR = _OPENCLAW_PATHS.workspace / 'logs'
 
 KEEP_TRAJECTORY_DAYS = int(os.environ.get('GC_KEEP_TRAJECTORY_DAYS', '7'))
 KEEP_SESSION_DAYS    = int(os.environ.get('GC_KEEP_SESSION_DAYS',    '14'))
 KEEP_BAK_DAYS        = int(os.environ.get('GC_KEEP_BAK_DAYS',        '3'))
 KEEP_TMP_DAYS        = int(os.environ.get('GC_KEEP_TMP_DAYS',        '14'))
+KEEP_LOG_MB          = float(os.environ.get('GC_KEEP_LOG_MB',        '2'))
+KEEP_LOG_LINES       = int(os.environ.get('GC_KEEP_LOG_LINES',       '2000'))
+LOG_QUIET_SECONDS    = int(os.environ.get('GC_LOG_QUIET_SECONDS',    '60'))
+# Hysteresis: trim at five times the tail we keep, so a given log is rewritten
+# about once a year instead of every night.
+TRIM_AT_MULTIPLE     = int(os.environ.get('GC_TRIM_AT_MULTIPLE',     '5'))
+READ_FLOOR_BYTES     = int(os.environ.get('GC_LOG_READ_FLOOR_BYTES', str(128 * 1024)))
 
 for _name, _days in (('GC_KEEP_TRAJECTORY_DAYS', KEEP_TRAJECTORY_DAYS),
                      ('GC_KEEP_SESSION_DAYS', KEEP_SESSION_DAYS),
@@ -175,6 +188,70 @@ def gc_sessions_dir(now_ts, dry_run, allow_future=False):
     return total_files, total_bytes
 
 
+def trim_logs(now_ts, dry_run, dirpath=None):
+    """Copy-truncate over-long append-only logs, keeping their last lines.
+
+    Everything under `logs/` is append-only and nothing reads it from the
+    front: `ops/system_check.py` reads a fixed tail of each host cron log
+    looking for a crash, and `intraday_watchdog` says outright that a line in
+    watchdog.jsonl "is not something kcn reads". So the retention that fits is
+    a tail, not an age — an age cutoff on a single ever-growing file deletes
+    either all of it or none of it.
+
+    A file is trimmed when it holds more than TRIM_AT_LINES lines (five times
+    what we keep, so this rewrites a given log about once a year rather than
+    every night) or when it is over KEEP_LOG_MB, which catches the pathological
+    single-huge-line case a line count would miss. Files under READ_FLOOR are
+    never opened.
+
+    Copy-truncate rather than rename: the cron lines redirect with `>>`, so a
+    running job holds an O_APPEND descriptor on this inode. Renaming the file
+    sends that job's remaining output to a file nobody will look at again;
+    rewriting the same inode keeps every writer pointed at the live log. Only
+    `.log` and `.jsonl` are eligible — `logs/` also holds state files like
+    `brief_postflight_status.json`, which are read whole and must not be cut.
+    """
+    dirpath = dirpath or LOGS_DIR
+    if not dirpath.exists():
+        return 0, 0
+    cap = int(KEEP_LOG_MB * 1024 * 1024)
+    n_files, n_bytes = 0, 0
+    for p in sorted(dirpath.iterdir()):
+        if not p.is_file() or p.suffix not in ('.log', '.jsonl'):
+            continue
+        try:
+            st = p.stat()
+        except FileNotFoundError:
+            continue
+        if st.st_size < READ_FLOOR_BYTES:
+            continue
+        # A log written to in the last minute may have an appender mid-line;
+        # leave it for tomorrow rather than race it for the bytes it is over.
+        if now_ts - st.st_mtime < LOG_QUIET_SECONDS:
+            continue
+        try:
+            with p.open('r+', encoding='utf-8', errors='replace') as f:
+                lines = f.readlines()
+                if len(lines) <= KEEP_LOG_LINES * TRIM_AT_MULTIPLE and st.st_size <= cap:
+                    continue
+                kept = lines[-KEEP_LOG_LINES:]
+                if not dry_run:
+                    f.seek(0)
+                    f.writelines(kept)
+                    f.truncate()
+        except OSError as e:
+            print(f'  skip {p.name}: {e}', file=sys.stderr)
+            continue
+        freed = st.st_size - sum(len(line.encode('utf-8')) for line in kept)
+        n_files += 1
+        n_bytes += max(freed, 0)
+        print(f'  trimmed {p.name}: {len(lines)} lines / {humansize(st.st_size)} '
+              f'→ last {len(kept)}')
+    print(f'  logs (> {KEEP_LOG_LINES * TRIM_AT_MULTIPLE} lines or '
+          f'{KEEP_LOG_MB:g} MB): {n_files} files, {humansize(n_bytes)}')
+    return n_files, n_bytes
+
+
 def gc_handoff(dry_run):
     if not HANDOFF_FILE.exists():
         return False
@@ -204,7 +281,8 @@ def main():
     now = time.time()
     print(f'gc_sessions: dir={SESSIONS_DIR} dry_run={args.dry_run}')
     print(f'  keep trajectory ≤ {KEEP_TRAJECTORY_DAYS}d, session ≤ {KEEP_SESSION_DAYS}d, '
-          f'bak ≤ {KEEP_BAK_DAYS}d, workspace .tmp ≤ {KEEP_TMP_DAYS}d')
+          f'bak ≤ {KEEP_BAK_DAYS}d, workspace .tmp ≤ {KEEP_TMP_DAYS}d, '
+          f'logs ≤ {KEEP_LOG_MB:g} MB (tail {KEEP_LOG_LINES} lines)')
 
     total_files, total_bytes = gc_sessions_dir(now, args.dry_run)
 
@@ -221,6 +299,10 @@ def main():
     )
     total_files += f
     total_bytes += b
+
+    # Reported on its own line, not folded into the totals below: a trimmed
+    # log is still there, and "freed 3 files" would be a lie about it.
+    trim_logs(now, args.dry_run)
 
     # Expired gateway-supervisor-restart-handoff
     gc_handoff(args.dry_run)

--- a/tests/test_gc_sessions_log_trim.py
+++ b/tests/test_gc_sessions_log_trim.py
@@ -1,0 +1,136 @@
+"""The nightly sweep must cap the append-only logs without breaking a writer.
+
+`logs/` had no rotation of any kind: `publish_dashboard.log` was 10,484 lines
+and `logs/watchdog.jsonl` 99 days of delivery evidence, both still growing
+(#1324). The sweep that already prunes sessions/ and memory/.tmp now trims them
+back to a tail — which is the only retention that fits a single ever-growing
+file, since an age cutoff on one would delete all of it or none of it.
+
+Two properties matter more than the trimming itself:
+
+* the inode survives, because the cron lines redirect with `>>` and a running
+  job holds an O_APPEND descriptor on it;
+* state files sharing the directory (`brief_postflight_status.json`) are not
+  logs and must come through untouched.
+"""
+import importlib.util
+import sys
+import time
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load():
+    for path in (ROOT, ROOT / "src"):
+        if str(path) not in sys.path:
+            sys.path.insert(0, str(path))
+    spec = importlib.util.spec_from_file_location(
+        "kcnyu_gc_sessions_logs", ROOT / "ops" / "host" / "gc_sessions.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+gc = _load()
+OLD = time.time() - 3600
+
+
+def _logs_dir(tmp_path, files):
+    logs = tmp_path / "logs"
+    logs.mkdir()
+    for name, text in files.items():
+        path = logs / name
+        path.write_text(text, encoding="utf-8")
+        import os
+        os.utime(path, (OLD, OLD))
+    return logs
+
+
+def _fat(marker="line", lines=50000):
+    return "".join(f"{marker} {i}\n" for i in range(lines))
+
+
+def test_an_oversized_log_keeps_its_tail_and_loses_its_head(tmp_path, monkeypatch):
+    monkeypatch.setattr(gc, "KEEP_LOG_LINES", 100)
+    logs = _logs_dir(tmp_path, {"publish_dashboard.log": _fat()})
+
+    gc.trim_logs(time.time(), dry_run=False, dirpath=logs)
+
+    kept = (logs / "publish_dashboard.log").read_text().splitlines()
+    assert len(kept) == 100
+    assert kept[-1] == "line 49999", "the newest line must survive"
+    assert "line 0" not in kept, "the head must be gone"
+
+
+def test_the_inode_survives_so_a_running_cron_keeps_writing(tmp_path, monkeypatch):
+    """`>>` in crontab means a live job holds a descriptor on this file."""
+    monkeypatch.setattr(gc, "KEEP_LOG_LINES", 10)
+    logs = _logs_dir(tmp_path, {"watchdog.jsonl": _fat("{}")})
+    log = logs / "watchdog.jsonl"
+    before = log.stat().st_ino
+
+    with log.open("a", encoding="utf-8") as appending_job:
+        gc.trim_logs(time.time(), dry_run=False, dirpath=logs)
+        appending_job.write("after the trim\n")
+
+    assert log.stat().st_ino == before, "renaming would strand the open writer"
+    assert log.read_text().endswith("after the trim\n")
+
+
+def test_a_state_file_in_the_same_directory_is_not_a_log(tmp_path, monkeypatch):
+    monkeypatch.setattr(gc, "KEEP_LOG_LINES", 10)
+    state = '{"sent_ok": true, "padding": "' + "x" * 200000 + '"}'
+    logs = _logs_dir(tmp_path, {"brief_postflight_status.json": state})
+
+    gc.trim_logs(time.time(), dry_run=False, dirpath=logs)
+
+    assert (logs / "brief_postflight_status.json").read_text() == state, (
+        "a status file read whole was cut in half")
+
+
+def test_a_log_still_being_written_this_minute_is_left_alone(tmp_path, monkeypatch):
+    """Racing an appender for a few KB is not worth a torn line."""
+    monkeypatch.setattr(gc, "KEEP_LOG_LINES", 10)
+    logs = _logs_dir(tmp_path, {"gold_dca.log": _fat()})
+    fresh = logs / "gold_dca.log"
+    now = time.time()
+    import os
+    os.utime(fresh, (now, now))
+
+    gc.trim_logs(now, dry_run=False, dirpath=logs)
+
+    assert len(fresh.read_text().splitlines()) == 50000
+
+
+def test_a_log_under_the_thresholds_is_untouched(tmp_path, monkeypatch):
+    """Hysteresis: a log five times the tail is what gets rewritten, not any log."""
+    monkeypatch.setattr(gc, "KEEP_LOG_LINES", 2000)
+    logs = _logs_dir(tmp_path, {"dst-sync.log": _fat(lines=9000)})
+
+    files, _ = gc.trim_logs(time.time(), dry_run=False, dirpath=logs)
+
+    assert files == 0
+    assert len((logs / "dst-sync.log").read_text().splitlines()) == 9000
+
+
+def test_one_pathological_line_still_trips_the_byte_cap(tmp_path, monkeypatch):
+    """A line count cannot see a single multi-megabyte line."""
+    monkeypatch.setattr(gc, "KEEP_LOG_LINES", 2)
+    monkeypatch.setattr(gc, "KEEP_LOG_MB", 0.2)
+    logs = _logs_dir(tmp_path, {"gitgc.log": "x" * 300000 + "\ntail one\ntail two\n"})
+
+    files, freed = gc.trim_logs(time.time(), dry_run=False, dirpath=logs)
+
+    assert files == 1 and freed > 250000
+    assert (logs / "gitgc.log").read_text() == "tail one\ntail two\n"
+
+
+def test_dry_run_reports_without_cutting(tmp_path, monkeypatch):
+    monkeypatch.setattr(gc, "KEEP_LOG_LINES", 10)
+    logs = _logs_dir(tmp_path, {"nostr_broadcast.log": _fat()})
+
+    files, freed = gc.trim_logs(time.time(), dry_run=True, dirpath=logs)
+
+    assert files == 1 and freed > 0
+    assert len((logs / "nostr_broadcast.log").read_text().splitlines()) == 50000


### PR DESCRIPTION
Closes #1324.

`logs/` had no rotation of any kind. `publish_dashboard.log` is 10,514 lines / 673 KB, `logs/watchdog.jsonl` 99 days of delivery evidence, and both only grow — nothing in the repo or the crontab ever cut either one.

The nightly sweep that already prunes `sessions/` and `memory/.tmp` (`ops/host/gc_sessions.py`, 03:30 daily) now trims them too, so this needs no crontab change.

## Why a tail and not an age

An age cutoff on a single ever-growing file deletes all of it or none of it. Nothing reads these from the front: `ops/system_check.py` reads a fixed tail of each host cron log looking for a crash, and `intraday_watchdog` says outright that a line in watchdog.jsonl "is not something kcn reads".

## The three details that are the actual work

- **Copy-truncate, not rename.** The crontab redirects with `>>`, so a running job holds an O_APPEND descriptor on the inode; renaming sends the rest of that job's output to a file nobody opens again. Rewriting the same inode keeps every writer on the live log — asserted by `st_ino` across a trim with an appender open.
- **`.log` and `.jsonl` only.** `logs/` also holds state read whole (`brief_postflight_status.json`), which a tail-trim would corrupt.
- **Hysteresis and a quiet window.** Trim at five times the tail we keep (plus a byte cap for the pathological single-huge-line case), and skip anything written in the last minute — so this rewrites a given log about once a year rather than every night, and never races an appender for the bytes it is over.

Dry run against the live workspace: `publish_dashboard.log` 10,514 lines / 673 KB → last 2,000, freeing 540 KB; nothing else is near either threshold. `tests/test_gc_sessions_log_trim.py` (7 assertions) plus the existing `test_gc_sessions_rules.py` and `test_system_check_host_cron_logs.py` pass.

## Note on #1320 (the sibling issue)

Not fixed here because it is not true: `memory/.tmp` **is** swept, by this same script, at 14 days, since 2026-06-10. The issue's grep was scoped to `src/` and so never saw `ops/host/gc_sessions.py`. The 413 files / 24 MB it measured is the steady state of 14 days of cron traffic, and the oldest file on disk is exactly 14 days old. Closing it separately with that evidence.

https://claude.ai/code/session_01RnEpMv8MLR9cHv6H3TCDKc