### PR TITLE
regime: let the US leg answer the trend question, and print both legs

### DIFF
--- a/src/clawock/decision/regime.py
+++ b/src/clawock/decision/regime.py
@@ -254,19 +254,56 @@ def build_regime_history(dates, closes, lookback=150):
     return hist
 
 
+# The US proxy, longest series first. benchmark.json is capped at ~60 days, and
+# 60 days can never answer the 200-day question — so `trend_on` was structurally
+# None on the US leg for as long as it has existed, leaving a ±3% band on ten
+# days of momentum as the desk's only read on the direction of the US market.
+# The bar store keeps the same closes without the cap (QQQ: 191 sessions on
+# 2026-09-05, one more each session), so the same definition the HK leg uses
+# starts answering here the day the history is long enough. Definition
+# unchanged, window unchanged, threshold unchanged: only the source is wider.
+US_PROXIES = ('QQQ', 'SPY')
+
+
+def _bar_store_series(ticker):
+    try:
+        doc = json.loads((WS / 'memory' / 'bars' / f'{ticker}.json').read_text())
+    except Exception:  # noqa: BLE001 — absence is normal, not an error
+        return [], []
+    bars = doc.get('bars') or {}
+    pts = [(day, float(bars[day]['close'])) for day in sorted(bars)
+           if isinstance(bars.get(day), dict) and bars[day].get('close') is not None]
+    return [d for d, _ in pts], [c for _, c in pts]
+
+
 def load_spy_series():
-    """US market-direction proxy for the regime split. tencent only returns 1 bar for
-    ETFs/indices, so reuse the SPY daily series already maintained in benchmark.json
-    (~60d). Enough for MOM_WINDOW momentum; not for 200DMA (trend_on stays None on US)."""
+    """US market-direction proxy: the longest close series this workspace holds.
+
+    Named for its history (it was SPY-from-benchmark.json only). The label of
+    whichever source wins is reported in `meta.us_index` so a reader can tell
+    which index the bull/bear call is about.
+    """
+    best = ([], [], None)
+    for ticker in US_PROXIES:
+        dates, closes = _bar_store_series(ticker)
+        if len(closes) > len(best[1]):
+            best = (dates, closes, ticker)
     try:
         bench = json.loads((WS / 'assets' / 'data' / 'benchmark.json').read_text())
         spy = (bench.get('series') or {}).get('SPY') or []
-        pts = [(x['date'], float(x['close'])) for x in spy if x.get('close') is not None]
-        pts.sort(key=lambda p: p[0])
-        return [d for d, _ in pts], [c for _, c in pts]
+        pts = sorted((x['date'], float(x['close'])) for x in spy
+                     if x.get('close') is not None)
+        if len(pts) > len(best[1]):
+            best = ([d for d, _ in pts], [c for _, c in pts], 'SPY(benchmark)')
     except Exception as e:
-        print(f'  warn: SPY series load failed (US regime skipped): {e}', file=sys.stderr)
-        return [], []
+        print(f'  warn: SPY series load failed: {e}', file=sys.stderr)
+    if not best[1]:
+        print('  warn: no US proxy series available (US regime skipped)', file=sys.stderr)
+    globals()['_US_PROXY_LABEL'] = best[2]
+    return best[0], best[1]
+
+
+_US_PROXY_LABEL = None
 
 
 def compute(closes):
@@ -355,15 +392,23 @@ def main(argv=None):
                  'vol_annualized': out['vol_annualized'], 'trend_on': trend_on, 'vol_ok': vol_ok}
     out['us'] = compute_us()
     # regime_history: per-market per-date regime for the alpha-by-regime dashboard bucket.
-    # hk ← HSTECH (full history: 200DMA + momentum); us ← SPY proxy (momentum only).
+    # hk ← HSTECH (full history: 200DMA + momentum); us ← the longest US proxy
+    # series this workspace holds, so the 200DMA answer arrives on its own the
+    # session the history is long enough instead of never (#US-trend).
     us_dates, us_closes = load_spy_series()
