### PR TITLE
dashboard: measure the equity tooltip once before placing it (#1327)

### DIFF
--- a/site/assets/js/dashboard.charts.js
+++ b/site/assets/js/dashboard.charts.js
@@ -627,9 +627,16 @@
       } else if (hoverIndex === 0) rows.push("总利润较昨日: <b>首日</b>");
       tooltip.innerHTML = `<b>${escapeHtml(model.dates[hoverIndex])}</b><br>${rows.join("<br>")}`;
       tooltip.hidden = false;
+      // Measure once, then place. The old order read offsetWidth after writing
+      // innerHTML and offsetHeight after writing style.left, so each mousemove
+      // over the chart forced two synchronous layouts instead of one. Hoisting
+      // both reads is safe because the tooltip is absolutely positioned with a
+      // max-width and no `right`: its box is content-driven and `left` cannot
+      // change it.
+      const tipW = tooltip.offsetWidth, tipH = tooltip.offsetHeight;
       const x = event.clientX - rect.left;
-      tooltip.style.left = Math.min(Math.max(8, x + 12), Math.max(8, rect.width - tooltip.offsetWidth - 8)) + "px";
-      tooltip.style.top = Math.max(8, event.clientY - rect.top - tooltip.offsetHeight - 10) + "px";
+      tooltip.style.left = Math.min(Math.max(8, x + 12), Math.max(8, rect.width - tipW - 8)) + "px";
+      tooltip.style.top = Math.max(8, event.clientY - rect.top - tipH - 10) + "px";
       scheduleDraw();
     }
 


### PR DESCRIPTION
Closes #1327.

`showTooltip` wrote `innerHTML`, read `offsetWidth`, wrote `style.left`, then read `offsetHeight` — two synchronous layouts per mousemove over the equity chart where one would do. Both reads now happen together, before either write.

Safe by construction rather than by measurement: the tooltip is `position: absolute` with `max-width: 240px` and no `right`, so its box is content-driven and `left` cannot change it. The values written are identical.

## What the issue got wrong

Fixing it anyway, but the record should be straight:

- **"低内存 VPS（available ≈200MB、swap 1.5G）上会造成明显的性能抖动"** — this JS runs in the viewer's browser. This host's memory has nothing to do with a reflow on kcn's phone. The same sentence appears in #1332, so it is a pattern in this batch, not a slip.
- **Its RED-CHECK** asserted only that `dashboard.charts.js` contains `getBoundingClientRect` *and* `tooltip.style` somewhere in the file — true of any file with a tooltip, before or after this change. It ran red for a reason unrelated to its claim.

The read-after-write itself is real, and it is two lines, so it is done rather than argued about. No new gate: a static "geometry read after a style write" rule over JS would be mostly false positives, and this is not a class worth enshrining.

https://claude.ai/code/session_01RnEpMv8MLR9cHv6H3TCDKc