### PR TITLE
tests: stop asking the live host what a unit test should assert

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -213,6 +213,64 @@ _WRITE_LOG = []
 _LAST_SEEN = {}
 
 
+#: A path that cannot exist, so `openclaw` resolution fails the way it does on
+#: every machine that has no runtime installed — which is every CI runner.
+_NO_OPENCLAW_BINARY = "/nonexistent/clawock-tests-have-no-openclaw"
+
+
+def pytest_configure(config):
+    """No test reaches the live OpenClaw runtime, on any host.
+
+    `providers.openclaw.cron_cli_json` shells out to `openclaw cron … --json`,
+    and that round-trips through the gateway: the module's own comment measures
+    it at ~42s on a loaded host, and 4.6s is ordinary. CI never paid it, because
+    no runner has `openclaw` on PATH and the call fails immediately — so the
+    suite's cost on the one machine that DOES have the runtime was invisible to
+    everything that watches the suite.
+
+    Measured 2026-09-06 on the live box:
+
+        tests/test_brief_watchdog_retry_budget.py     39.4s -> 4.5s   (17 passed)
+
+    Speed is the smaller half. The larger half is that those runs were reaching
+    the real cron of the live trading host to decide what a *unit test* asserted:
+    `alert_brief_missing` stubs `brief_cron_job_state` but calls `brief_cron_job`
+    as well, and nothing stubbed that. A test whose answer depends on whether
+    this particular host has a healthy runtime is a test that means something
+    different for every person who runs it — the same complaint as the two
+    guarantees above, one layer out.
+
+    `CLAWOCK_OPENCLAW_BIN` is the documented override, so this uses the public
+    seam rather than patching the module. A test that genuinely wants the real
+    binary sets the variable itself; `monkeypatch.setenv` inside a test wins over
+    the value planted here.
+    """
+    os.environ.setdefault("CLAWOCK_OPENCLAW_BIN", _NO_OPENCLAW_BINARY)
+
+
+@pytest.fixture
+def resolves_the_real_openclaw_binary(monkeypatch):
+    """Opt out of the sentinel above, for tests that are ABOUT the binary path.
+
+    `providers.openclaw` has two ways to name the runtime: `OPENCLAW_BIN`, a
+    module constant from `shutil.which` computed at import and blind to the
+    environment, and `runtime_paths().binary`, which honours
+    `CLAWOCK_OPENCLAW_BIN`. Tests that assert "the argv we built starts with the
+    binary" compare the first against a call that used the second, so planting a
+    sentinel in the environment makes them disagree about a thing neither is
+    really testing.
+
+    Pinning the override to the constant makes the two agree by construction,
+    which is what those tests always assumed and never said.
+    """
+    monkeypatch.setenv("CLAWOCK_OPENCLAW_BIN", _openclaw_module().OPENCLAW_BIN)
+
+
+def _openclaw_module():
+    from clawock.providers import openclaw  # noqa: PLC0415 - after sys.path setup
+    return openclaw
+
+
 def pytest_sessionstart(session):
     """Baseline before ANY fixture runs.
 

--- a/tests/test_runtime_coupling_ratchet.py
+++ b/tests/test_runtime_coupling_ratchet.py
@@ -360,7 +360,8 @@ def test_a_multi_source_label_is_not_counted_as_coupling():
         "would reward removing multi-source support")
 
 
-def test_the_cron_writes_moved_rather_than_vanished():
+def test_the_cron_writes_moved_rather_than_vanished(
+        resolves_the_real_openclaw_binary):
     """The schedule writers are the reason this metric exists.
 
     The substring classifier missed them while reporting a falling number, so

--- a/tests/test_sync_cron_payloads.py
+++ b/tests/test_sync_cron_payloads.py
@@ -62,7 +62,8 @@ def test_exact_contract_is_an_idempotent_noop():
     assert errors == []
 
 
-def test_drift_plan_and_command_patch_only_declared_fields():
+def test_drift_plan_and_command_patch_only_declared_fields(
+        resolves_the_real_openclaw_binary):
     data = contract()
     live = live_from_contract(data)
     job = next(item for item in live if item["name"] == "美股盘中盯盘")
@@ -165,7 +166,8 @@ def test_running_changed_job_is_a_precondition_error():
     ]
 
 