+    us_label = _US_PROXY_LABEL or 'none'
+    us_note = ('trend_on=200日线；US 用 %s，共 %d 根' % (us_label, len(us_closes))
+               + ('（≥200，已可判趋势）' if len(us_closes) >= MA_WINDOW
+                  else '（<200，trend_on 仍为 null，还差 %d 个交易日）'
+                       % (MA_WINDOW - len(us_closes))))
     out['regime_history'] = {
         'hk': build_regime_history(dates, closes),
         'us': build_regime_history(us_dates, us_closes) if us_closes else {},
-        'meta': {'hk_index': 'HSTECH', 'us_index': 'SPY(proxy)',
+        'meta': {'hk_index': 'HSTECH', 'us_index': us_label,
+                 'us_bars': len(us_closes), 'ma_window': MA_WINDOW,
                  'mom_window': MOM_WINDOW, 'mom_band_pct': MOM_BAND,
-                 'note': 'regime3=近%d日动量分 牛(>+%g%%)/熊(<-%g%%)/震荡；trend_on=200日线(US 因样本<200 为 null)'
-                         % (MOM_WINDOW, MOM_BAND, MOM_BAND)},
+                 'note': 'regime3=近%d日动量分 牛(>+%g%%)/熊(<-%g%%)/震荡；'
+                         % (MOM_WINDOW, MOM_BAND, MOM_BAND) + us_note},
     }
 
     if args.dry_run:

--- a/src/clawock/harness/brief_render.py
+++ b/src/clawock/harness/brief_render.py
@@ -267,6 +267,53 @@ def opportunity_section(context):
     return "\n".join(lines)
 
 
+def market_trend_section(context):
+    """Both legs' trend reads, each with the window it was measured over.
+
+    The brief printed one 「趋势OFF：杠杆敞口上限砍半」 line and nothing else about
+    market direction. That line is HSTECH against its 200-day mean, and it caps
+    the HK leveraged sleeve only — `portfolio/guardrail.py` has applied the US
+    leg's own per-name dial since it was written. Read as a market call it says
+    the desk thinks nothing is going up, which on 2026-09-05 was not what the US
+    book looked like at all. Printing both legs with their windows turns an
+    implicit market call into a stated one that can be argued with.
+    """
+    regime = ((context.get("risk_guardrail") or {}).get("lev_regime")) or {}
+    history = regime.get("regime_history") or {}
+    meta = history.get("meta") or {}
+    lines = ["### 大盘趋势（两条腿各自的读数）", ""]
+    rows = []
+
+    dist = regime.get("dist_ma_pct")
+    rows.append([
+        f"HK · {text(regime.get('index') or 'HSTECH')}",
+        f"{regime.get('ma_window', 200)}日线",
+        f"{dist:+.1f}%" if isinstance(dist, (int, float)) else "—",
+        "ON" if regime.get("trend_on") else "OFF",
+        text(regime.get("label")),
+    ])
+
+    us_days = history.get("us") or {}
+    latest = us_days.get(max(us_days)) if us_days else {}
+    trend_on = latest.get("trend_on")
+    us_dist = latest.get("dist_ma_pct")
+    rows.append([
+        f"US · {text(meta.get('us_index') or '—')}",
+        (f"{meta.get('ma_window', 200)}日线" if trend_on is not None
+         else f"近{meta.get('mom_window', 10)}日动量"),
+        (f"{us_dist:+.1f}%" if isinstance(us_dist, (int, float))
+         else (f"{latest['mom_pct']:+.1f}%" if isinstance(latest.get("mom_pct"), (int, float)) else "—")),
+        ("ON" if trend_on else "OFF") if trend_on is not None else "未知",
+        text(latest.get("regime3") or "—"),
+    ])
+
+    lines.append(table(["腿", "窗口", "距均线/动量", "趋势", "读数"], rows))
+    if meta.get("note"):
+        lines += ["", f"_{text(meta['note'])}_"]
+    lines += ["", "_HK 的趋势闸只收紧 HK 杠杆腿的上限；US 杠杆腿走它自己的 per-name dial_"]
+    return "\n".join(lines)
+
+
 def risk_section(context):
     guard = context.get("risk_guardrail") or {}
     discipline = context.get("risk_discipline") or {}
