### PR TITLE
tests: one name for the runtime, so the sentinel needs no exceptions

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -244,31 +244,17 @@ def pytest_configure(config):
     seam rather than patching the module. A test that genuinely wants the real
     binary sets the variable itself; `monkeypatch.setenv` inside a test wins over
     the value planted here.
+
+    This needed three tests to opt out when it first landed, which was the wrong
+    shape and is gone: they compared `OPENCLAW_BIN` — a `shutil.which` constant
+    computed at import and blind to the environment — against argv the code had
+    built from `runtime_paths().binary`, which honours it. Two names for one
+    runtime, agreeing only by luck, and the sentinel is simply what made the luck
+    run out. They now assert against the name the code actually used, and
+    `test_cron_live_state.test_one_name_for_the_runtime` keeps the two from
+    drifting apart again.
     """
     os.environ.setdefault("CLAWOCK_OPENCLAW_BIN", _NO_OPENCLAW_BINARY)
-
-
-@pytest.fixture
-def resolves_the_real_openclaw_binary(monkeypatch):
-    """Opt out of the sentinel above, for tests that are ABOUT the binary path.
-
-    `providers.openclaw` has two ways to name the runtime: `OPENCLAW_BIN`, a
-    module constant from `shutil.which` computed at import and blind to the
-    environment, and `runtime_paths().binary`, which honours
-    `CLAWOCK_OPENCLAW_BIN`. Tests that assert "the argv we built starts with the
-    binary" compare the first against a call that used the second, so planting a
-    sentinel in the environment makes them disagree about a thing neither is
-    really testing.
-
-    Pinning the override to the constant makes the two agree by construction,
-    which is what those tests always assumed and never said.
-    """
-    monkeypatch.setenv("CLAWOCK_OPENCLAW_BIN", _openclaw_module().OPENCLAW_BIN)
-
-
-def _openclaw_module():
-    from clawock.providers import openclaw  # noqa: PLC0415 - after sys.path setup
-    return openclaw
 
 
 def pytest_sessionstart(session):

--- a/tests/test_cron_live_state.py
+++ b/tests/test_cron_live_state.py
@@ -199,3 +199,41 @@ def test_timeline_returns_nonzero_when_live_state_is_empty(monkeypatch, capsys):
 
     assert timeline.main() == 2
     assert "no live CLI/SQLite state" in capsys.readouterr().err
+
+
+def test_one_name_for_the_runtime(monkeypatch):
+    """`OPENCLAW_BIN` and `runtime_paths().binary` must not disagree.
+
+    `providers.openclaw` names the runtime twice: `OPENCLAW_BIN` is a
+    `shutil.which` constant computed at import, and `runtime_paths().binary`
+    reads `CLAWOCK_OPENCLAW_BIN` on every call. Every production call site — the
+    two `cron_cli_json`/`run_cron_job` probes and `build_cron_edit_argv` — uses
+    the second. Nothing outside tests uses the first.
+
+    They agreed on the live box and on CI by coincidence: on the box both
+    resolve the same install, and on a runner with no runtime both fall back to
+    the bare name. So three tests asserted argv against the constant and passed
+    everywhere, right up until something set the documented override — at which
+    point the constant kept answering with a path the code had not used.
+
+    This is the assertion those three should have been making. It fails if the
+    constant ever becomes load-bearing again, or if a call site stops honouring
+    the override.
+    """
+    monkeypatch.setenv("CLAWOCK_OPENCLAW_BIN", "/opt/example/openclaw")
+
+    seen = []
+
+    class Result:
+        stdout = "{}"
+
+    provider.cron_cli_json(["list", "--json"],
+                           runner=lambda cmd: seen.append(cmd) or Result())
+    provider.run_cron_job("job-1", runner=lambda cmd: seen.append(cmd) or Result())
+    edit = provider.build_cron_edit_argv("job-1", {"enabled": True})
+
+    used = {argv[0] for argv in seen} | {edit[0]}
+    assert used == {"/opt/example/openclaw"}, (
+        f"a call site ignored CLAWOCK_OPENCLAW_BIN: {sorted(used)}")
+    assert provider.runtime_paths().binary == "/opt/example/openclaw"
+

--- a/tests/test_runtime_coupling_ratchet.py
+++ b/tests/test_runtime_coupling_ratchet.py
@@ -360,8 +360,7 @@ def test_a_multi_source_label_is_not_counted_as_coupling():
         "would reward removing multi-source support")
 
 
-def test_the_cron_writes_moved_rather_than_vanished(
-        resolves_the_real_openclaw_binary):
+def test_the_cron_writes_moved_rather_than_vanished():
     """The schedule writers are the reason this metric exists.
 
     The substring classifier missed them while reporting a falling number, so
