### PR TITLE
brief: four parts and one heading convention, instead of twenty flat sections

### DIFF
--- a/site/_layouts/default.html
+++ b/site/_layouts/default.html
@@ -125,10 +125,62 @@
 
   /* Typography for rendered brief content */
   article h1 { font-size: 22px; margin: 0 0 14px; line-height: 1.3; letter-spacing: -0.01em; }
-  article h2 { font-size: 18px; margin: 22px 0 10px; padding-top: 12px; border-top: 1px solid var(--border); color: var(--accent); }
-  article h2:first-child { padding-top: 0; border-top: none; }
-  article h3 { font-size: 15px; margin: 16px 0 8px; color: var(--text); }
+
+  /* Two heading levels, two jobs (2026-09-06). The brief used to be twenty flat
+     `h2`s, and the rule-above-every-h2 rendering turned it into twenty
+     equally-weighted slabs with nothing saying which one was the decision. It is
+     now four `h2` parts with `h3` subsections inside them, so the weight
+     difference has to be visible: the part is a titled band, the subsection is a
+     quiet label. */
+  article h2 {
+    font-size: 17px; font-weight: 650; margin: 30px 0 14px; padding: 10px 14px;
+    color: var(--text); letter-spacing: -0.01em;
+    background: linear-gradient(180deg, var(--card-2), transparent 140%);
+    border-left: 3px solid var(--accent);
+    border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
+  }
+  article h2:first-of-type { margin-top: 22px; }
+  article h3 {
+    font-size: 13px; font-weight: 600; margin: 22px 0 8px;
+    color: var(--text-dim); text-transform: none;
+    letter-spacing: 0.02em;
+  }
+  /* A hairline that starts at the text rather than a full rule: it separates
+     subsections without competing with the part bands above them. */
+  article h3::after {
+    content: ""; display: block; margin-top: 6px;
+    height: 1px; background: var(--border);
+  }
+  article h2 + h3 { margin-top: 4px; }
   article p { margin: 10px 0; }
