### PR TITLE
brief: make the card and the page the same report, in the same order

### DIFF
--- a/src/clawock/harness/brief_render.py
+++ b/src/clawock/harness/brief_render.py
@@ -537,7 +537,7 @@ def judge_section(plan):
             text(decision.get("driven_by")),
             text(decision.get("rationale")),
         ])
-    return "### 今日动作\n\n" + table(
+    return f"### {PAGE_ACTION_HEADING}\n\n" + table(
         ["Ticker", "Action", "Frame", "Strategy", "driven_by", "理由"], rows)
 
 
@@ -748,6 +748,15 @@ def data_holes_section(context, judgment):
 
 # --- documents -------------------------------------------------------------
 
+#: Section names the page and the card share. They exist as constants because the
+#: two surfaces are rendered by two functions, and a reader taps from one to the
+#: other: renaming a heading in only one of them is how they drift into looking
+#: like different reports. `test_the_card_and_the_page_agree` pins the pair.
+PAGE_ACTION_HEADING = "今日动作"
+PAGE_BOOK_PART = "这本账现在什么样"
+CARD_BOOK_HEADING = "这本账"
+
+
 def render_brief(context, judgment, plan, *, date=None, sector_scan=None):
     """The full pre-open report.  Order is fixed here and nowhere else."""
     date = date or context.get("date") or ""
@@ -787,7 +796,7 @@ def render_brief(context, judgment, plan, *, date=None, sector_scan=None):
             risk_voices_section(judgment),
             tier1_section(context, judgment),
         ]),