@@ -389,7 +388,7 @@ def test_the_cron_writes_moved_rather_than_vanished(
     adapter = importlib.import_module("clawock.providers.openclaw")
     argv = adapter.build_cron_edit_argv(
         "job-id", {"schedule": {"expr": "0 8 * * 1-5", "tz": "Asia/Shanghai"}})
-    assert argv[0] == adapter.OPENCLAW_BIN
+    assert argv[0] == adapter.runtime_paths().binary
     assert argv[1:4] == ["cron", "edit", "job-id"]
     assert "--exact" in argv, (
         "a schedule edit must pin the slot exactly; a scheduler stagger is how "

--- a/tests/test_sync_cron_payloads.py
+++ b/tests/test_sync_cron_payloads.py
@@ -11,7 +11,7 @@ sys.path.insert(0, str(ROOT))
 
 from clawock import scheduling as cron_contract
 import sync_cron_payloads
-from clawock.providers.openclaw import OPENCLAW_BIN
+from clawock.providers.openclaw import runtime_paths
 
 
 JULY = datetime(2026, 7, 30, 0, tzinfo=timezone.utc)
@@ -62,8 +62,7 @@ def test_exact_contract_is_an_idempotent_noop():
     assert errors == []
 
 
-def test_drift_plan_and_command_patch_only_declared_fields(
-        resolves_the_real_openclaw_binary):
+def test_drift_plan_and_command_patch_only_declared_fields():
     data = contract()
     live = live_from_contract(data)
     job = next(item for item in live if item["name"] == "美股盘中盯盘")
@@ -81,7 +80,7 @@ def test_drift_plan_and_command_patch_only_declared_fields(
         "thinking", "fallbacks", "toolsAllow", "message"
     }
     command = sync_cron_payloads.build_edit_command(change)
-    assert command[0] == OPENCLAW_BIN
+    assert command[0] == runtime_paths().binary
     assert command[1:4] == ["cron", "edit", job["id"]]
     assert command[command.index("--thinking") + 1] == "adaptive"
     profile = data["payload_profiles"]["intraday"]
@@ -166,8 +165,7 @@ def test_running_changed_job_is_a_precondition_error():
     ]
 
 
-def test_apply_stops_at_first_failure_and_uses_argv(
-        resolves_the_real_openclaw_binary):
+def test_apply_stops_at_first_failure_and_uses_argv():
     changes = [
         {
             "id": "one",
@@ -194,7 +192,7 @@ def test_apply_stops_at_first_failure_and_uses_argv(
     # argv[0] is the absolute binary, not a bare name resolved off PATH (#330
     # step 2). The DST sync runs from crontab, where the bare form only works
     # because that entry happens to use a login shell.
-    assert calls[0][0][0] == OPENCLAW_BIN
+    assert calls[0][0][0] == runtime_paths().binary
     assert calls[0][0][1:4] == ["cron", "edit", "one"]
     assert "first" in errors[0]
     assert "boom" in errors[0]


### PR DESCRIPTION
kcn：「为什么要指不存在的路径？这样子符合测试预期吗？」——**问对了**。那三个「退出口」不是配置，是掩盖。

## 为什么它们需要退出口：`providers.openclaw` 给运行时起了两个名字

| | 怎么算的 | 认 `CLAWOCK_OPENCLAW_BIN` 吗 |
|---|---|---|
| `OPENCLAW_BIN` | `shutil.which("openclaw")`，**import 时算一次的常量** | **否** |
| `runtime_paths().binary` | 每次调用读环境 | **是** |

**生产代码全部用第二个**（`cron_cli_json:216`、`run_cron_job:249`、`build_cron_edit_argv:610`），
**测试之外没有任何东西用第一个**。

两者一直一致纯属巧合：本机上都解析到同一个安装；CI 上没有运行时，两者都退化成裸名 `openclaw`。
所以那三个测试**拿一个代码没用过的常量去比 argv，在任何人跑过的机器上都是绿的**——
直到有东西设了那个文档化的 override。

```
$ CLAWOCK_OPENCLAW_BIN=/opt/x/openclaw
OPENCLAW_BIN        = /root/.local/share/pnpm/openclaw
runtime_paths().bin = /opt/x/openclaw           ← 代码真正用的
```

## 改法：让断言指向代码真正用的那个名字

三处 `== OPENCLAW_BIN` → `== runtime_paths().binary`，**退出口 fixture 删掉**。

新增 `test_one_name_for_the_runtime`——**这才是那三个测试本来该做的断言**：
设了 override 之后，两个探针 + argv builder **必须都用它**。
把 `build_cron_edit_argv` 改回用常量，它当场红。

## 那么「为什么是不存在的路径」

因为**一个测试有权假设的环境，就是 CI 跑的那个环境**——那里根本没有运行时，
失败形态正是 `FileNotFoundError` 被 `cron_cli_json` 的 `except Exception` 吞成 `None`。
**复现那个状态才是目的**；换成一个会应答的 stub，等于发明了第三种没人真正部署的环境
（而且 `run_cron_job` 会把「stub 退出 0」读成「任务已排队」，那才是真的不符合预期）。

现在这条路上不再有例外，所以它也不用再靠运气。

**3345 passed。**

---

## 附：kcn 问的第二件事——GitHub Actions 的核数

`ubuntu-latest` + 仓库是 public ⇒ **4 vCPU**（private 才是 2）。`validate` 里
**pytest 占 241s / 全 job 279s**，所以并行确实是那一格唯一值得动的地方。

但仓里已经量过并把结论写进了测试
（`test_import_layering.py::test_the_write_guard_has_no_position_in_the_collection_order`）：

> `-n 4` does pass, three runs at 175/182/191s against ~195s serial: **5-10%, not 3x**.
> The top twelve tests … every one of them is subprocess-bound. So xdist stays off:
> a few percent is not worth a flake class.

**那个测量现在过时了**，因为 #1362 把 openclaw/gh 的等待删掉了，profile 变了。本机重测（2 核）：

| | 时间 |
|---|---|
| 串行（#1362 之后） | **198.0s** |
| `-n 2`（#1362 之后） | **158.9s** ← -20% |
| `-n 2`（#1362 之前） | 243s（vs 串行 343s） |

**但那个 flake class 是真的**：同样的 `-n 2`，在 #1362 之前那次
`test_the_write_guard_has_no_position_in_the_collection_order` **红了**，之后这次绿了——
`_WRITE_LOG` 在 xdist 下是每 worker 一份，写它的测试和断言它的测试可能落在不同 worker。

所以 CI 开 `-n 4` 大概能把那 241s 砍掉三到四成，**但要先把那条测试在 xdist 下的行为修好**
（让它在 `workerinput` 存在时 skip），否则买来的是随机红。要我接着做这一步吗？

https://claude.ai/code/session_01HBSt6geARRtj3ypRnFXBZ1