### PR TITLE
Two signals that never reached the reader who needed them (#1349, #1350)

### DIFF
--- a/site/decimap/index.html
+++ b/site/decimap/index.html
@@ -285,7 +285,8 @@ permalink: /decimap/
   </div>
 
   <div class="dm-scrim" id="dm-scrim" hidden></div>
-  <aside class="dm-drawer" id="dm-drawer" aria-hidden="true" aria-label="决策详情">
+  <aside class="dm-drawer" id="dm-drawer" role="dialog" aria-modal="true"
+         aria-hidden="true" aria-label="决策详情">
     <button class="dm-close" type="button" id="dm-close" aria-label="关闭">&times;</button>
     <div id="dm-drawer-body"></div>
   </aside>
@@ -570,11 +571,40 @@ permalink: /decimap/
       || '<p class="dm-sub" style="padding:10px 12px">没有匹配的票。</p>';
   }
 
+  // The drawer is modal: a scrim covers the page and Escape closes it. Until
+  // #1350 that was true for the mouse only — nothing stopped Tab from walking
+  // straight out of the drawer into the board behind the scrim, and closing
+  // dropped focus on <body>, so a keyboard reader lost their place in a 741-row
+  // table and had to start over.
+  //
+  // `inert` on the siblings is how the main dashboard already does this
+  // (dashboard.hero.js:1510, dashboard.render.js:2821): it removes the
+  // background from the tab order and from the accessibility tree in one
+  // attribute, so the trap needs no keydown handler of its own to maintain.
+  // The drawer and its scrim are children of #decimap too, so they are skipped
+  // by identity rather than by making the whole container inert.
+  let drawerReturnFocus = null;
+
+  function setBackgroundInert(on) {
+    const root = el('decimap');
+    const drawer = el('dm-drawer');
+    const scrim = el('dm-scrim');
+    if (!root) return;
+    for (const child of root.children) {
+      if (child === drawer || child === scrim) continue;
+      child.inert = on;
+    }
+  }
+
   function showDrawer(html) {
+    // Captured before focus moves, so closing can put the reader back on the
+    // cell or timeline marker they opened — not on <body>.
+    drawerReturnFocus = document.activeElement;
     el('dm-drawer-body').innerHTML = html;
     el('dm-drawer').classList.add('is-open');
     el('dm-drawer').setAttribute('aria-hidden', 'false');
     el('dm-scrim').hidden = false;
+    setBackgroundInert(true);
     el('dm-close').focus();
   }
 
@@ -673,6 +703,12 @@ permalink: /decimap/
     el('dm-drawer').classList.remove('is-open');
     el('dm-drawer').setAttribute('aria-hidden', 'true');
     el('dm-scrim').hidden = true;
+    setBackgroundInert(false);
+    // Lift inert before restoring focus: focus() on an inert element is a no-op.
+    if (drawerReturnFocus && document.contains(drawerReturnFocus)) {
+      drawerReturnFocus.focus();
+    }
+    drawerReturnFocus = null;
   }
 
   function renderAll() { renderKpi(); renderBoard(); renderTimeline(); }

--- a/src/clawock/decision/packet.py
+++ b/src/clawock/decision/packet.py
@@ -17,6 +17,7 @@ import json
 import math
 import os
 import re
+import sys
 from pathlib import Path
 
 from clawock.decision.actions import ACTIVE_ACTIONS
@@ -42,6 +43,9 @@ MAX_QUERY_BYTES = 24 * 1024
 # crossing from being a surprise.
 MAX_SUMMARY_BYTES = 48 * 1024
 SUMMARY_BUDGET_WARN_RATIO = 0.8
+#: The packet ceiling needs the same early word as the summary's; see
+#: the note at the raise in `compile_packet` for why it was missing.
+PACKET_BUDGET_WARN_RATIO = 0.8
 ADD_ALPHA_POLICY = workspace_root() / "config" / "add-alpha-policy.json"
 VERDICTS = {"bullish", "neutral", "bearish", "mixed"}
 DISPOSITIONS = {"candidate", "wait", "reject"}
@@ -283,6 +287,51 @@ def _apply_setup_usage(technical: dict, usage: dict) -> dict:
         setup["remaining_tranches"] = max(0, maximum - used)
         setup["next_tranche_number"] = used + 1 if used < maximum else None
     return technical
