### PR TITLE
system-check: say when a delivery leg is rotting behind a working fallback

### DIFF
--- a/ops/system_check.py
+++ b/ops/system_check.py
@@ -1067,6 +1067,97 @@ def check_model_chain_health(r):
                                  f'{RUN_SCAN_LIMIT} runs')
 
 
+DELIVERY_DEGRADED_FAILURE_RATE = 0.20
+DELIVERY_HEALTHY_SUCCESS_RATE = 0.95
+
+
+def check_delivery_channel_health(r):
+    """A delivery leg that is quietly rotting, told apart from one bad slot.
+
+    Sibling of :func:`check_model_chain_health`, for the other chain. Every
+    report co-sends to WeChat and Telegram and the slot counts as delivered if
+    either lands, which is the right design — WeChat cannot confirm a cold-session
+    drop, so gating on it would suppress real reports. The cost of that design is
+    that **one leg can fail a third of the time and nothing says so**: the
+    postflight prints a warning to stderr, the watchdog correctly stays quiet
+    because Telegram carried the slot, and no gate or view ever adds the failures
+    up. Measured 2026-09-06 over the ledger's own four-day window: Telegram
+    98/100, WeChat 67/100, and WeChat trending 84% -> 76% -> 68% across three
+    consecutive days without a single alert anywhere.
+
+    Two different things get reported, because they need different answers:
+
+    * a slot where **every** channel failed is a report that did not reach a
+      human, and the watchdog's re-send is the only thing that saved it;
+    * a channel far below its sibling is a leg degrading behind a working
+      fallback — nothing is lost today, and that is exactly why it goes unseen.
+
+    Channels are enumerated from the `*_ok` fields the ledger actually carries
+    rather than from a hardcoded pair, so a third channel is covered the day it
+    starts writing its result (the same reason the packaging and argparse gates
+    read their real source instead of a list someone has to remember to
+    update).
+
+    WARNING, never CRITICAL: a push is not the thing to block over a delivery
+    statistic, and `check_model_chain_health` set that precedent for the chain
+    next door.
+    """
+    try:
+        sys.path.insert(0, str(_REPO_ROOT / 'src'))
+        from clawock.automation import workflow_outcomes  # noqa: PLC0415
+        ledger = json.loads(workflow_outcomes.public_path().read_text(encoding='utf-8'))
+    except Exception:
+        return  # no ledger on this host yet
+    records = ledger.get('records') or []
+
+    slots = []
+    for rec in records:
+        delivery = ((rec.get('stages') or {}).get('primary_delivery') or {})
+        channels = {k[:-3]: bool(v) for k, v in delivery.items()
+                    if k.endswith('_ok') and isinstance(v, bool)}
+        if channels:
+            slots.append((rec.get('slot') or '', channels))
+    if not slots:
+        return
+    slots.sort(key=lambda s: s[0])
+    slots = slots[-RUN_SCAN_LIMIT:]
+
+    names = sorted({name for _, ch in slots for name in ch})
+    totals = {n: [0, 0] for n in names}  # name -> [ok, seen]
+    silent = []
+    for slot, ch in slots:
+        for name, ok in ch.items():
+            totals[name][1] += 1
+            totals[name][0] += 1 if ok else 0
+        if ch and not any(ch.values()):
+            silent.append(slot)
+
+    def rate(name):
+        ok, seen = totals[name]
+        return ok / seen if seen else 1.0
+
+    tally = ' · '.join(f'{n} {totals[n][0]}/{totals[n][1]}' for n in names)
+    if silent:
+        shown = ', '.join(silent[-4:])
+        r.add('delivery channels', WARNING,
+              f'{len(silent)} slot(s) where every channel failed — only the '
+              f'watchdog re-send stood between these and a missed report: {shown} '
+              f'({tally} over the last {len(slots)} slots)')
+        return
+    healthy = [n for n in names if rate(n) >= DELIVERY_HEALTHY_SUCCESS_RATE]
+    rotting = [n for n in names
+               if (1 - rate(n)) >= DELIVERY_DEGRADED_FAILURE_RATE and n not in healthy]
+    if rotting and healthy:
+        named = '; '.join(f'{n} {rate(n) * 100:.0f}%' for n in rotting)
+        r.add('delivery channels', WARNING,
+              f'{named} while {"/".join(healthy)} carries every slot — nothing is '
+              f'lost today, which is why this leg can rot unnoticed '
+              f'({tally} over the last {len(slots)} slots)')
+    else:
+        r.add('delivery channels', OK,
+              f'{tally} over the last {len(slots)} slots')
+
+
 def check_host_cron_logs(r):
     """A host cron job whose log ends in a crash has been failing unnoticed.
 
@@ -1553,6 +1644,7 @@ def main():
         check_delivered_but_unarchived,
         check_fallback_chain_shape,
         check_model_chain_health,
+        check_delivery_channel_health,
         check_generated_cron_docs,
         check_research_artifacts,
         check_trading_calendar_horizon,

--- a/tests/test_system_check_delivery_channels.py
+++ b/tests/test_system_check_delivery_channels.py
@@ -1,0 +1,116 @@
+"""A delivery leg can rot for days behind a working fallback (2026-09-06).
+
+Every report co-sends to WeChat and Telegram and the slot counts as delivered
+if either lands. That is the right design — WeChat cannot confirm a
+cold-session drop, so gating on it would suppress real reports. The cost is
+that **one leg can fail a third of the time and nothing says so**: postflight
+prints to stderr, the watchdog correctly stays quiet because Telegram carried
+the slot, and no gate or view ever adds the failures up.
+
+Measured over the ledger's own four-day window on 2026-09-06: Telegram 98/100,
+WeChat 67/100, WeChat trending 84% -> 76% -> 68% across three consecutive days,
+zero alerts anywhere. Finding that took an ad-hoc script; that is the bug.
+
+The check must NOT be a fix for the delivery mechanism (re-send, keepalive and
+channel-switch have each been declined). It only makes the trend legible.
+
+Channels are enumerated from the `*_ok` fields the ledger carries, so this stays
+true when a third channel appears — a hardcoded (wechat, telegram) pair would
+report a healthy system the day someone adds one.
+"""
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+@pytest.fixture(scope="module")
+def system_check():
+    for path in (ROOT, ROOT / "src"):
+        if str(path) not in sys.path:
+            sys.path.insert(0, str(path))
+    spec = importlib.util.spec_from_file_location(
+        "kcnyu_system_check_delivery", ROOT / "ops" / "system_check.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _ledger(tmp_path, slots):
+    """Write a workflow-outcomes ledger holding exactly `slots`."""
+    out = tmp_path / "assets" / "data"
+    out.mkdir(parents=True, exist_ok=True)
+    records = [
+        {"job": "港股开盘报告", "slot": f"2026-09-0{1 + i // 8}T{9 + i % 8:02d}:30:00+08:00",
+         "stages": {"primary_delivery": {"status": "success", **channels}}}
+        for i, channels in enumerate(slots)
+    ]
+    (out / "workflow-outcomes.json").write_text(
+        json.dumps({"schema_version": 1, "records": records}), encoding="utf-8")
+    return tmp_path
+
+
+def _run(system_check, monkeypatch, tmp_path, slots):
+    _ledger(tmp_path, slots)
+    monkeypatch.setenv("CLAWOCK_WORKSPACE", str(tmp_path))
+    r = system_check.Result()
+    system_check.check_delivery_channel_health(r)
+    return [row for row in r.checks if row[0] == "delivery channels"]
+
+
+def test_a_leg_failing_a_third_of_the_time_is_reported(
+        system_check, monkeypatch, tmp_path):
+    """The 2026-09-06 shape: Telegram perfect, WeChat two thirds."""
+    slots = [{"wechat_ok": i % 3 != 0, "telegram_ok": True} for i in range(30)]
+    rows = _run(system_check, monkeypatch, tmp_path, slots)
+    assert rows, "a leg at 67% next to one at 100% must produce a row"
+    _, status, detail = rows[0]
+    assert status == system_check.WARNING, (
+        "WARNING, not CRITICAL: a delivery statistic is not a reason to block a "
+        "push, and check_model_chain_health set that precedent")
+    assert "wechat" in detail
+    assert "telegram" in detail, "say which leg is carrying it, not only which is rotting"
+
+
+def test_two_healthy_legs_do_not_warn(system_check, monkeypatch, tmp_path):
+    slots = [{"wechat_ok": True, "telegram_ok": True} for _ in range(30)]
+    rows = _run(system_check, monkeypatch, tmp_path, slots)
+    assert rows and rows[0][1] == system_check.OK
+    assert "30/30" in rows[0][2], "the healthy row still has to carry the numbers"
+
+
+def test_a_slot_nobody_received_outranks_a_degrading_leg(
+        system_check, monkeypatch, tmp_path):
+    """Every channel false = the report reached no human that slot."""
+    slots = [{"wechat_ok": i % 3 != 0, "telegram_ok": True} for i in range(29)]
+    slots.append({"wechat_ok": False, "telegram_ok": False})
+    rows = _run(system_check, monkeypatch, tmp_path, slots)
+    assert rows and rows[0][1] == system_check.WARNING
+    assert "every channel failed" in rows[0][2], (
+        "a slot with no delivery at all must not be summarised as a percentage — "
+        "it is a different failure from a leg that is merely degrading")
+
+
+def test_channels_come_from_the_ledger_not_from_a_hardcoded_pair(
+        system_check, monkeypatch, tmp_path):
+    """A third channel must be covered the day it starts writing its result."""
+    slots = [{"wechat_ok": True, "telegram_ok": True, "signal_ok": i % 4 != 0}
+             for i in range(32)]
+    rows = _run(system_check, monkeypatch, tmp_path, slots)
+    assert rows, "a new channel at 75% must be visible without touching this gate"
+    assert "signal" in rows[0][2], (
+        "the channel set is enumerated from the *_ok fields; hardcoding "
+        "(wechat, telegram) would report this ledger as healthy")
+
+
+def test_a_ledger_that_is_not_there_is_silent(system_check, monkeypatch, tmp_path):
+    """Not every host publishes reports; absence is not a finding."""
+    monkeypatch.setenv("CLAWOCK_WORKSPACE", str(tmp_path))
+    r = system_check.Result()
+    system_check.check_delivery_channel_health(r)
+    assert not [row for row in r.checks if row[0] == "delivery channels"]


### PR DESCRIPTION
## What

A new `delivery channels` check in `ops/system_check.py`, sibling to
`check_model_chain_health` — same shape, the other chain.

## Why

Every report co-sends to WeChat and Telegram and the slot counts as delivered if
either lands. That design is right: WeChat cannot confirm a cold-session drop, so
gating on it would suppress real reports. **Its cost is that one leg can fail a
third of the time and nothing says so** — postflight prints to stderr, the watchdog
correctly stays quiet because Telegram carried the slot, and no gate or view ever
adds the failures up.

Measured 2026-09-06 from `assets/data/workflow-outcomes.json`
(`stages.primary_delivery`, 100 records over the ledger's four-day window):

| 日期 | 槽数 | wechat_ok | telegram_ok |
|---|---:|---:|---:|
| 09-01 | 18 | 5 (28%) | 16 (89%) |
| 09-02 | 25 | 21 (84%) | 25 (100%) |
| 09-03 | 25 | 19 (76%) | 25 (100%) |
| 09-04 | 25 | 17 (68%) | 25 (100%) |
| 09-05 | 7 | 5 (71%) | 7 (100%) |

Telegram 98/100, WeChat 67/100, WeChat trending **84% → 76% → 68%** across three
consecutive days — and finding that took an ad-hoc script. That is the gap.

Failures are all `OutboundDeliveryError: sendMessage ret=-2 errmsg=prepare failed`.
Token expiry does not explain them: the account's `context-tokens.json` was
rewritten 09-04 21:44 and the 09-05 04:05 send still failed.

**This does not touch the delivery mechanism.** Re-sending, keepalive and switching
channels have each been declined before; what is being closed is that the trend was
invisible, not that the fallback is wrong.

## On live data

```
⚠ WARN  delivery channels: wechat 68% while telegram carries every slot —
        nothing is lost today, which is why this leg can rot unnoticed
        (telegram 40/40 · wechat 27/40 over the last 40 slots)
```

## Design notes

- **Two failures, two answers.** A slot where *every* channel failed is a report
  that reached no human and only the watchdog's re-send saved it; that is reported
  by name, not folded into a percentage. A channel far below its sibling is a leg
  degrading behind a working fallback.
- **Channels are enumerated from the ledger**, from whatever `*_ok` fields it
  carries — not a hardcoded `(wechat, telegram)` pair — so a third channel is
  covered the day it starts writing its result.
- **WARNING, never CRITICAL.** A delivery statistic is not a reason to block a
  push; `check_model_chain_health` set that precedent for the chain next door.
- A host with no ledger stays silent.

## Tests

`tests/test_system_check_delivery_channels.py`, 5 cases. Mutation-tested both ways:

| 变异 | 结果 |
|---|---|
| channel 集合写死成 `(wechat, telegram)` | `test_channels_come_from_the_ledger_not_from_a_hardcoded_pair` 红 |
| 删掉「全通道失败」分支 | `test_a_slot_nobody_received_outranks_a_degrading_leg` 红 |

https://claude.ai/code/session_01HBSt6geARRtj3ypRnFXBZ1