### PR TITLE
dashboard: a card that answers "why is there no add today"

### DIFF
--- a/site/assets/css/dashboard.css
+++ b/site/assets/css/dashboard.css
@@ -1412,6 +1412,43 @@
   .matrix-status.positive::before { background: var(--positive); }
   .matrix-status.neutral::before { background: var(--neutral); }
 
+  /* Add side — the counts, the family warm-up bars and the two tables that
+     answer "why is there no add today". Reuses .holdings-table for the tables
+     so the type scale and the sticky header come from one place. */
+  .add-counts { display: flex; flex-wrap: wrap; gap: var(--space-2); margin-bottom: var(--space-3); }
+  .add-chip {
+    display: inline-flex; align-items: center; gap: 6px;
+    padding: 4px 10px; border-radius: 999px; background: var(--surface-3);
+    color: var(--text-dim); font: var(--fs-xs)/1 var(--mono);
+    border: 1px solid var(--border);
+  }
+  .add-chip b { color: var(--text); font-size: var(--fs-sm); }
+  .add-chip.is-candidate { border-color: var(--positive); color: var(--text); }
+  .add-chip.is-reject { border-color: var(--warning); }
+  .add-chip.is-cold { border-style: dashed; }
+  .add-why {
+    margin: 0 0 var(--space-3); padding: var(--space-3);
+    background: var(--surface-3); border-radius: var(--radius-sm);
+    border-left: 2px solid var(--accent); font-size: var(--fs-sm); line-height: 1.6;
+  }
+  .add-families { display: flex; flex-direction: column; gap: 6px; margin-bottom: var(--space-3); }
+  .add-family {
+    display: grid; grid-template-columns: minmax(9em, 1.2fr) minmax(60px, 1fr) minmax(7em, auto);
+    align-items: center; gap: var(--space-3); font-size: var(--fs-xs);
+  }
+  .add-family-name { color: var(--text-dim); }
+  .add-family-bar {
+    height: 5px; border-radius: 3px; background: var(--surface-3); overflow: hidden;
+  }
+  .add-family-bar i { display: block; height: 100%; background: var(--accent); }
+  .add-family-detail { color: var(--text-faint); font-family: var(--mono); text-align: right; }
+  .add-family-detail.is-on { color: var(--positive); }
+  .add-table .add-why-cell {
+    white-space: normal; line-height: 1.45; font-size: var(--fs-micro); color: var(--text-dim);
+  }
+  /* The row every hit rate above has to be read against. */
+  .add-table tr.add-baseline > td { border-top: 1px solid var(--border); color: var(--text-faint); }
+
   /* Plan actions */
   .plan-actions { display: flex; flex-direction: column; gap: 8px; }
   .plan-action {

--- a/site/assets/js/dashboard.render.js
+++ b/site/assets/js/dashboard.render.js
@@ -78,6 +78,123 @@
     return { date: latest.date || null, rows };
   }
 