+
+
+def _history_view(context: dict, ticker: str) -> dict:
+    """How this ticker's own past calls turned out, as the writer can see it.
+
+    `compute_reflections` settles every episode for a held ticker into a win
+    rate, a per-bucket tally (`加×1 胜0; 持×15 胜9`) and the last three calls
+    with their realised benefit. It has run every morning since the reflections
+    step existed — and it went nowhere a decision could read it. SKILL.md
+    Step 2 makes the packet summary the model's *only standing input*
+    ("bundle 是审计深钻，不是默认模型输入"), and the packet carried no per-ticker
+    outcome history at all: the process writing today's call on CRCL could not
+    see that the last 17 calls on CRCL won 59%, and that the one time it added,
+    it lost.
+
+    That is the shape #1337 fixed for the add side — a signal that exists,
+    is even visible on the dashboard, and has no path into the process that
+    writes decisions.
+
+    The last three calls (`recent`) are deliberately NOT projected either, and
+    the reason is a measurement: the packet baseline is 94,071 of 98,304 bytes,
+    so the whole block has ~4.2KB to live in. Carrying `recent` cost 3,868 and
+    landed 295 bytes under a cap whose overrun is a hard `ValueError` — one more
+    holding and the morning brief gets no packet at all, which is the 2026-08-17
+    failure verbatim. The three tallies below cost 936 bytes for the same
+    decision: what the model needs at write time is "how have my calls on this
+    name gone, and in which buckets", and the blow-by-blow is audit depth, which
+    is what the bundle is for.
+
+    `lesson` is deliberately NOT projected. It is a pre-written sentence
+    ("主动 call 多半没跑赢持有，本次谨慎") and this module's contract is that code
+    owns facts and the model owns the opinion overlay. Handing the model a
+    finished conclusion is the one thing the packet boundary exists to prevent;
+    the numbers it was derived from are all here.
+    """
+    row = (context.get("reflections") or {}).get(ticker) or {}
+    if not row:
+        # Emitted even when empty: "this ticker has no settled episodes yet" and
+        # "history was never wired in" must not look the same to a reader.
+        return {"settled_episodes": 0}
+    return {
+        "settled_episodes": row.get("n"),
+        "win_rate": row.get("win_rate"),
+        "by_action": row.get("bucket_history"),
+    }
 
 
 def _thesis_view(context: dict, ticker: str) -> dict:
@@ -1089,6 +1138,7 @@ def compile_packet(context: dict, generation_id: str | None = None) -> dict:
                 },
             },
             "sentiment": _sentiment_view(sentiment_rows, ticker, source_ticker),
+            "history": _history_view(context, ticker),
             "information": information_view,
             "evidence": matching_events,
             "risk": ticker_risks,
@@ -1295,6 +1345,24 @@ def compile_packet(context: dict, generation_id: str | None = None) -> dict:
     size = len(_compact(packet).encode("utf-8"))
     if size > MAX_PACKET_BYTES:
         raise ValueError(f"decision packet exceeds {MAX_PACKET_BYTES} bytes: {size}")
+    if size > MAX_PACKET_BYTES * PACKET_BUDGET_WARN_RATIO:
+        # 2026-08-17 taught this about the *summary* budget: "Nothing warned on
+        # the way past the line, because the trigger was portfolio growth, not a
+        # code change." `SUMMARY_BUDGET_WARN_RATIO` was the answer — and the
+        # packet's own ceiling never got one, so the lesson stopped at the
+        # smaller of the two numbers.
+        #
+        # Measured 2026-09-06 while adding `history`: the packet was already at
+        # 94,071 of 98,304 bytes (95.7%), i.e. past where the summary's warning
+        # would have fired, with nothing anywhere saying so. Overrunning it is a
+        # hard ValueError in preflight, which is the morning brief getting no
+        # packet at all — so the warning has to arrive while there is still room
+        # to act, not at the wall.
+        print(f"warn: decision packet at {size} bytes is "
+              f"{size / MAX_PACKET_BYTES:.1%} of the {MAX_PACKET_BYTES}-byte "
+              f"ceiling ({len(tickers)} tickers) — overrunning it fails preflight "
+              f"outright, so trim a projection before the next holding lands",
+              file=sys.stderr)
     return packet
 
 
@@ -1384,6 +1452,10 @@ def summary_view(packet: dict) -> dict:
                     .get("usable_for_decisions"),
                 },
                 "early_trend": ((row.get("quant") or {}).get("early_trend") or {}),
+                # The summary — not the full packet — is what SKILL.md Step 2
+                # calls the model's 唯一常驻输入, so a field added to
+                # `compile_packet` and not to this projection reaches nobody.
+                "history": row.get("history"),
                 "risk_count": len(row.get("risk") or []),
                 "constraints": row.get("constraints"),
             }