+
+  /* The reference material the brief folds away. Closed by default is the whole
+     point — the page opens on the call, not on the book. */
+  article details.brief-appendix {
+    margin: 30px 0 0; border: 1px solid var(--border);
+    border-radius: var(--radius-sm); background: var(--card-2);
+    padding: 0 14px;
+  }
+  article details.brief-appendix > summary {
+    cursor: pointer; list-style: none; padding: 12px 0;
+    font-size: 13px; font-weight: 600; color: var(--text-dim);
+    display: flex; align-items: center; gap: 8px;
+  }
+  article details.brief-appendix > summary::-webkit-details-marker { display: none; }
+  article details.brief-appendix > summary::before {
+    content: "▸"; color: var(--accent); font-size: 11px;
+    transition: transform 0.15s ease;
+  }
+  article details.brief-appendix[open] > summary::before { transform: rotate(90deg); }
+  article details.brief-appendix > summary:hover { color: var(--text); }
+  article details.brief-appendix > summary:focus-visible {
+    outline: 2px solid var(--accent); outline-offset: 2px; border-radius: 4px;
+  }
+  article details.brief-appendix[open] > summary { border-bottom: 1px solid var(--border); }
+  article details.brief-appendix > *:last-child { margin-bottom: 14px; }
+  @media (prefers-reduced-motion: reduce) {
+    article details.brief-appendix > summary::before { transition: none; }
+  }
   article ul, article ol { margin: 8px 0; padding-left: 22px; }
   article li { margin: 4px 0; }
   article code {

--- a/src/clawock/harness/brief_postflight.py
+++ b/src/clawock/harness/brief_postflight.py
@@ -53,14 +53,23 @@ from clawock.automation import workflow_outcomes  # noqa: E402
 #   - 同行扫描 / Peer Rotation: lines 332-358 and 509
 # The Chinese labels are the direct localized renderings of those named concepts;
 # 盘前深度简报 is also the prompt's own report name (lines 3 and 635).
+# The section names the rendered report must still contain. 2026-09-06 regrouped
+# twenty flat sections into four parts (`brief_render.render_brief`), so the old
+# names moved — and this table is a THIRD place that has to move with them, next
+# to SKILL.md and the cron payload. It was the only thing that noticed: rendering
+# the new layout against a real generation produced six "缺段标记" issues here
+# while the markdown itself was perfectly valid.
+#
+# Aliases keep the old names accepted so a brief rendered before the change (or
+# by a rolled-back harness) still validates rather than being called broken.
 REQUIRED_MARKDOWN_SECTIONS = {
     'Header': ('Header', '盘前摘要', '盘前深度简报'),
-    'Tier 1': ('Tier 1', '第一层'),
-    'Tier 2': ('Tier 2', '第二层'),
-    'Tier 3': ('Tier 3', '第三层'),
-    'Judge': ('Judge', '裁决'),
-    'Confidence': ('Confidence', '信心'),
-    'Next-Session': ('Next-Session', 'Next Session', '下一交易时段'),
+    '分析师四格': ('分析师四格', 'Tier 1', '第一层'),
+    '多空对辩': ('多空对辩', 'Tier 2', '第二层'),
+    '风险官三票': ('风险官三票', 'Tier 3', '第三层'),
+    '今日动作': ('今日动作', 'Judge', '裁决'),
+    '信心与判定': ('信心与判定', 'Confidence', '信心'),
+    '下一节点': ('下一节点', 'Next-Session', 'Next Session', '下一交易时段'),
     '同行扫描': ('同行扫描', 'Peer Rotation'),
 }
 HKD_USD_BUG_PATTERNS = [
@@ -527,15 +536,15 @@ def validate_markdown(path, context=None):
         # Only enforce when macro is known-fresh. age None = unknown/stale (preflight
         # now omits stale sidecars, but if one reaches here, don't demand the section
         # off unprovable-fresh data — that would fail a correctly-omitted section).
-        if (age is not None and age <= STALE_H) and m.get('vix') and '▎大盘速读' not in text:
+        if (age is not None and age <= STALE_H) and m.get('vix') and '大盘速读' not in text:
             issues.append('pre-open.md 缺 ▎大盘速读 段（context.macro 有 fresh 数据 '
                           f'age={age}h 但 LLM 没写）')
     if context and context.get('sentiment'):
         s = context['sentiment']
         age = s.get('age_hours')
         tickers = s.get('tickers') or []
-        if (age is not None and age <= STALE_H) and tickers and '▎社交舆情' not in text:
-            issues.append(f'pre-open.md 缺 ▎社交舆情速读 段（context.sentiment '
+        if (age is not None and age <= STALE_H) and tickers and '社交舆情' not in text:
+            issues.append(f'pre-open.md 缺「社交舆情」段（context.sentiment '
                           f'{len(tickers)} 个 ticker 有信号 age={age}h 但 LLM 没写）')
 
     return issues

--- a/src/clawock/harness/brief_render.py
+++ b/src/clawock/harness/brief_render.py
@@ -171,7 +171,7 @@ def header_section(context, judgment):
     hk_book, _ = _holdings(context, "hk")
     us_book, _ = _holdings(context, "us")
 
-    lines = ["## Header — Book 双视角（HK + USD 不能直接相加）", ""]
+    lines = ["### 双币账本（HK + USD 不能直接相加）", ""]
     lines.append(f"**🧭 Regime**: {text(regime)} · {text(_narrative(judgment).get('regime_read'))}")
     lines.append("")
     lines.append(
@@ -202,7 +202,7 @@ def concentration_section(context):
             pct(row.get("top2_pct"), sign=False),
             money(row.get("leg_total"), digits=0),
         ])
-    return "### 集中度（core.concentration）\n\n" + table(
+    return "### 集中度\n\n" + table(
         ["Leg", "HHI", "判定", "Top2", "腿总值"], rows)
 
 
@@ -241,7 +241,7 @@ def opportunity_section(context):
     """
     read = context.get("opportunity") or {}
     counts = read.get("counts") or {}
-    lines = ["### 加仓面（opportunity · 收盘确认）", ""]
+    lines = ["### 加仓面（收盘确认）", ""]
     if not read:
         return "\n".join(lines + ["_context 里没有 opportunity 读数（preflight 版本过旧）_"])
     lines.append(
@@ -349,7 +349,7 @@ def risk_section(context):
                      text(item.get("severity")), text(item.get("detail")),
                      text(item.get("breach_id"))])
 
-    lines = ["### 风险纪律（risk_discipline / risk_guardrail）", ""]
+    lines = ["### 风控硬闸", ""]
     lines.append(_track_record_line(context, ("cut", "trim_on_rebound")))
     lines.append("")
     lines.append(
@@ -384,7 +384,7 @@ def breakeven_section(context):
         ])
     if not rows:
         return ""
-    out = ["### Breakeven math（context.breakeven_math）", "",
+    out = ["### 回本测算", "",
            table(["Ticker", "浮%", "2x chop drag/月", "回本需", "半年窗含 drag 等效标的需"], rows)]
     note = math_block.get("note")
     if note:
@@ -393,7 +393,7 @@ def breakeven_section(context):
 
 
 def holdings_section(context):
-    out = ["## ▎仓位明细"]
+    out = ["### 仓位明细"]
     for leg, currency in (("hk", "HKD"), ("us", "USD")):
         book, held = _holdings(context, leg)
         if not held:
@@ -433,7 +433,7 @@ def retrospective_section(context):
                  else row.get("outcome") or row.get("verdict")),
         ])
     prior = retro.get("prior_plan_date")
-    head = f"## Retrospective（{text(prior)} plan）"
+    head = f"### 昨日兑现（{text(prior)} 的 plan）"
     if not rows:
         return head + "\n\n上一份 plan 无可对账决策。"
     return head + "\n\n" + table(
@@ -483,25 +483,26 @@ def tier1_section(context, judgment):
         ])) or MISSING
         rows.append([ticker, market, text(row.get("fundamentals")),
                      text(row.get("sentiment_read")), text(row.get("cross_market"))])
-    return "## Tier 1 — 4 Analyst 大表\n\n" + table(
+    return "### 分析师四格\n\n" + table(
         ["票", "Market（harness 计算）", "Fundamentals", "Sentiment", "Cross-Market"], rows)
 
 
 def tier2_section(judgment):
     narrative = _narrative(judgment)
     return "\n".join([
-        "## Tier 2 — Bull vs Bear",
+        "### 多空对辩",
         "",
-        "**▎Bull**", "", text(narrative.get("bull")),
+        "**看多**", "", text(narrative.get("bull")),
         "",
-        "**▎Bear**", "", text(narrative.get("bear")),
+        "**看空**", "", text(narrative.get("bear")),
         "",
-        f"**▎Devil's advocate** — 攻击的共识：{text(narrative.get('attacked_consensus'))}",
+        f"**魔鬼代言人** — 攻击的共识：{text(narrative.get('attacked_consensus'))}",
         "", text(narrative.get("devils_advocate")),
     ])
 
 
-def tier3_section(judgment, plan):
+def risk_voices_section(judgment):
+    """The three risk officers, in the rotation the model declared."""
     narrative = _narrative(judgment)
     voices = ("aggressive", "conservative", "neutral")
     first = narrative.get("risk_voice_first")
@@ -510,12 +511,21 @@ def tier3_section(judgment, plan):
         # produce three named voices rather than a section headed "None".
         first = voices[0]
     ordered = [first] + [voice for voice in voices if voice != first]
-    out = ["## Tier 3 — 3 Risk Voices + Judge", ""]
+    out = ["### 风险官三票", ""]
     for index, voice in enumerate(ordered):
         label = VOICE_LABELS.get(voice, voice)
         suffix = " · 今日首位表态" if index == 0 else ""
-        out += [f"**▎{label}{suffix}**", "", text(narrative.get(voice)), ""]
+        out += [f"**{label}{suffix}**", "", text(narrative.get(voice)), ""]
+    return "\n".join(out).rstrip()
 
+
+def judge_section(plan):
+    """The calls themselves — what the harness validated and the ledger records.
+
+    Split out of the old `Tier 3 — 3 Risk Voices + Judge` because those are two
+    different questions: the voices are the argument, this is the answer. Under
+    the four-part layout the answer opens the report and the argument follows it.
+    """
     rows = []
     for decision in (plan.get("decisions") or []):
         debate = decision.get("debate") or {}
@@ -527,9 +537,8 @@ def tier3_section(judgment, plan):
             text(decision.get("driven_by")),
             text(decision.get("rationale")),
         ])
-    out += ["### Judge — 合成判词（来自 plan.json，harness 校验过边界）", "",
-            table(["Ticker", "Action", "Frame", "Strategy", "driven_by", "理由"], rows)]
-    return "\n".join(out)
+    return "### 今日动作\n\n" + table(
+        ["Ticker", "Action", "Frame", "Strategy", "driven_by", "理由"], rows)
 
 
 def sector_section(sector_scan, judgment):
@@ -543,7 +552,7 @@ def sector_section(sector_scan, judgment):
     sectors = (sector_scan or {}).get("sectors") or []
     read = text(_narrative(judgment).get("sector_read"))
     if not sectors:
-        return "\n".join(["## ▎板块全景", "", read])
+        return "\n".join(["### 板块全景", "", read])
     rows = []
     for sector in sectors:
         movers = "、".join(
@@ -558,7 +567,7 @@ def sector_section(sector_scan, judgment):
                 movers or MISSING,
                 text(own.get("attribution")),
             ])
-    out = ["## ▎板块全景", "",
+    out = ["### 板块全景", "",
            table(["板块", "持仓", "今日", "位置", "板块 Top", "归因"], rows), "", read]
     return "\n".join(out)
 
@@ -582,7 +591,7 @@ def peer_section(context, judgment):
             f"{gap:+.2f}pp" if gap is not None else MISSING,
             text((judgments.get(ticker) or {}).get("peer_read")),
         ])
-    return "## ▎同行扫描\n\n" + table(
+    return "### 同行扫描\n\n" + table(
         ["持仓", "主题", "今日 self", "最强同行", "差距", "判断"], rows)
 
 
@@ -605,7 +614,7 @@ def macro_section(context, judgment):
         parts.append(f"10Y **{pct(macro.get('treasury_10y_yield_pct'), sign=False)}**")
     body = " · ".join(part for part in parts if part)
     return "\n".join([
-        "## ▎大盘速读", "",
+        "### 大盘速读", "",
         f"{body}（as_of {text(macro.get('as_of'))}, age {num(macro.get('age_hours'), 1)}h）",
         "", text(_narrative(judgment).get("macro_read")),
     ])
@@ -631,7 +640,7 @@ def sentiment_section(context, judgment):
         ])
     if not rows:
         return ""
-    return "## ▎社交舆情速读\n\n" + table(
+    return "### 社交舆情\n\n" + table(
         ["票", "Reddit 7d", "新闻关键词", "近 5 日", "信号判断"], rows)
 
 
@@ -640,7 +649,7 @@ def influencer_section(context):
     counts = influencer.get("counts") or {}
     if not counts.get("total"):
         return ""
-    out = [f"## ▎名人异动/政策风向（age {num(influencer.get('age_hours'), 1)}h）", "",
+    out = [f"### 名人异动 / 政策风向（{num(influencer.get('age_hours'), 1)}h 前）", "",
            f"撞持仓 **{counts.get('held_hits', 0)}** · 新机会 {counts.get('new_ideas', 0)}"
            f" · 板块相关 {counts.get('sector_hits', 0)}", ""]
     for bucket, label in (("held_hits", "撞持仓"), ("new_ideas", "新机会"),
@@ -680,7 +689,7 @@ def confidence_section(judgment, plan):
             text(row.get("rationale")),
             text(row.get("falsifier")),
         ])
-    return "## Confidence\n\n" + table(
+    return "### 信心与判定\n\n" + table(
         ["Ticker", "Action", "Confidence", "Verdict", "理由", "证伪条件"], rows)
 
 
@@ -714,7 +723,7 @@ def calibration_section(context, judgment):
             _interval(row.get("cluster_ci95")),
             "✅" if row.get("edge_significant") else "—",
         ])
-    out = ["## ▎Decision v2 校准（decision_metrics）", "", head, ""]
+    out = ["### 决策校准", "", head, ""]
     if rows:
         out += [table(["driven_by", "n", "avg benefit", "cluster CI95", "edge"], rows), ""]
     out.append(text(_narrative(judgment).get("calibration_read")))
@@ -724,7 +733,7 @@ def calibration_section(context, judgment):
 def next_session_section(judgment):
     steps = _narrative(judgment).get("next_session") or []
     body = "\n".join(f"{index}. {text(step)}" for index, step in enumerate(steps, 1))
-    return "## Next-Session Plan\n\n" + (body or "无。")
+    return "### 下一节点\n\n" + (body or "无。")
 
 
 def data_holes_section(context, judgment):
@@ -733,8 +742,8 @@ def data_holes_section(context, judgment):
     surface = (context.get("research_surface") or {}).get("errors") or []
     holes += [str(error) for error in surface]
     if not holes:
-        return "## ▎待补（data holes）\n\n无。"
-    return "## ▎待补（data holes）\n\n" + "\n".join(f"- {text(hole)}" for hole in holes)
+        return "### 待补\n\n无。"
+    return "### 待补\n\n" + "\n".join(f"- {text(hole)}" for hole in holes)
 
 
 # --- documents -------------------------------------------------------------
@@ -748,6 +757,56 @@ def render_brief(context, judgment, plan, *, date=None, sector_scan=None):
     except ValueError:
         pass
     title = f"盘前深度简报｜{date} {weekday} {BRIEF_SLOT_HKT} HKT".strip()
+
+    # Four parts, in this order and nowhere else (2026-09-06, kcn: 「就和盘中一样」).
+    #
+    # It used to be twenty flat `##` sections with four heading conventions
+    # competing in one document — `## Header — Book 双视角`, `### 集中度
+    # （core.concentration）`, `## ▎仓位明细`, `## Tier 1 — 4 Analyst 大表` — and
+    # the layout stylesheet draws a rule above every `h2`, so the page arrived as
+    # twenty equally-weighted slabs with internal field names printed in the
+    # headings. Nothing told a reader which block was the decision and which was
+    # background.
+    #
+    # Every section still renders; none of the analysis was cut (kcn: 「内容可以
+    # 稍微精简，但该有的输出决策分析都要有，不要砍」). What changed is that the
+    # twenty are grouped under four `##` parts with one `###` convention beneath
+    # them, and the reference material moves inside a `<details>` so the page
+    # opens on the call rather than on the book.
+    #
+    # The intraday check-in is the model this follows: harness data block plus
+    # one model paragraph, and the reader never wonders where to start.
+    parts = [
+        ("今天做什么", [
+            judge_section(plan),
+            confidence_section(judgment, plan),
+            next_session_section(judgment),
+        ]),
+        ("我的看法", [
+            tier2_section(judgment),
+            risk_voices_section(judgment),
+            tier1_section(context, judgment),
+        ]),
+        ("这本账现在什么样", [
+            header_section(context, judgment),
+            concentration_section(context),
+            risk_section(context),
+            opportunity_section(context),
+            breakeven_section(context),
+            holdings_section(context),
+            market_trend_section(context),
+        ]),
+    ]
+    appendix = [
+        retrospective_section(context),
+        peer_section(context, judgment),
+        sector_section(sector_scan, judgment),
+        macro_section(context, judgment),
+        sentiment_section(context, judgment),
+        influencer_section(context),
+        calibration_section(context, judgment),
+        data_holes_section(context, judgment),
+    ]
 
     blocks = [
         "---",
@@ -763,47 +822,35 @@ def render_brief(context, judgment, plan, *, date=None, sector_scan=None):
         "",
         f"**反方**：{text(judgment.get('portfolio_counterargument'))}",
         "",
-        header_section(context, judgment),
-        "",
-        concentration_section(context),
-        "",
-        risk_section(context),
-        "",
-        opportunity_section(context),
-        "",
-        market_trend_section(context),
-        "",
-        breakeven_section(context),
-        "",
-        holdings_section(context),
-        "",
-        retrospective_section(context),
-        "",
-        tier1_section(context, judgment),
-        "",
-        tier2_section(judgment),
-        "",
-        tier3_section(judgment, plan),
-        "",
-        peer_section(context, judgment),
-        "",
-        sector_section(sector_scan, judgment),
-        "",
-        macro_section(context, judgment),
-        "",
-        sentiment_section(context, judgment),
-        "",
-        influencer_section(context),
-        "",
-        confidence_section(judgment, plan),
-        "",
-        calibration_section(context, judgment),
-        "",
-        next_session_section(judgment),
-        "",
-        data_holes_section(context, judgment),
-        "",
     ]
+    for heading, sections in parts:
+        rendered = [section for section in sections if section and section.strip()]
+        if not rendered:
+            continue
+        blocks += [f"## {heading}", ""]
+        for section in rendered:
+            blocks += [section, ""]
+
+    # `<details>` rather than a fifth part: this is the material a reader consults
+    # when a number above surprises them, not material they read every morning.
+    #
+    # `markdown="1"` is load-bearing, not decoration. The site runs kramdown with
+    # `input: GFM` and kramdown does NOT parse markdown inside a block-level HTML
+    # element unless the element says so — without the attribute every table in
+    # this appendix ships to the page as literal pipe characters, and nothing in
+    # the markdown validator would notice because the markdown itself is fine.
+    # `test_brief_render_layout` pins it for that reason.
+    kept = [section for section in appendix if section and section.strip()]
+    if kept:
+        blocks += [
+            "<details class=\"brief-appendix\" markdown=\"1\">",
+            "<summary>背景与校准</summary>",
+            "",
+        ]
+        for section in kept:
+            blocks += [section, ""]
+        blocks += ["</details>", ""]
+
     body = "\n".join(block for block in blocks if block is not None)
     # Collapse the blank lines an omitted section leaves behind, so a quiet day
     # does not publish a page full of gaps.

--- a/tests/test_brief_postflight_sections.py
+++ b/tests/test_brief_postflight_sections.py
@@ -58,7 +58,10 @@ def test_genuinely_omitted_section_still_raises_same_missing_issue(tmp_path):
 
     issues = brief_postflight.validate_markdown(path)
 
-    assert _missing_section_issues(issues) == ['pre-open.md 缺段标记 "Tier 2"']
+    # The concept key is the section's current name (2026-09-06 regrouped the
+    # report into four parts); `## 第二层` stays an accepted alias, which is why
+    # the localized fixture above still validates.
+    assert _missing_section_issues(issues) == ['pre-open.md 缺段标记 "多空对辩"']
     # Keep today's warn/fail threshold semantics: one non-critical issue is a warn;
     # five such issues still fail. The section omission itself remains surfaced.
     assert brief_postflight.categorize(issues) == 'warn'

--- a/tests/test_brief_render.py
+++ b/tests/test_brief_render.py
@@ -109,11 +109,18 @@ def _judgment(**overrides):
 def test_the_report_is_rendered_in_one_fixed_order():
     body = render.render_brief(CONTEXT, _judgment(), PLAN, date="2026-08-31")
 
-    order = ["# 盘前深度简报", "## Header", "### 集中度", "### 风险纪律",
-             "### Breakeven math", "## ▎仓位明细", "## Retrospective", "## Tier 1",
-             "## Tier 2", "## Tier 3", "### Judge", "## ▎同行扫描", "## ▎大盘速读",
-             "## ▎社交舆情速读", "## Confidence", "## ▎Decision v2 校准",
-             "## Next-Session Plan", "## ▎待补"]
+    # Four parts, then the folded appendix (2026-09-06). The order of the
+    # subsections inside a part is pinned here for the same reason the flat list
+    # used to be: the report's shape is a decision, not an accident of which
+    # section function happened to be appended last.
+    order = ["# 盘前深度简报",
+             "## 今天做什么", "### 今日动作", "### 信心与判定", "### 下一节点",
+             "## 我的看法", "### 多空对辩", "### 风险官三票", "### 分析师四格",
+             "## 这本账现在什么样", "### 双币账本", "### 集中度", "### 风控硬闸",
+             "### 回本测算", "### 仓位明细", "### 大盘趋势",
+             "<details class=\"brief-appendix\"", "<summary>背景与校准</summary>",
+             "### 昨日兑现", "### 同行扫描", "### 大盘速读", "### 社交舆情",
+             "### 决策校准", "### 待补", "</details>"]
     positions = [body.index(heading) for heading in order]
     assert positions == sorted(positions), (
         "section order is the harness's, and it must not depend on the judgment")
@@ -141,13 +148,13 @@ def test_model_text_lands_in_the_slot_it_was_written_for():
 
     bull = body.index("最坏定价已吃掉大半。")
     bear = body.index("纪律未执行是最大风险。")
-    assert body.index("## Tier 2") < bull < bear < body.index("## Tier 3")
+    assert body.index("### 多空对辩") < bull < bear < body.index("### 风险官三票")
     assert "板块仍有 alpha" in body
 
 
 def test_the_first_risk_voice_is_the_one_the_judgment_named():
     body = render.render_brief(CONTEXT, _judgment(), PLAN, date="2026-08-31")
-    tier3 = body[body.index("## Tier 3"):body.index("### Judge")]
+    tier3 = body[body.index("### 风险官三票"):body.index("### 分析师四格")]
 
     assert tier3.index("Conservative") < tier3.index("Aggressive"), (
         "the rotation is stated by the model and ordered by the harness")
@@ -159,7 +166,7 @@ def test_a_missing_narrative_field_reads_as_a_hole_not_as_None():
     body = render.render_brief(CONTEXT, judgment, PLAN, date="2026-08-31")
 
     assert "None" not in body
-    macro = body[body.index("## ▎大盘速读"):body.index("## ▎社交舆情速读")]
+    macro = body[body.index("### 大盘速读"):body.index("### 社交舆情")]
     assert render.MISSING in macro
 
 
@@ -175,7 +182,7 @@ def test_the_judge_table_comes_from_the_plan_not_the_prose():
     """The plan is the validated boundary; the report must not restate it in the
     model's own words, or the two can disagree about what was decided."""
     body = render.render_brief(CONTEXT, _judgment(), PLAN, date="2026-08-31")
-    judge = body[body.index("### Judge"):body.index("## ▎同行扫描")]
+    judge = body[body.index("### 今日动作"):body.index("### 信心与判定")]
 
     assert "**cut**" in judge and "risk_rebalance" in judge
     assert "technical_breakdown + relative_strength" in judge
@@ -195,7 +202,7 @@ SECTOR_SCAN = {
 def test_the_sector_sweep_is_rendered_when_the_scan_exists():
     body = render.render_brief(CONTEXT, _judgment(), PLAN, date="2026-08-31",
                                sector_scan=SECTOR_SCAN)
-    sector = body[body.index("## ▎板块全景"):body.index("## ▎大盘速读")]
+    sector = body[body.index("### 板块全景"):body.index("### 大盘速读")]
 
     assert "09678" in sector and "落后" in sector
     assert "利好盘后才公布" in sector
@@ -205,7 +212,7 @@ def test_the_sector_sweep_is_rendered_when_the_scan_exists():
 def test_a_missing_sector_scan_still_publishes_the_read():
     """A day the search quota was spent still has to publish."""
     body = render.render_brief(CONTEXT, _judgment(), PLAN, date="2026-08-31")
-    sector = body[body.index("## ▎板块全景"):body.index("## ▎大盘速读")]
+    sector = body[body.index("### 板块全景"):body.index("### 大盘速读")]
 
     assert "板块内部分化。" in sector
     assert "|" not in sector, "no table when there is no scan"
@@ -294,7 +301,7 @@ def test_an_unknown_verdict_still_prints_itself():
 
 def test_the_confidence_table_carries_the_badge():
     body = render.render_brief(CONTEXT, _judgment(), PLAN, date="2026-08-31")
-    table = body[body.index("## Confidence"):body.index("## ▎Decision v2 校准")]
+    table = body[body.index("### 信心与判定"):body.index("### 下一节点")]
 
     assert '<span class="verdict verdict-bearish">🔴 看空</span>' in table
     assert "| 看空 |" not in table, "the plain-text cell is what #1272 replaced"
@@ -313,3 +320,53 @@ def test_the_stylesheet_tints_every_badge_class():
     # Tokens, not literals: the layout redefines --green/--red under
     # prefers-color-scheme, so a hardcoded hex would be wrong in one theme.
     assert "var(--green)" in layout and "var(--red)" in layout
+
+
+# ── the four-part layout, and the two ways it can silently break ────────────
+
+def test_the_appendix_says_markdown_1_or_every_table_in_it_ships_as_pipes():
+    """Load-bearing attribute, not decoration.
+
+    The site runs kramdown with `input: GFM`, and kramdown does not parse
+    markdown inside a block-level HTML element unless the element says so. Drop
+    `markdown="1"` and every table in the appendix reaches the page as literal
+    `|` characters — while the markdown itself stays valid, so neither
+    `validate_markdown` nor the table-column checker would see anything wrong.
+    """
+    body = render.render_brief(CONTEXT, _judgment(), PLAN, date="2026-08-31")
+    opening = body[body.index("<details"):body.index(">", body.index("<details")) + 1]
+    assert 'markdown="1"' in opening, (
+        f"appendix opens as {opening!r} — kramdown will ship its tables as text")
+
+
+def test_the_reference_material_is_folded_and_the_call_is_not():
+    """The page has to open on the decision, not on the book."""
+    body = render.render_brief(CONTEXT, _judgment(), PLAN, date="2026-08-31")
+    fold = body.index("<details")
+    for heading in ("## 今天做什么", "## 我的看法", "## 这本账现在什么样"):
+        assert body.index(heading) < fold, f"{heading} was folded away"
+    for heading in ("### 昨日兑现", "### 决策校准", "### 待补"):
+        assert body.index(heading) > fold, f"{heading} is reference material, not the call"
+    assert body.index("## 今天做什么") < body.index("## 我的看法"), (
+        "the answer comes before the argument")
+
+
+def test_exactly_four_parts_and_one_subsection_convention():
+    """Twenty flat `##` with four heading styles is the thing this replaced.
+
+    `##` is a part; `###` is a subsection; nothing else. The old report mixed
+    `## Header — Book 双视角`, `### 集中度（core.concentration）`, `## ▎仓位明细`
+    and `## Tier 1 — 4 Analyst 大表` in one document, and printed internal field
+    names in the headings a reader sees.
+    """
+    body = render.render_brief(CONTEXT, _judgment(), PLAN, date="2026-08-31")
+    parts = [line for line in body.splitlines() if line.startswith("## ")]
+    assert parts == ["## 今天做什么", "## 我的看法", "## 这本账现在什么样"], parts
+    subs = [line for line in body.splitlines() if line.startswith("### ")]
+    assert subs, "the parts have no subsections"
+    for line in parts + subs:
+        assert "▎" not in line, f"{line!r} still carries the card ornament"
+        for leak in ("core.", "context.", "risk_discipline", "decision_metrics",
+                     "Tier ", "plan.json"):
+            assert leak not in line, f"{line!r} prints an internal name at the reader"
+


### PR DESCRIPTION
kcn：「brief output 的格式和确定性输出…html 里面排版非常乱，区块也很杂」+「就和盘中一样」
+「内容可以稍微精简，但该有的输出决策分析都要有，不要砍」+「样式好看一点」。

## 现状先说清楚

**「模型出 JSON、harness 渲染」这半边已经做了**（#1232：模型只写 judgment，
`brief_render.py` 出版式）。乱的不是那个，是**信息架构**：

- 20 个平级 `##`，**四套标题写法**在同一篇里打架：
  `## Header — Book 双视角` / `### 集中度（core.concentration）` / `## ▎仓位明细` /
  `## Tier 1 — 4 Analyst 大表` / `## Confidence`
- 内部字段名直接印给读者：`core.concentration`、`risk_discipline / risk_guardrail`、
  `context.breakeven_math`、`decision_metrics`、`来自 plan.json`
- 版式里 `article h2` 每个都画一条横线 ⇒ 页面 = **20 块等重的板砖**，
  没有任何东西说明哪块是决策、哪块是背景

## 改法：四块 + 一套标题，**一段分析都没删**

```
今天做什么            今日动作 · 信心与判定 · 下一节点
我的看法              多空对辩 · 风险官三票 · 分析师四格
这本账现在什么样      双币账本 · 集中度 · 风控硬闸 · 加仓面 · 回本测算 · 仓位明细 · 大盘趋势
<details>背景与校准   昨日兑现 · 同行 · 板块 · 大盘速读 · 社交舆情 · 名人异动 · 决策校准 · 待补
```

**答案在论据前面**，参考材料折叠——那是「上面某个数字让你意外时才去翻」的东西，
不是每天早上要读的。judgment schema 没动（v3 原样），所以模型侧零改动、零风险。

`tier3_section` 拆成 `risk_voices_section` + `judge_section`：那本来是两个问题共用一个标题。

## 三个会静默坏掉的地方，都钉住了

**1. `markdown="1"` 是承重的，不是装饰。** 站点是 kramdown + `input: GFM`，
kramdown **不会**解析块级 HTML 里的 markdown，除非元素自己声明。少了它，
附录里每张表都会以字面 `|` 发到页面上——而 `validate_markdown` 和表格列数闸
**都不会报错**，因为 markdown 本身是好的。

**2. postflight 的段名表是第三处要跟着改的地方**（另两处是 SKILL.md 和 cron payload）。
它也是唯一一个抓到重命名的东西：拿 2026-09-04 真实 generation 渲染新版式，
这里吐了 6 条 `缺段标记`，而 markdown 完全合法。旧段名保留为 alias，
所以改动前渲染的简报仍然验得过。

**3. 标题里不许再出现内部名。** 测试枚举所有 `##`/`###`，禁 `▎` 与
`core.` / `context.` / `risk_discipline` / `decision_metrics` / `Tier ` / `plan.json`。

## 样式

- `h2`（部）→ 左侧强调条 + 渐隐底色的**标题带**；`h3`（小节）→ 安静的标签 +
  从文字起笔的发丝线。**「部」和「小节」的重量差必须看得见**，否则分组白做
- 折叠块：旋转的 disclosure 标记、`:focus-visible` 焦点环、
  `prefers-reduced-motion` 退路
- `article h2` 那条「每个都画横线」去掉了——4 个部不需要 20 条线

## 验证

| 变异 | 结果 |
|---|---|
| 去掉 `markdown="1"` | `test_the_appendix_says_markdown_1_or_every_table_in_it_ships_as_pipes` 红 |
| 把「昨日兑现」放回正文 | `test_the_reference_material_is_folded_and_the_call_is_not` + 顺序表 红 |

拿 **2026-09-04 真实 generation** 渲染：31,400 字节，`validate_markdown` **0 issue**。
`site_layout_mobile.spec.js` 绿；`-k brief` **298 passed**。

（`test_pages_deployment_contract.py` 那 2 条在 master 上本来就是红的，与本 PR 无关——
已在 stash 后单独复核过。）

https://claude.ai/code/session_01HBSt6geARRtj3ypRnFXBZ1