+  // ── Add side ────────────────────────────────────────────────────────────
+  // Why there is, or is not, an add today. The dashboard could show 47 days of
+  // sell-only advice with no way to ask why: the reason lives in three
+  // quantities the payload now carries (#1337/#1340/#1341) — which evidence
+  // families are still warming up and how far, what the add side read today
+  // and what would settle it, and what each entry shape has been worth against
+  // a baseline. Nothing here is computed in the browser; every number is
+  // projected from the brief context or from an `add_shapes` run card.
+  const ADD_VERDICT_LABEL = { candidate: "候选", wait: "等", reject: "挡住" };
+  const ADD_FAMILY_LABEL = {
+    price_relative_factor: "价格相对 · 量化因子",
+    price_relative_peer: "价格相对 · 同行残差",
+    point_in_time_information: "时点信息 · 新闻/关注度",
+  };
+  const ADD_SHAPE_LABEL = {
+    breakout: "突破（未过热）",
+    breakout_overheated: "突破但过热",
+    pullback_in_uptrend: "上升趋势中的回踩",
+    deep_dip: "深跌",
+  };
+
+  function renderAddSide() {
+    const card = document.getElementById("add-side-card");
+    const body = document.getElementById("add-side-body");
+    if (!card || !body) return;
+    const data = safe(DATA, "add_side");
+    if (!data) { card.style.display = "none"; return; }
+    card.style.display = "";
+
+    const counts = data.counts || {};
+    const parts = [];
+
+    if (data.pending) {
+      parts.push(`<div class="empty-state">加仓读数要等下一次盘前简报生成（本条从简报 context 投影，不在面板里重算）。</div>`);
+    } else {
+      const chip = (key, cls) =>
+        `<span class="add-chip ${cls}">${ADD_VERDICT_LABEL[key]} <b>${counts[key] ?? 0}</b></span>`;
+      parts.push(`<div class="add-counts">${chip("candidate", "is-candidate")}` +
+        `${chip("wait", "is-wait")}${chip("reject", "is-reject")}` +
+        (data.cold_start ? `<span class="add-chip is-cold">冷启动期 · 单族半仓</span>` : "") +
+        `</div>`);
+      if (data.why_no_candidate) {
+        parts.push(`<p class="add-why"><b>今天没有候选的原因</b>：${escapeHtml(data.why_no_candidate)}</p>`);
+      }
+    }
+
+    const families = data.families || [];
+    if (families.length) {
+      parts.push(`<div class="sub-block-head">证据族开机状态</div>`);
+      parts.push(`<div class="add-families">` + families.map(row => {
+        const label = ADD_FAMILY_LABEL[row.name] || row.name;
+        const progress = row.progress;
+        const pctDone = progress ? Math.min(100, Math.round(progress.have / progress.need * 100)) : (row.active ? 100 : 0);
+        const detail = row.active ? "已激活"
+          : progress ? `${progress.counter} ${progress.have}/${progress.need}`
+          : (row.blockers || []).join("、") || "预热中";
+        return `<div class="add-family">` +
+          `<span class="add-family-name">${escapeHtml(label)}</span>` +
+          `<span class="add-family-bar"><i style="width:${pctDone}%"></i></span>` +
+          `<span class="add-family-detail ${row.active ? "is-on" : ""}">${escapeHtml(detail)}</span>` +
+          `</div>`;
+      }).join("") + `</div>`);
+    }
+
+    const rows = data.rows || [];
+    if (rows.length) {
+      parts.push(`<div class="sub-block-head">今天的读数</div>`);
+      parts.push(`<div class="table-wrap"><table class="holdings-table add-table"><thead><tr>` +
+        `<th>标的</th><th>判定</th><th>为什么</th><th>要什么才算数</th><th class="num">距 20 日高</th>` +
+        `</tr></thead><tbody>` + rows.map(row => {
+          const pct = row.pct_from_high;
+          return `<tr><td><span class="ticker">${escapeHtml(row.ticker || DASH)}</span></td>` +
+            `<td><span class="matrix-status ${row.verdict === "candidate" ? "positive" : row.verdict === "reject" ? "elevated" : "neutral"}">` +
+            `${escapeHtml(ADD_VERDICT_LABEL[row.verdict] || row.verdict || DASH)}</span></td>` +
+            `<td class="add-why-cell">${escapeHtml(row.why || DASH)}</td>` +
+            `<td class="add-why-cell">${escapeHtml(row.needs || DASH)}</td>` +
+            `<td class="num">${pct == null ? DASH : `${pct > 0 ? "+" : ""}${Number(pct).toFixed(2)}%`}</td></tr>`;
+        }).join("") + `</tbody></table></div>`);
+    }
+
+    const study = data.shapes;
+    if (study && study.shapes) {
+      const horizons = ["t1", "t5", "t20"];
+      const cell = triple => triple
+        ? `${(triple[1] * 100).toFixed(1)}%<span class="muted"> ${triple[2] > 0 ? "+" : ""}${Number(triple[2]).toFixed(2)}%</span>`
+        : DASH;
+      const bodyRows = Object.keys(ADD_SHAPE_LABEL)
+        .filter(name => study.shapes[name])
+        .map(name => `<tr><td>${escapeHtml(ADD_SHAPE_LABEL[name])}</td>` +
+          horizons.map(h => `<td class="num">${cell(study.shapes[name][h])}</td>`).join("") + `</tr>`)
+        .join("");
+      // The baseline row is the point: a shape hitting 50% is worth nothing
+      // where a random session hits 50.1%.
+      const baseRow = `<tr class="add-baseline"><td>基线 · 随便哪一天</td>` +
+        horizons.map(h => `<td class="num">${cell((study.baseline || {})[h])}</td>`).join("") + `</tr>`;
+      parts.push(`<div class="sub-block-head">入场形态历史命中率 <span class="muted">${study.names || DASH} 只票 · 命中率 / 均值</span></div>`);
+      parts.push(`<div class="table-wrap"><table class="holdings-table add-table"><thead><tr>` +
+        `<th>形态</th><th class="num">T+1</th><th class="num">T+5</th><th class="num">T+20</th>` +
+        `</tr></thead><tbody>${bodyRows}${baseRow}</tbody></table></div>`);
+      parts.push(`<p class="chart-hint">样本高度重叠、幸存者偏差、单一上行 regime —— 这三条限制比其中三行之间的差异还大。` +
+        `对着基线读，别单看。可复跑：<code>clawock evaluate-add-shapes</code>${study.run_id ? ` · run card <code>${escapeHtml(study.run_id)}</code>` : ""}。</p>`);
+    }
+
+    const track = data.track_record || {};
+    const trackParts = Object.entries(track)
+      .filter(([, seat]) => seat && seat.settled)
+      .map(([action, seat]) =>
+        `<code>${escapeHtml(action)}</code> ${(seat.hit_rate * 100).toFixed(1)}% ` +
+        `<span class="muted">(${seat.win}胜/${seat.loss}负, n=${seat.settled})</span>`);
+    if (trackParts.length) {
+      parts.push(`<p class="chart-hint"><b>这几类建议的历史命中率</b>（T+1，假设成交）：` +
+        `${trackParts.join(" · ")} —— 命中率不是执行理由，是读建议时的先验。</p>`);
+    }
+
+    body.innerHTML = parts.join("");
+  }
+
   function renderWatchLevels() {
     const card = document.getElementById("watch-levels-card");
     const list = document.getElementById("watch-levels-list");
@@ -380,7 +497,7 @@
       renderNewsDigest, renderMacro, renderPeerDivergence, renderSectorContext,
     ],
     plan: [
-      renderWatchLevels, renderPlanActions, renderPlanTimeline,
+      renderAddSide, renderWatchLevels, renderPlanActions, renderPlanTimeline,
       renderBearCases, renderHiddenConcentration,
     ],
     reflect: [

--- a/site/index.html
+++ b/site/index.html
@@ -763,6 +763,12 @@ layout: null
   <section class="panel" data-panel="plan">
     <h2>Plan</h2>
 
+    <div class="card lead" id="add-side-card" style="display:none">
+      <h3>加仓面 <span class="muted" style="text-transform:none;letter-spacing:0;font-weight:500;font-size:var(--fs-xs)">Add side · 收盘确认</span></h3>
+      <p class="chart-hint">为什么今天有/没有加仓建议。三个证据族任意两族成立才授权试探仓——两族没开机时，「任意两族」就退化成「必须追涨」。三态都不是下单授权。</p>
+      <div id="add-side-body"></div>
+    </div>
+
     <div class="card" id="watch-levels-card" style="display:none">
       <h3>今日触发位 <span class="muted" id="watch-levels-date" style="text-transform:none;letter-spacing:0;font-weight:500;font-size:var(--fs-xs)">Watch Levels</span></h3>
       <p class="chart-hint">盘前计划写死的触发价位 vs 现价。距离越近越该盯，&lt;2% 标红。</p>

--- a/src/clawock/publish/dashboard.py
+++ b/src/clawock/publish/dashboard.py
@@ -1685,6 +1685,115 @@ def _latest_brief_context():
         return None, None
 
 
+def compute_add_side(shape_cards_dir=None):
+    """The add side, as the brief already computed it — projected, not recomputed.
+
+    Every number here is copied from something that already exists: the brief
+    context carries `opportunity` / `add_alpha_activation` / `action_track_record`
+    (#1337, #1340), and the newest `add_shapes` run card carries the shape study
+    (#1341). Recomputing any of it here would create a second answer to the same
+    question, which is the failure this whole line of work started from.
+
+    It exists because the dashboard could show a book with no add decisions in
+    it and no way to ask why. The answer has three parts and all three are
+    quantities, not prose: which evidence families are still warming up and how
+    far, what the add side read today and what would settle it, and what each
+    entry shape has historically been worth against a baseline.
+    """
+    _, context = _latest_brief_context()
+    context = context or {}
+    opportunity = context.get('opportunity') or {}
+    activation = context.get('add_alpha_activation') or {}
+    track = (context.get('action_track_record') or {}).get('by_action') or {}
+
+    families = []
+    for name, row in (activation.get('families') or {}).items():
+        progress = None
+        for counter, pair in (row.get('progress') or {}).items():
+            # The countdown only; a pass/fail flag has nothing to count down.
+            if (isinstance(pair, list) and len(pair) == 2
+                    and all(isinstance(x, (int, float)) and not isinstance(x, bool)
+                            for x in pair) and pair[0] < pair[1]):
+                progress = {'counter': counter, 'have': pair[0], 'need': pair[1]}
+                break
+        families.append({
+            'name': name,
+            'active': bool(row.get('active')),
+            'progress': progress,
+            'blockers': list(row.get('blockers') or [])[:3],
+        })
+
+    rows = []
+    for row in (opportunity.get('rows') or [])[:8]:
+        evidence = row.get('evidence') or {}
+        rows.append({
+            'ticker': row.get('ticker'),
+            'verdict': row.get('verdict'),
+            'why': (row.get('why') or '')[:90],
+            'needs': (row.get('needs') or '')[:70],
+            'prior_20d_high': evidence.get('prior_20d_high'),
+            'pct_from_high': evidence.get('pct_from_high'),
+        })
+
+    shapes = _latest_shape_study(shape_cards_dir)
+    return {
+        'as_of': context.get('date'),
+        # The brief only started emitting these blocks on 2026-09-05, so a
+        # checkout whose newest context predates that has the shape study and
+        # nothing else. Saying which is the difference between an empty card and
+        # a card that looks broken.
+        'pending': not opportunity,
+        'counts': opportunity.get('counts') or {},
+        'why_no_candidate': opportunity.get('why_no_candidate'),
+        'policy': opportunity.get('policy'),
+        'cold_start': bool(activation.get('cold_start')),
+        'families': families,
+        'rows': rows,
+        'shapes': shapes,
+        'track_record': {
+            action: {'hit_rate': seat.get('hit_rate'), 'win': seat.get('win'),
+                     'loss': seat.get('loss'), 'settled': seat.get('settled')}
+            for action, seat in track.items()
+            if action in ('cut', 'trim_on_rebound', 'add_only_on_trigger')
+        },
+    }
+
+
+def _latest_shape_study(cards_dir=None):
+    """The newest `add_shapes` run card's metrics, or None.
+
+    A run card rather than a live recomputation on purpose: the card records the
+    exact bars and parameters behind the numbers, so what the dashboard shows is
+    re-derivable with `clawock run-card --run-id …` instead of being a figure
+    that only ever existed on a web page.
+    """
+    directory = Path(cards_dir) if cards_dir else WS_ROOT / 'memory' / 'backtests'
+    try:
+        cards = sorted(directory.glob('add_shapes-*.json'))
+        if not cards:
+            return None
+        card = load_json(str(max(cards, key=os.path.getmtime)))
+    except Exception as e:
+        print(f'  warn: add_shapes run card unreadable: {e}', file=sys.stderr)
+        return None
+    metrics = (card or {}).get('metrics') or {}
+    if not metrics.get('shapes'):
+        return None
+    keep = ('breakout', 'breakout_overheated', 'pullback_in_uptrend', 'deep_dip')
+    trimmed = {}
+    for name in keep:
+        seat = metrics['shapes'].get(name) or {}
+        row = {h: [cell.get('n'), cell.get('hit_rate'), cell.get('mean_pct')]
+               for h, cell in seat.items() if isinstance(cell, dict)}
+        if row:
+            trimmed[name] = row
+    baseline = {h: [cell.get('n'), cell.get('hit_rate'), cell.get('mean_pct')]
+                for h, cell in (metrics.get('baseline') or {}).items()
+                if isinstance(cell, dict)}
+    return {'shapes': trimmed, 'baseline': baseline,
+            'names': metrics.get('names'), 'run_id': (card or {}).get('run_id')}
+
+
 def load_previous_payload(path):
     """Return `(payload_or_None, missing)` for a previously published dashboard.
 
@@ -3887,6 +3996,11 @@ def build_projection(previous_source=None, shadow_previous=None):
     _embed('t0_setups', 't0_setups.json')              # compute_t0_setups.py: T+0 牌面评级(追高检测)
     _embed('t0_setup_review', 't0_setup_review.json')  # t0_setup_review.py: 牌面命中率背书(T+1对账)
     _embed('catalysts', 'catalysts.json')              # clawock catalysts + brief preflight
+    # The add side: why there is or is not an add today, projected from the
+    # brief context and the add_shapes run card (#1337/#1340/#1341). A book with
+    # no add decisions in it and no way to ask why is how 47 days of sell-only
+    # advice went unquestioned.
+    out['add_side'] = compute_add_side()
     _embed('benchmark', 'benchmark.json')              # fetch_benchmark_history.py: SPY/HSI/HSTECH daily close
     # 基准新鲜度守卫 — Polygon/HSI 抓取偶发限流会让 benchmark.json 停更(曾停到6天),
     # equity curve 的 SPY/恒科等值线会静默退化成平线。被动暴露 staleness 给前端显示小字

--- a/tests/dashboard_tab_runtime.spec.js
+++ b/tests/dashboard_tab_runtime.spec.js
@@ -1144,6 +1144,71 @@ async function testVerdictDeckFillsItsBoxAndRanksGatesBySeverity(browser, base) 
 // 点名的位置从判词挪到了「投递」泳道（kcn 2026-09-01：「我也不知道该怎么看」
 // ⇒ 判词只回答「页面上的数字能不能信」，一个任务没落地不改变这个答案）。
 // 断言跟着挪，但要求不变：**不展开就能读到是哪一档、发生了什么**。
+async function testAddSideCardExplainsWhyThereIsNoAdd(browser, base) {
+  // 47 天里 48 次收盘突破对 0 条加仓建议，而面板上没有任何地方能问「为什么」。
+  // 这张牌就是那个答案，它有三部分且三部分都是数字：证据族开机到哪了、今天的
+  // 读数是什么、每种入场形态历史上值多少。这里钉住的是最容易被做丢的那两样：
+  // 「没有候选的原因」必须显示出来（静默的零就是当初那 47 天），以及形态表必须
+  // 带基线行（命中 50% 在基线也是 50% 的地方毫无意义）。
+  const context = await browser.newContext({ viewport: { width: 1280, height: 900 } });
+  const page = await context.newPage();
+  await stubLiveOrigin(page, {
+    patch: (name, json) => {
+      if (name !== "overview.json" && name !== "dashboard.json") return null;
+      json.add_side = {
+        as_of: "2026-09-05", pending: false, cold_start: true,
+        counts: { candidate: 0, wait: 9, reject: 1 },
+        why_no_candidate: "3 只已收盘站上前 20 日高，但 z≥2 判为追高：ROBN z=2.96",
+        families: [
+          { name: "price_relative_factor", active: false,
+            progress: { counter: "prospective_dates", have: 8, need: 24 },
+            blockers: ["prospective_dates"] },
+          { name: "point_in_time_information", active: false,
+            progress: { counter: "history_dates", have: 16, need: 24 },
+            blockers: ["history_dates"] },
+        ],
+        rows: [{ ticker: "CRCL", verdict: "wait", why: "窗口内无一手公告",
+                 needs: "站上 96.4", prior_20d_high: 96.4, pct_from_high: -7.09 }],
+        shapes: {
+          names: 25, run_id: "add_shapes-20260905-deadbeef",
+          shapes: {
+            breakout: { t1: [93, .548, 1.44], t5: [93, .591, 3.77], t20: [84, .655, 20.06] },
+            pullback_in_uptrend: { t1: [436, .456, -.24], t5: [413, .455, .64], t20: [313, .383, 3.99] },
+          },
+          baseline: { t1: [3135, .506, .26], t5: [3035, .486, 1.13], t20: [2660, .501, 5.24] },
+        },
+        track_record: { cut: { hit_rate: .5258, win: 112, loss: 101, settled: 213 } },
+      };
+      return json;
+    },
+  });
+  const state = observe(page);
+  await page.goto(base, { waitUntil: "networkidle" });
+  await waitForData(page);
+  await page.click('.tab-btn[data-tab="plan"]');
+  await waitForTab(page, "plan");
+
+  const card = page.locator("#add-side-card");
+  await card.waitFor({ state: "visible" });
+  const text = await card.innerText();
+  assert.match(text, /没有候选的原因/,
+    "a silent zero add side is exactly the 47 days this card exists to end");
+  assert.match(text, /ROBN z=2\.96/, "the reason lost the names and numbers behind it");
+  assert.match(text, /基线 · 随便哪一天/,
+    "the shape table lost its baseline row — every hit rate now reads as better than it is");
+  assert.match(text, /冷启动/, "the cold-start state was not surfaced");
+  assert.match(text, /8\/24|16\/24/, "the family warm-up counters are not rendered");
+
+  const bars = await page.locator("#add-side-card .add-family-bar i").evaluateAll(
+    nodes => nodes.map(node => node.style.width));
+  assert(bars.length >= 2 && bars.every(width => /%$/.test(width)),
+    "the warm-up bars carry no width, so the progress is invisible");
+
+  assert.deepEqual(state.failures, []);
+  assert.deepEqual(state.errors, []);
+  await page.close();
+}
+
 async function testCronRailAccountsForEverySlotWithoutASecondVerdict(browser, base) {
   // #1270 拆开这块牌的判据是「某个任务挂了」和「页面上的数字不可信」不能共用
   // 一行判词。时刻表折进来时最容易犯的错就是给它再配一句判词 —— 于是同一件事
@@ -1395,6 +1460,7 @@ async function main() {
     await testHoldingsAndHeroNeverTruncate(browser, base);
     await testVerdictDeckFillsItsBoxAndRanksGatesBySeverity(browser, base);
     await testDataHealthNamesTheDegradedSlotAndWeChatDrops(browser, base);
+    await testAddSideCardExplainsWhyThereIsNoAdd(browser, base);
     await testCronRailAccountsForEverySlotWithoutASecondVerdict(browser, base);
     await testCronNeedsActionMergesIntoTheOneTodoListButWatchDoesNot(browser, base);
   } finally {

--- a/tests/test_dashboard_add_side_card.py
+++ b/tests/test_dashboard_add_side_card.py
@@ -1,0 +1,152 @@
+"""The dashboard has to be able to answer "why is there no add today".
+
+For 47 days the book produced sell-only advice and the dashboard showed it
+without any way to ask why. The answer was never missing — it was in three
+places nobody looked: the evidence families' activation counters, the add-side
+read in the brief context, and #856's shape study, which had no durable artifact
+at all until `evaluate-add-shapes` (#1341).
+
+This card projects all three. The assertions are about that word: every number
+is copied from the brief context or an `add_shapes` run card, because a second
+computation of the same quantity in the publish layer is how a dashboard and a
+brief end up telling kcn different things on the same morning.
+"""
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+from clawock.publish import dashboard
+
+ROOT = Path(__file__).resolve().parents[1]
+INDEX = (ROOT / "site" / "index.html").read_text(encoding="utf-8")
+RENDER = (ROOT / "site" / "assets" / "js" / "dashboard.render.js").read_text(encoding="utf-8")
+CSS = (ROOT / "site" / "assets" / "css" / "dashboard.css").read_text(encoding="utf-8")
+
+
+CONTEXT = {
+    "date": "2026-09-05",
+    "opportunity": {
+        "counts": {"candidate": 0, "wait": 9, "reject": 1},
+        "why_no_candidate": "3 只已收盘站上前 20 日高，但 z≥2 判为追高",
+        "policy": "技术突破…",
+        "rows": [
+            {"ticker": "CRCL", "verdict": "wait", "why": "窗口内无一手公告",
+             "needs": "站上 96.4", "evidence": {"prior_20d_high": 96.4,
+                                                "pct_from_high": -7.09}},
+            {"ticker": "SPCH", "verdict": "reject", "why": "纪律动作未了结",
+             "needs": "先把纪律动作走完", "evidence": {}},
+        ],
+    },
+    "add_alpha_activation": {
+        "cold_start": True,
+        "families": {
+            "price_relative_factor": {
+                "active": False,
+                "progress": {"prospective_dates": [8, 24],
+                             "membership_history": [False, True]},
+                "blockers": ["prospective_dates", "clustered_edge"]},
+            "point_in_time_information": {
+                "active": False, "progress": {"history_dates": [16, 24]},
+                "blockers": ["history_dates"]},
+        },
+    },
+    "action_track_record": {"by_action": {
+        "cut": {"win": 112, "loss": 101, "settled": 213, "hit_rate": 0.5258},
+        "hold_and_watch": {"win": 158, "loss": 216, "settled": 376, "hit_rate": 0.42},
+    }},
+}
+
+CARD = {
+    "run_id": "add_shapes-20260905-deadbeef",
+    "metrics": {
+        "names": 25,
+        "shapes": {
+            "breakout": {"t20": {"n": 84, "hit_rate": 0.655, "mean_pct": 20.06}},
+            "pullback_in_uptrend": {"t20": {"n": 313, "hit_rate": 0.383, "mean_pct": 3.99}},
+        },
+        "baseline": {"t20": {"n": 2660, "hit_rate": 0.501, "mean_pct": 5.24}},
+    },
+}
+
+
+@pytest.fixture()
+def projected(tmp_path, monkeypatch):
+    cards = tmp_path / "backtests"
+    cards.mkdir()
+    (cards / "add_shapes-20260905-deadbeef.json").write_text(json.dumps(CARD))
+    monkeypatch.setattr(dashboard, "_latest_brief_context",
+                        lambda: ("brief-context-2026-09-05.json", CONTEXT))
+    return dashboard.compute_add_side(shape_cards_dir=cards)
+
+
+def test_it_projects_the_brief_context_rather_than_recomputing_it(projected):
+    assert projected["counts"] == {"candidate": 0, "wait": 9, "reject": 1}
+    assert projected["why_no_candidate"] == CONTEXT["opportunity"]["why_no_candidate"], (
+        "the reason is the whole point of the card and must arrive verbatim")
+    assert projected["cold_start"] is True
+    assert projected["pending"] is False
+
+
+def test_a_family_carries_the_counter_it_is_waiting_on_and_never_a_flag(projected):
+    """`membership_history: [False, True]` is a pass/fail, not a countdown.
+
+    `isinstance(False, int)` is True, so a naive filter renders it as
+    "membership_history 0/1" — a progress bar for something that cannot progress.
+    """
+    factor = next(row for row in projected["families"]
+                  if row["name"] == "price_relative_factor")
+    assert factor["progress"] == {"counter": "prospective_dates", "have": 8, "need": 24}
+    assert factor["active"] is False
+
+
+def test_the_shape_study_comes_from_a_run_card_so_it_stays_re_derivable(projected):
+    study = projected["shapes"]
+    assert study["run_id"] == "add_shapes-20260905-deadbeef", (
+        "without the run id the numbers on the page cannot be traced to the run "
+        "that produced them — the exact failure #1341 exists to prevent")
+    assert study["shapes"]["breakout"]["t20"] == [84, 0.655, 20.06]
+    assert study["baseline"]["t20"] == [2660, 0.501, 5.24], (
+        "the baseline row is what makes every other row mean anything")
+
+
+def test_only_the_action_kinds_this_card_is_about_are_carried(projected):
+    """Payload budget: the card shows the add side, not the whole ledger."""
+    assert set(projected["track_record"]) <= {
+        "cut", "trim_on_rebound", "add_only_on_trigger"}
+    assert "hold_and_watch" not in projected["track_record"]
+
+
+def test_a_context_from_before_the_add_side_shipped_says_so(monkeypatch, tmp_path):
+    """An empty card that looks broken is worse than one that says "not yet"."""
+    monkeypatch.setattr(dashboard, "_latest_brief_context", lambda: (None, {"date": "2026-09-04"}))
+    projected = dashboard.compute_add_side(shape_cards_dir=tmp_path)
+
+    assert projected["pending"] is True
+    assert projected["counts"] == {}
+
+
+def test_the_projection_stays_small_enough_for_the_payload(projected):
+    """186KB of a 200KB cap was already spent when this card was added."""
+    size = len(json.dumps(projected, ensure_ascii=False).encode("utf-8"))
+    assert size < 4000, f"the add-side projection grew to {size} bytes"
+
+
+def test_the_card_is_wired_from_markup_to_renderer_to_stylesheet():
+    assert 'id="add-side-card"' in INDEX and 'id="add-side-body"' in INDEX
+    assert re.search(r"plan:\s*\[\s*renderAddSide", RENDER), (
+        "the renderer exists but the plan tab never calls it")
+    assert '.add-family-bar' in CSS and '.add-baseline' in CSS
+
+
+def test_the_card_never_computes_the_numbers_it_shows():
+    """A browser-side recomputation is a second answer to the same question."""
+    body = RENDER[RENDER.index("function renderAddSide"):
+                  RENDER.index("function renderWatchLevels")]
+    for forbidden in ("prior_20d_high >", "Math.max(", "reduce("):
+        assert forbidden not in body, (
+            f"renderAddSide grew its own arithmetic ({forbidden}); the numbers "
+            "belong to the brief context and the run card")


### PR DESCRIPTION
kcn: 「如果这些可以可视化就都做进去dashboard」.

## What it shows

A card at the top of the **Plan** tab, next to 今日触发位:

- **counts + the reason** — candidate / wait / reject, and when there is no candidate, which of the three reasons it was. *「3 只已收盘站上前 20 日高，但 z≥2 判为追高：ROBN z=2.96、HOOD z=2.82、CRCL z=2.01」*. A silent zero is what made 47 days of advice read as sell-only.
- **the warm-up bars** — which evidence family is up, what it waits on, how far: `prospective_dates 8/24`, `history_dates 16/24`. "Any two families" behaves as "a breakout is mandatory" while two of the three cannot fire, and that state had no surface anywhere.
- **the shape table with its baseline row** — what each entry shape has been worth at T+1/5/20 against a random session in the same names. Breakout 65.5% at T+20 is a finding *only* because the baseline is 50.1%; the row that makes that visible is asserted to exist.
- **the track record line** — `cut` 52.6% (112胜/101负, n=213), next to the advice it qualifies.

## Projected, never recomputed

`compute_add_side` copies from the brief context (`opportunity`, `add_alpha_activation`, `action_track_record` — #1337/#1340) and from the newest `add_shapes` run card (#1341), which is also why the card can print the `run_id`: the numbers on the page trace back to the run that produced them. A test asserts `renderAddSide` contains no arithmetic of its own — a second computation of the same quantity in the publish layer is how a dashboard and a brief end up disagreeing on the same morning.

746 bytes against ~9KB of headroom under the 200KB payload cap (the file was at 186.5KB).

## Gates

- `tests/test_dashboard_add_side_card.py` — projection fidelity; the family progress carries a *counter* and never a pass/fail flag (`isinstance(False, int)` is True, so a naive filter renders "membership_history 0/1", a progress bar for something that cannot progress); the run id survives; the baseline is carried; a pre-#1337 context says `pending` instead of looking broken; the size stays under 4KB; the card is wired markup → renderer → stylesheet.
- `tests/dashboard_tab_runtime.spec.js` — a real browser opens the Plan tab and asserts the reason keeps its names and numbers, the baseline row is present, the cold-start chip renders, the counters appear, and the warm-up bars have a width. Render proof belongs in CI, not on this host.

**Today it will render the shape table and a `pending` note**: the `opportunity` blocks first appear in tomorrow's 08:00 brief context, since the ones on disk predate #1337.

https://claude.ai/code/session_01RnEpMv8MLR9cHv6H3TCDKc