-        ("这本账现在什么样", [
+        (PAGE_BOOK_PART, [
             header_section(context, judgment),
             concentration_section(context),
             risk_section(context),
@@ -860,25 +869,41 @@ def render_brief(context, judgment, plan, *, date=None, sector_scan=None):
 
 
 def render_card(context, judgment, plan, *, date=None, page_url=None):
-    """The WeChat/Telegram card: the same facts, cut to what fits a phone."""
+    """The WeChat/Telegram card: the same facts, cut to what fits a phone.
+
+    Two surfaces, one report. The card is the trimmed one and the page is what a
+    reader opens when the card makes them want more, so the two must agree on
+    what comes first and on what things are called — a reader who taps through
+    should land on the same words in the same order, not on a different document.
+
+    So this follows the page's four-part order (2026-09-06): the call, then the
+    book, then the levels. It used to lead with the book, which put 1.3KB of
+    balance between the reader and the four cuts the brief exists to state.
+
+    What the card deliberately drops, recorded here so the trim is a decision
+    rather than an omission nobody re-examined:
+
+    * `**反方**` — the page opens with the assessment and its counterargument;
+      the card keeps only the assessment. Both are the model's longest prose and
+      two of them is a wall on a phone.
+    * every argument section (多空对辩 / 风险官三票 / 分析师四格) and the whole
+      背景与校准 appendix — that is what the link at the bottom is for.
+
+    `▎` is the card's own ornament and stays here. It was removed from the page
+    headings, where markdown already carries the hierarchy.
+    """
     date = date or context.get("date") or ""
     book = context.get("book_totals") or {}
     fx = context.get("fx") or {}
     concentration = context.get("concentration") or {}
     lines = [f"📊 盘前深度简报｜{date} {BRIEF_SLOT_HKT} HKT  (USDHKD={num(fx.get('rate'), 4)})", ""]
     lines += ["▎核心结论", text(judgment.get("portfolio_assessment")), ""]
-    lines += ["▎Book",
-              f"USD${money(book.get('usd_base_total'), digits=0)}"
-              f" | HK leg HKD${money(book.get('hk_pnl_hkd'), digits=0)}"
-              f" | US leg USD${money(book.get('us_pnl_usd'), digits=0)}",
-              f"HHI: HK {num((concentration.get('hk') or {}).get('hhi'), 3)}"
-              f" · US {num((concentration.get('us') or {}).get('hhi'), 3)}", ""]
 
     actions = [d for d in (plan.get("decisions") or [])
                if d.get("action") not in (None, "hold_and_watch", "watch")]
     holds = [d for d in (plan.get("decisions") or [])
              if d.get("action") in ("hold_and_watch", "watch")]
-    lines.append("▎今日动作")
+    lines.append(f"▎{PAGE_ACTION_HEADING}")
     if actions:
         for index, decision in enumerate(actions, 1):
             size = (decision.get("size") or {}).get("shares")
@@ -895,6 +920,13 @@ def render_card(context, judgment, plan, *, date=None, page_url=None):
                      + "/".join(str(d.get("ticker")) for d in holds)
                      + " hold_and_watch")
     lines.append("")
+
+    lines += [f"▎{CARD_BOOK_HEADING}",
+              f"USD${money(book.get('usd_base_total'), digits=0)}"
+              f" | HK leg HKD${money(book.get('hk_pnl_hkd'), digits=0)}"
+              f" | US leg USD${money(book.get('us_pnl_usd'), digits=0)}",
+              f"HHI: HK {num((concentration.get('hk') or {}).get('hhi'), 3)}"
+              f" · US {num((concentration.get('us') or {}).get('hhi'), 3)}", ""]
 
     levels = plan.get("watch_levels") or {}
     if levels:

--- a/tests/test_brief_render.py
+++ b/tests/test_brief_render.py
@@ -370,3 +370,44 @@ def test_exactly_four_parts_and_one_subsection_convention():
                      "Tier ", "plan.json"):
             assert leak not in line, f"{line!r} prints an internal name at the reader"
 
+
+# ── the trimmed surface and the full one must not drift apart ───────────────
+
+def test_the_card_and_the_page_agree_on_what_comes_first():
+    """A reader taps the card's link expecting the same report, not another one.
+
+    The card used to lead with the book — 1.3KB of balance between the reader and
+    the four cuts the brief exists to state — while the page (after the four-part
+    regroup) leads with the call. Same report, two orders, and whichever one you
+    read second felt wrong.
+    """
+    judgment = _judgment()
+    page = render.render_brief(CONTEXT, judgment, PLAN, date="2026-08-31")
+    card = render.render_card(CONTEXT, judgment, PLAN, date="2026-08-31")
+
+    assert card.index("▎" + render.PAGE_ACTION_HEADING) < card.index("▎" + render.CARD_BOOK_HEADING), (
+        "the card puts the book before the call; the page does not")
+    assert page.index("### " + render.PAGE_ACTION_HEADING) < page.index("## " + render.PAGE_BOOK_PART), (
+        "the page puts the book before the call")
+
+
+def test_both_surfaces_call_the_action_section_the_same_thing():
+    """Renaming a heading on one surface only is how they drift."""
+    judgment = _judgment()
+    page = render.render_brief(CONTEXT, judgment, PLAN, date="2026-08-31")
+    card = render.render_card(CONTEXT, judgment, PLAN, date="2026-08-31")
+    assert f"### {render.PAGE_ACTION_HEADING}" in page
+    assert f"▎{render.PAGE_ACTION_HEADING}" in card
+    assert render.CARD_BOOK_HEADING in render.PAGE_BOOK_PART, (
+        "the card's book heading should read as a short form of the page's part, "
+        f"got {render.CARD_BOOK_HEADING!r} vs {render.PAGE_BOOK_PART!r}")
+
+
+def test_the_card_keeps_its_own_ornament_and_the_page_does_not():
+    """`▎` is the card's hierarchy (plain text has no headings); markdown has its own."""
+    judgment = _judgment()
+    card = render.render_card(CONTEXT, judgment, PLAN, date="2026-08-31")
+    page = render.render_brief(CONTEXT, judgment, PLAN, date="2026-08-31")
+    assert "▎" in card
+    assert not any(line.startswith("#") and "▎" in line for line in page.splitlines())
+


### PR DESCRIPTION
kcn：「记得还要区分裁剪版和真实看到的完整版效果。前者可以靠代码处理」。

## 现状

**裁剪版已经是代码处理的**——`render_card` 拿同一份 context/judgment/plan 生成微信/Telegram 卡，
模型不参与排版。这一半是好的。

问题是 #1358 把**完整版**重排成四块之后，两个面**不再一致**了：

| | 完整版（页面） | 裁剪版（卡片） |
|---|---|---|
| 开头 | 今天做什么 → 我的看法 → 这本账 | 核心结论 → **Book** → 今日动作 |
| 账本段叫什么 | `## 这本账现在什么样` | `▎Book` |

卡片把 **1.3KB 的余额摆在读者和「今天要砍四笔」之间**。点链接过去先读到的是另一个顺序——
同一份简报，读第二遍的那个总觉得不对。

## 改法

卡片跟上页面的顺序：**核心结论 → 今日动作 → 这本账 → 触发位**。

段名抽成常量（`PAGE_ACTION_HEADING` / `PAGE_BOOK_PART` / `CARD_BOOK_HEADING`）——
**两个面是两个函数渲染的，只改其中一个的标题正是它们漂开的方式**，`▎Book` 对
`## 这本账现在什么样` 已经是了。

**卡片故意丢掉什么，写进 docstring**，让「裁剪」是一个记录在案的决定而不是没人再看的遗漏：

- `**反方**` —— 页面开头是 assessment + 反方，卡片只留 assessment。
  两段都是模型最长的散文，手机上放两段就是一堵墙
- 全部论据段（多空对辩 / 风险官三票 / 分析师四格）与整个背景与校准附录
  —— 那是底部那条链接的用途

`▎` 留在卡片这边：纯文本没有标题层级，它是卡片**唯一**的层级；页面去掉是因为 markdown 自带。

## 验证

三条测试钉住这一对：顺序、共享段名、`▎` 只出现在一边。

| 变异 | 结果 |
|---|---|
| 把卡片的「这本账」挪回动作前面 | `test_the_card_and_the_page_agree_on_what_comes_first` 红 |

真实 2026-09-04 generation：**1,302 字符 / 四段 / 与页面同名**

```
📊 盘前深度简报｜2026-09-04 08:03 HKT  (USDHKD=7.8414)
▎核心结论
▎今日动作
▎这本账
▎触发位
📈 完整深度报告：
```

`-k "brief or card"` **366 passed**。

https://claude.ai/code/session_01HBSt6geARRtj3ypRnFXBZ1