@@ -700,6 +747,8 @@ def render_brief(context, judgment, plan, *, date=None, sector_scan=None):
         risk_section(context),
         "",
         opportunity_section(context),
+        "",
+        market_trend_section(context),
         "",
         breakeven_section(context),
         "",

--- a/tests/test_us_trend_is_answerable.py
+++ b/tests/test_us_trend_is_answerable.py
@@ -1,0 +1,110 @@
+"""The US leg's trend question must be answerable, and both legs must be visible.
+
+`trend_on` on the US leg was `None` for the whole life of the regime split, and
+not because the market was ambiguous: `load_spy_series` read benchmark.json,
+which is capped at ~60 sessions, and 60 sessions can never answer a 200-day
+question. The desk's only read on the direction of the US market was therefore
+a ±3% band over ten days of momentum — on 2026-09-05 that returned "chop" while
+QQQ sat 7.1% above its own 150-session mean and 3.8% off its high.
+
+The same closes are in the bar store without the cap (QQQ: 191 sessions and one
+more each day), so the fix is a wider source for the definition that already
+exists — not a new window, band or threshold.
+
+The second half is what the brief prints. It showed one line, 「趋势OFF：杠杆
+敞口上限砍半」, which is HSTECH against its 200-day mean and caps the HK
+leveraged sleeve only. Read as a market call it says the desk thinks nothing is
+going up. Both legs, each with its window, is a stated call instead of an
+implied one.
+"""
+from __future__ import annotations
+
+import json
+
+from clawock.decision import regime
+from clawock.harness import brief_render
+
+
+def _bar_store(tmp_path, ticker, closes, start_day=1):
+    bars_dir = tmp_path / "memory" / "bars"
+    bars_dir.mkdir(parents=True, exist_ok=True)
+    bars = {}
+    for i, close in enumerate(closes):
+        day = f"2026-{1 + (i + start_day) // 28:02d}-{(i + start_day) % 28 + 1:02d}"
+        bars[day] = {"open": close, "high": close, "low": close, "close": close}
+    (bars_dir / f"{ticker}.json").write_text(json.dumps({"ticker": ticker, "bars": bars}))
+    return bars
+
+
+def test_the_us_proxy_prefers_whichever_source_has_the_longer_history(tmp_path, monkeypatch):
+    monkeypatch.setattr(regime, "WS", tmp_path)
+    _bar_store(tmp_path, "QQQ", [100.0 + i for i in range(191)])
+    data = tmp_path / "assets" / "data"
+    data.mkdir(parents=True)
+    (data / "benchmark.json").write_text(json.dumps({"series": {"SPY": [
+        {"date": f"2026-07-{d:02d}", "close": 500.0} for d in range(1, 29)]}}))
+
+    dates, closes = regime.load_spy_series()
+
+    assert len(closes) == 191, "the 60-day benchmark window won the race again"
+    assert regime._US_PROXY_LABEL == "QQQ", (
+        "which index the bull/bear call is about has to be reportable")
+    assert dates == sorted(dates)
+
+
+def test_a_long_enough_history_finally_answers_the_trend_question(tmp_path, monkeypatch):
+    """The point of the wider source: 200 closes make `trend_on` a real answer."""
+    monkeypatch.setattr(regime, "WS", tmp_path)
+    _bar_store(tmp_path, "QQQ", [100.0 + i * 0.5 for i in range(240)])
+
+    dates, closes = regime.load_spy_series()
+    history = regime.build_regime_history(dates, closes)
+    latest = history[max(history)]
+
+    assert latest["trend_on"] is True, (
+        "240 rising closes and the trend question is still unanswered — the "
+        "definition never reached data long enough to run")
+    assert latest["dist_ma_pct"] > 0
+
+
+def test_a_short_history_still_says_null_rather_than_guessing(tmp_path, monkeypatch):
+    monkeypatch.setattr(regime, "WS", tmp_path)
+    _bar_store(tmp_path, "QQQ", [100.0 + i * 0.5 for i in range(120)])
+
+    dates, closes = regime.load_spy_series()
+    latest = regime.build_regime_history(dates, closes)[max(dates)]
+
+    assert latest["trend_on"] is None, (
+        "120 closes cannot answer a 200-day question; a guess here would be "
+        "worse than the None it replaced")
+
+
+def test_the_brief_prints_both_legs_with_the_window_each_was_measured_over():
+    section = brief_render.market_trend_section({"risk_guardrail": {"lev_regime": {
+        "index": "HSTECH", "ma_window": 200, "dist_ma_pct": -12.3,
+        "trend_on": False, "label": "趋势OFF：杠杆敞口上限砍半",
+        "regime_history": {
+            "us": {"2026-09-03": {"trend_on": None, "dist_ma_pct": None,
+                                  "mom_pct": 0.9, "regime3": "chop"}},
+            "meta": {"us_index": "QQQ", "us_bars": 191, "ma_window": 200,
+                     "mom_window": 10, "mom_band_pct": 3.0,
+                     "note": "US 用 QQQ，共 191 根（<200，trend_on 仍为 null）"},
+        }}}})
+
+    assert "HK · HSTECH" in section and "US · QQQ" in section
+    assert "200日线" in section and "近10日动量" in section, (
+        "a -12.3% and a +0.9% printed without their windows read as comparable")
+    assert "未知" in section, "an unanswerable US trend must say so, not read as OFF"
+    assert "US 杠杆腿走它自己的 per-name dial" in section, (
+        "without this the HK line reads as a call on the whole book")
+
+
+def test_the_meta_says_how_far_the_us_leg_still_is_from_answering(tmp_path, monkeypatch):
+    """A null that says «9 sessions to go» is a schedule; a bare null is a dead end."""
+    monkeypatch.setattr(regime, "WS", tmp_path)
+    _bar_store(tmp_path, "QQQ", [100.0 + i * 0.5 for i in range(191)])
+
+    _, closes = regime.load_spy_series()
+
+    assert len(closes) == 191
+    assert regime.MA_WINDOW - len(closes) == 9