-def test_apply_stops_at_first_failure_and_uses_argv():
+def test_apply_stops_at_first_failure_and_uses_argv(
+        resolves_the_real_openclaw_binary):
     changes = [
         {
             "id": "one",

--- a/tests/test_workflow_health.py
+++ b/tests/test_workflow_health.py
@@ -100,8 +100,24 @@ def test_only_scheduled_workflows_are_assessed():
     assert result["scheduled_workflows"] == len(calls)
 
 
-def test_the_rollup_never_fails_its_host_job(capsys):
-    assert wh.main(["--json"]) == 0 or True       # exit code is always 0 by contract
+def test_the_rollup_never_fails_its_host_job(capsys, monkeypatch):
+    """Exit 0 whatever the rollup found — and without asking GitHub.
+
+    This used to call `wh.main(["--json"])` bare, so every run of the unit suite
+    shelled out to `gh` once per tracked workflow and waited on the network:
+    18.1s on 2026-09-06, and an answer that depended on this host's `gh` auth and
+    on GitHub being up. The assertion never looked at the result (`== 0 or True`
+    cannot fail), so all of that bought nothing.
+
+    `report()` already takes a `runner`, which is the seam the rest of this
+    module tests through; `main` reaches it via the same provider. Feeding it a
+    canned failure is a stronger version of the same claim: the rollup returns 0
+    even when what it found is bad.
+    """
+    monkeypatch.setattr(wh, "fetch_runs",
+                        lambda workflow, limit=20, runner=None: [
+                            run("failure", 1), run("failure", 2)])
+    assert wh.main(["--json"]) == 0
     source = (ROOT / "ops" / "ci" / "workflow_health.py").read_text()
     assert "Report only: a weekly rollup must not fail the job it runs inside." in source
 


### PR DESCRIPTION
kcn：「看看测试速度能更快吗」。查下来最慢的那一批不是算得慢，是**在问外部服务**。

## 全套 343s → 196s（-43%），3344 passed

| | 改前 | 改后 |
|---|---:|---:|
| `test_brief_watchdog_retry_budget.py` | **39.4s** | **4.5s** |
| `test_workflow_health.py` | **18.1s** | **0.5s** |
| 全套（本机） | **343s** | **196s** |

## 但速度是小的那一半

**`test_brief_watchdog_retry_budget` 的 8 个测试，每个都去问了一次这台实盘主机的真实 cron。**

`alert_brief_missing` stub 了 `brief_cron_job_state`，但**还调了没被 stub 的
`brief_cron_job()`** → `cron_cli_json` → `subprocess.run(["openclaw","cron",...])`。
profile 出来 4.6s 里 4.61s 花在 `select.poll`：

```
1  0.000  4.631  tests/…/_alert_text
1  0.000  4.631  brief_watchdog.py:299(alert_brief_missing)
1  0.000  4.628  _watchdog_common.py:438(brief_cron_job)      ← 没被 stub
1  0.000  4.617  providers/openclaw.py:205(cron_cli_json)
4  4.610  4.610  {method 'poll' of 'select.poll' objects}
```

**CI 一毫秒都没付过**——runner 上没有 `openclaw`，调用立刻失败。所以这笔开销只存在于
**有运行时的那台机器**，而看着这套测试的任何东西都看不见它。
一个「答案取决于本机有没有健康运行时」的单元测试，对每个跑它的人含义都不一样。

`test_the_rollup_never_fails_its_host_job` 更直接：裸调 `wh.main(["--json"])`，
每次跑单元测试都对每个 workflow shell out 一次 `gh` 等网络，**而断言是
`assert wh.main(...) == 0 or True`——它不可能失败**。18 秒买了个零。

## 改法

`conftest.pytest_configure` 把 `CLAWOCK_OPENCLAW_BIN` 指到一个不可能存在的路径，
**在所有机器上复现 CI 的环境**。用的是**文档化的 override**，不是 patch 模块。

三个测试本身就是关于二进制路径的，通过 `resolves_the_real_openclaw_binary` 显式退出：
`providers.openclaw` 有**两种**说出运行时名字的方式——`OPENCLAW_BIN`（`shutil.which`
常量，对环境变量瞎）和 `runtime_paths().binary`（认环境变量）——那些测试拿前者去比
一个用了后者的调用。把 override 钉到常量上让两者**按构造相等**，这正是它们一直假设
却从没说出来的事。

`test_the_rollup_never_fails_its_host_job` 改成喂 `fetch_runs` 一个假的 failure 并断言
`== 0`——**比原来强**（原来那句断言不可能红），而且 0.5s。

## 验证

| 变异 | 结果 |
|---|---|
| `wh.main` 直接返回 1 | `test_the_rollup_never_fails_its_host_job` 红（**改前是绿的**）|

全套 **3344 passed, 5 skipped, 4 xfailed**，无新失败。**CI 侧零变化**——那边本来就是免费的；
变的是这套测试现在在两边含义相同。

## 还剩的慢项（没动，都是真在干活）

`test_clawock_launcher` 31.8s（建 venv 装包，module-scope 只付一次）、
`test_pr_publish_gate_contract` 18.3s（起真 git 仓跑真闸）、`test_regime_hmm` ~23s（walk-forward 计算）。
另：本机 `nproc=2`，`-n4` 并行早在 2026-08-22 测过只快 5-10%，没走这条路。

https://claude.ai/code/session_01HBSt6geARRtj3ypRnFXBZ1