--- a/tests/decimap_board.spec.js
+++ b/tests/decimap_board.spec.js
@@ -155,6 +155,53 @@ async function aCellOpensTheDecisionsItCounts(browser, base) {
   await context.close();
 }
 
+async function theDrawerTrapsFocusAndGivesItBack(browser, base) {
+  /* The drawer is modal for the mouse — scrim, Escape — and until #1350 it was
+     not modal for the keyboard: Tab walked straight out of it into the board
+     behind the scrim, and closing dropped focus on <body>, so a reader lost
+     their place in a 741-row table.
+
+     Behavioural on purpose. `inert` is the mechanism, but asserting the
+     attribute would pass on a page where the drawer never opens; what has to
+     hold is that the tabbing reader cannot leave and gets their cell back. */
+  const { context, page } = await open(browser, base, 1280);
+  await page.evaluate(() => document.querySelector("#dm-board .dm-cell").focus());
+  const opener = await page.evaluate(() => {
+    const cell = document.querySelector("#dm-board .dm-cell");
+    cell.click();
+    return cell.textContent.trim();
+  });
+  await page.waitForSelector(".dm-drawer.is-open");
+
+  const outside = await page.evaluate(() =>
+    [...document.getElementById("decimap").children]
+      .filter(el => el.id !== "dm-drawer" && el.id !== "dm-scrim" && !el.inert)
+      .map(el => el.id || el.tagName));
+  assert.deepEqual(outside, [],
+    `these siblings stayed reachable behind the open drawer: ${outside.join(", ")}`);
+
+  for (let i = 0; i < 12; i++) await page.keyboard.press("Tab");
+  const stillInside = await page.evaluate(() =>
+    document.getElementById("dm-drawer").contains(document.activeElement));
+  assert(stillInside, "12 tabs walked focus out of the open drawer");
+
+  await page.keyboard.press("Escape");
+  await page.waitForTimeout(80);
+  const back = await page.evaluate(() => ({
+    id: document.activeElement && document.activeElement.id,
+    tag: document.activeElement && document.activeElement.tagName,
+    text: document.activeElement && document.activeElement.textContent.trim(),
+    inertLeft: [...document.getElementById("decimap").children].filter(el => el.inert).length,
+  }));
+  assert.equal(back.inertLeft, 0, "closing the drawer left the page inert");
+  assert.notEqual(back.tag, "BODY",
+    "closing the drawer dropped focus on <body> instead of the cell that opened it");
+  assert.equal(back.text, opener,
+    `focus came back to ${back.tag}#${back.id}, not the cell that opened the drawer`);
+  await context.close();
+}
+
+
 async function thePageNeverScrollsSidewaysButTheBoardDoes(browser, base) {
   for (const width of [320, 390, 1280]) {
     const { context, page } = await open(browser, base, width);
@@ -257,6 +304,7 @@ async function main() {
     await theBoardIsATreeOverThePublishedRollUps(browser, base, payload);
     await noCellUsesColourAsItsOnlyChannel(browser, base);
     await aCellOpensTheDecisionsItCounts(browser, base);
+    await theDrawerTrapsFocusAndGivesItBack(browser, base);
     await thePageNeverScrollsSidewaysButTheBoardDoes(browser, base);
     await theKpiStripPrintsWhatThePayloadHolds(browser, base, payload);
     await theCaveatReportsWhatSurvivedItsPlacebo(browser, payload, html);

--- a/tests/test_packet_ticker_history.py
+++ b/tests/test_packet_ticker_history.py
@@ -1,0 +1,129 @@
+"""What this ticker's own past calls did, where the writer can read it (#1349).
+
+`compute_reflections` has settled every episode for every held ticker each
+morning — win rate, a per-bucket tally (`加×1 胜0; 持×15 胜9`), the last calls
+and their realised benefit — and it went nowhere a decision could reach it.
+SKILL.md Step 2 makes the packet summary the model's 唯一常驻输入; the packet
+carried no per-ticker outcome history at all, so the process writing today's
+call on CRCL could not see that its last 17 calls on CRCL won 59% and that the
+one time it added, it lost.
+
+Same shape as #1337: a signal that exists, is even on the dashboard, and has no
+path into the process that writes decisions.
+
+Two of these tests exist because of mistakes made while writing the fix:
+
+* `summary_view` is a hand-written per-field projection. A field added to
+  `compile_packet` and not to it reaches nobody — the first version of this
+  change did exactly that and looked complete.
+* the packet was already at 95.7% of its hard ceiling with nothing warning,
+  because the 2026-08-17 budget lesson had been applied to `MAX_SUMMARY_BYTES`
+  and not to `MAX_PACKET_BYTES`.
+"""
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+from clawock.decision import packet as packet_mod
+
+from test_brief_decision_packet import _context
+
+
+REFLECTION = {
+    "n": 17,
+    "win_rate": 0.59,
+    "bucket_history": "加×1 胜0; 持×15 胜9; watch×1 胜1",
+    "recent": [{"date": "2026-09-01", "action": "hold_and_watch", "conf": 0.6,
+                "outcome": "win", "benefit_pct": 2.2252}],
+    "lesson": "LEVX: 过去 17 个策略 episode 胜率 59%（主动 call 多半没跑赢持有，本次谨慎）",
+}
+
+
+def _with_reflections(rows):
+    ctx = copy.deepcopy(_context())
+    ctx["reflections"] = rows
+    return packet_mod.compile_packet(ctx, generation_id="test")
+
+
+def _held(packet):
+    return next(iter(packet["tickers"]))
+
+
+def test_the_writer_can_see_how_its_past_calls_on_this_ticker_went():
+    packet = _with_reflections({"LEVX": REFLECTION})
+    history = packet["tickers"]["LEVX"]["history"]
+    assert history["settled_episodes"] == 17
+    assert history["win_rate"] == 0.59
+    assert history["by_action"] == "加×1 胜0; 持×15 胜9; watch×1 胜1", (
+        "the per-bucket tally is the part that answers 'what happened the times "
+        "I added', which a single win rate cannot")
+
+
+def test_history_reaches_the_summary_because_that_is_the_standing_input():
+    """The regression that would make this whole change a no-op.
+
+    `summary_view` names its per-ticker fields one by one. Wiring `history` into
+    `compile_packet` alone leaves the model reading a summary without it.
+    """
+    packet = _with_reflections({"LEVX": REFLECTION})
+    summary = packet_mod.summary_view(packet)
+    rows = {row["ticker"]: row for row in summary["tickers"]}
+    assert rows["LEVX"].get("history"), (
+        "history is in the packet but not in summary_view — SKILL.md Step 2 calls "
+        "the summary the model's 唯一常驻输入, so this reaches nobody")
+    assert rows["LEVX"]["history"]["win_rate"] == 0.59
+
+
+def test_the_pre_written_lesson_stays_out_of_the_model_facing_packet():
+    """Code owns facts; the model owns the opinion overlay.
+
+    `reflections[tk]['lesson']` is a finished sentence telling the reader what to
+    conclude ("主动 call 多半没跑赢持有，本次谨慎"). Handing that to the model is the
+    one thing this boundary exists to prevent — the numbers it came from are all
+    projected, the conclusion is not.
+    """
+    packet = _with_reflections({"LEVX": REFLECTION})
+    blob = json.dumps(packet, ensure_ascii=False)
+    assert "本次谨慎" not in blob
+    assert "lesson" not in packet["tickers"]["LEVX"]["history"]
+
+
+def test_no_settled_history_is_stated_rather_than_omitted():
+    """"Nothing to say yet" and "never wired in" must not look the same."""
+    packet = _with_reflections({})
+    history = packet["tickers"][_held(packet)]["history"]
+    assert history == {"settled_episodes": 0}
+
+
+def test_the_packet_ceiling_warns_before_the_wall_like_the_summary_does(capsys):
+    """#1349's own finding: the 2026-08-17 lesson stopped at the smaller budget.
+
+    Overrunning `MAX_PACKET_BYTES` raises, and that raise is preflight failing —
+    the morning brief with no packet at all. A warning that only arrives at the
+    wall is the failure the summary already learned to precede.
+    """
+    assert packet_mod.PACKET_BUDGET_WARN_RATIO < 1.0
+    ctx = copy.deepcopy(_context())
+    real = packet_mod.MAX_PACKET_BYTES
+    try:
+        packet_mod.MAX_PACKET_BYTES = int(
+            len(packet_mod._compact(packet_mod.compile_packet(ctx, generation_id="t"))
+                .encode("utf-8")) / 0.9)
+        packet_mod.compile_packet(ctx, generation_id="t")
+    finally:
+        packet_mod.MAX_PACKET_BYTES = real
+    err = capsys.readouterr().err
+    assert "of the" in err and "ceiling" in err, (
+        f"a packet at 90% of its ceiling said nothing: {err!r}")
+
+
+def test_the_warning_stays_quiet_with_room_to_spare(capsys):
+    ctx = copy.deepcopy(_context())
+    packet_mod.compile_packet(ctx, generation_id="t")
+    assert "ceiling" not in capsys.readouterr().err


### PR DESCRIPTION
Closes #1349, closes #1350.

Two unrelated fixes, one shape: something the system already computed had no path
to the reader who needed it.

## #1349 — per-ticker outcome history into the decision packet

`compute_reflections` settles every episode for every held ticker each morning —
win rate, a per-bucket tally (`加×1 胜0; 持×15 胜9`), the last calls and their
realised benefit. It went nowhere a decision could reach it. SKILL.md Step 2 makes
the packet summary the model's 唯一常驻输入 ("bundle 是审计深钻，不是默认模型输入"),
and the packet carried no per-ticker outcome history at all:

```
packet CRCL 每票字段: constraints evidence execution facts information leg name
                     quant risk sentiment status technical thesis ticker
```

So the process writing today's call on CRCL could not see that its last 17 calls
on CRCL won 59%, and that the one time it added, it lost. Same shape as #1337.

Now:

```json
"history": {"settled_episodes": 17, "win_rate": 0.59,
            "by_action": "加×1 胜0; 持×15 胜9; watch×1 胜1"}
```

**Three deliberate omissions, each a test:**

| 决定 | 为什么 |
|---|---|
| 也写进 `summary_view` | 它是逐字段手写的投影。**第一版只改了 `compile_packet`，看着完整但谁也读不到** |
| 不带 `recent` | packet 基线 94,071/98,304；带上最近三笔要 3,868 字节，**落点距硬上限只剩 295**。三个统计量 810 字节回答同一个问题 |
| 不带 `lesson` | 它是一句写好的结论（「主动 call 多半没跑赢持有，本次谨慎」）。本模块的契约是 code owns facts, the model owns the opinion overlay |

**顺带发现的真问题**：packet 当时已经在 **95.7%** 的天花板上，而**没有任何预警**。
2026-08-17 那次事故教的正是这件事——但只教给了 *summary* 预算
（`SUMMARY_BUDGET_WARN_RATIO`），packet 自己的上限从来没配过。现在配了，同样 0.8。
线上今天就会响：

```
warn: decision packet at 96406 bytes is 98.1% of the 98304-byte ceiling (10 tickers)
      — overrunning it fails preflight outright, so trim a projection before the
      next holding lands
```

给下一个来削的人的地图（十票合计）：`information` 22.8K / `quant` 18.3K /
`add_alpha_diagnostics` 12.3K / `evidence` 8.5K；`history` 是 810。

## #1350 — decimap 抽屉对键盘也是模态的

抽屉有遮罩、Esc 能关，对鼠标是模态的；对键盘不是：`showDrawer` 把焦点移到关闭按钮
就撒手，Tab 直接走进遮罩后面那张 741 行的板；`closeDrawer` 把焦点丢在 `<body>` 上，
读者打开一个格子之后就失去了在表里的位置。

用 `inert` 标住兄弟节点——**主面板本来就是这么做的**
（`dashboard.hero.js:1510`、`dashboard.render.js:2821`），一个属性同时移出 tab 顺序和
无障碍树，不需要自己维护 keydown 陷阱。抽屉和遮罩也是 `#decimap` 的子节点，所以按
身份跳过而不是把整个容器 inert。关闭时**先解 inert 再恢复焦点**（对 inert 元素调
`focus()` 是空操作）。`<aside>` 补上 `role="dialog"` + `aria-modal="true"`。

测试是行为级的，不是断言属性——断言 `inert` 在「抽屉根本打不开」的页面上也会绿。
要成立的是：**12 次 Tab 出不去，Esc 之后格子回来**。

## 验证

| 变异 | 结果 |
|---|---|
| `history` 只进 packet 不进 summary | `test_history_reaches_the_summary_…` 红 |
| 把 `lesson` 也投影出去 | `test_the_pre_written_lesson_stays_out…` 红 |
| 删掉 packet 预算预警 | `test_the_packet_ceiling_warns_before_the_wall…` 红 |
| 去掉 `inert` | `these siblings stayed reachable behind the open drawer: H1, P, dm-kpi, …` |
| 去掉焦点恢复 | `focus came back to BUTTON#, not the cell that opened the drawer` |

`tests/test_packet_ticker_history.py` 6 例、`tests/decimap_board.spec.js` 全绿；
相邻套件 `test_brief_decision_packet` / `test_decision_v2` / `test_decision_traces` /
`test_decision_trace_parity` 127 例全绿。

https://claude.ai/code/session_01HBSt6geARRtj3ypRnFXBZ1