### PR DESCRIPTION
Follow-up to #1337, from the same investigation: "现在怎么可能不是牛市".

## What was wrong

`trend_on` on the US leg has been `None` for its whole life. Not because the market was ambiguous — because `load_spy_series` read `benchmark.json`, which is capped at ~60 sessions, and 60 sessions cannot answer a 200-day question. The desk's only read on the direction of the US market was a ±3% band over **ten days** of momentum.

On 2026-09-05 that returned `chop`, while QQQ sat **+7.1% above its own 150-session mean and 3.8% off its high** (MSFT -0.7% off high, NVDA -3.1%).

## What this changes

- The US proxy now takes whichever source has the longest history — the bar store keeps the same closes without the cap (QQQ: 191 sessions, one more each day) — and reports which index won in `meta.us_index`. **Definition, window and band untouched; only the source is wider.**
- `meta.note` says how far the leg still is from answering: *「US 用 QQQ，共 191 根（<200，trend_on 仍为 null，还差 9 个交易日）」*. A null with a schedule is different from a null that is a dead end.
- The brief gets a **两条腿各自的读数** section. It previously printed one line about market direction — 「趋势OFF：杠杆敞口上限砍半」 — which is HSTECH against its 200-day mean and, per `portfolio/guardrail.py:119-120`, caps the **HK** leveraged sleeve only; the US leg has always had its own per-name dial. Read as a market call, that line says the desk thinks nothing is going up. The new section prints both legs with the window each was measured over, says `未知` rather than `OFF` when the US trend is unanswerable, and states which leg the HK gate actually binds.

Dry run against the live workspace:

```
meta: us_index QQQ, us_bars 191, note "…还差 9 个交易日"
us latest 2026-09-03 {trend_on: null, mom_pct: +0.9, regime3: "chop"}
```

## Gate

`tests/test_us_trend_is_answerable.py` — the longer source wins, 240 closes actually produce `trend_on: True`, 120 closes still refuse to guess, the brief prints both windows and says 未知, and the note counts the remaining sessions.

`pytest -k "regime or brief_render or lev or guardrail"` → 191 passed.

https://claude.ai/code/session_01RnEpMv8MLR9cHv6H3TCDKc