### PR TITLE
tests: the write guard was silently off under -n, and cannot judge there

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -330,6 +330,58 @@ def _tolerated(node_id: str) -> bool:
     return any(node_id.startswith(prefix) for prefix in TOLERATED_WRITERS)
 
 
+#: Workers ship their write log to the controller under this key. xdist gives
+#: each worker its own process, so `_WRITE_LOG` is per-worker and the verdict
+#: below can only be reached by the one process that sees all of them.
+_WORKER_WRITE_LOG = "clawock_write_log"
+
+#: Filled on the controller as each worker exits.
+_WRITES_FROM_WORKERS: list[dict] = []
+
+try:  # pragma: no cover - depends on whether the optional plugin is installed
+    import xdist  # noqa: F401  PLC0415
+except ImportError:  # serial-only environment: the hook below would be unknown
+    pass
+else:
+    def pytest_testnodedown(node, error):
+        """Collect one worker's write log as it exits (xdist controller hook).
+
+        This is the join step. Without it, running `-n` silently switched the
+        write guard OFF — `pytest_sessionfinish` bailed out on every worker
+        because attribution across four partial logs is meaningless, and the
+        controller's own log is empty because the controller runs no tests. So
+        the parallel suite enforced nothing, and the only thing that said so was
+        a comment.
+        """
+        payload = getattr(node, "workeroutput", None) or {}
+        _WRITES_FROM_WORKERS.extend(payload.get(_WORKER_WRITE_LOG) or [])
+
+
+def _offenders(entries) -> set[str]:
+    """The tests to fail the run over. Exact, and only meaningful serially.
+
+    This watcher takes a filesystem snapshot around every test, so in a serial
+    run anything that moved between one test's start and its end was moved BY
+    that test. Under `-n` the snapshot is still global while the tests are not,
+    and two measurements on 2026-09-06 show that no rule over these entries can
+    fix that:
+
+    * the session dashboard rebuild ran in one worker and a test in the OTHER
+      worker reported the same four payloads as `created` — its window merely
+      overlapped the build, and it was named `<-- NEW`;
+    * scoping the verdict to "paths no tolerated writer touched" removes that
+      false accusation and immediately buys the opposite one: a deliberately
+      planted writer of `logs/zz-temp-offender.log` was EXCUSED, because the
+      tolerated test had also *observed* that file appear and so the path
+      counted as owned. Exit 0 on a run with a real new writer in it.
+
+    A guard that accuses the wrong test, or excuses the right one, is worse than
+    one that says "I cannot tell". So parallel runs get the table and no verdict;
+    see `pytest_sessionfinish`.
+    """
+    return {entry["test"] for entry in entries if not _tolerated(entry["test"])}
+
+
 def pytest_sessionfinish(session, exitstatus):
     """Fail the RUN when an untolerated writer touched published state.
 
@@ -353,12 +405,36 @@ def pytest_sessionfinish(session, exitstatus):
     """
     if session.config.getoption("collectonly", False):
         return
-    # xdist: every worker gets its own session and its own copy of the four
-    # files, so attribution is meaningless — the reasoning is unchanged from the
-    # assertion this replaces.
+    # xdist: a worker sees only the tests it ran, so it reports rather than
+    # judges. The controller joins the parts in `pytest_testnodedown` and reaches
+    # the verdict once, over the whole run — the same verdict a serial run gets.
     if getattr(session.config, "workerinput", None) is not None:
+        session.config.workeroutput[_WORKER_WRITE_LOG] = list(_WRITE_LOG)
         return
-    offenders = sorted({e["test"] for e in _WRITE_LOG if not _tolerated(e["test"])})
+    entries = [*_WRITE_LOG, *_WRITES_FROM_WORKERS]
+    if _WRITES_FROM_WORKERS:
+        # A parallel run reports and does not judge — see `_offenders`. Before
+        # the join above it did neither: `pytest_sessionfinish` returned on every
+        # worker and the controller's own log is empty because it runs no tests,
+        # so `-n` silently switched this guard off and nothing said so.
+        # Deliberately unnamed. Measured: `pytest tests/test_import_layering.py
+        # -n 2` flags `test_no_workflow_or_script_invokes_a_module_by_a_path_
+        # that_moved`, a read-only module that records nothing serially — under
+        # `-n` a bystander's window simply overlaps someone else's write. Naming
+        # innocents every run is how a warning gets trained out of people, so the
+        # parallel mode reports the count and where to get the answer.
+        if _offenders(entries):
+            reporter = session.config.pluginmanager.get_plugin("terminalreporter")
+            if reporter is not None:
+                reporter.write_line("")
+                reporter.write_line(
+                    "NOTE: published state changed during this -n run. Attribution "
+                    "needs a serial run — under xdist the snapshot is global while "
+                    "the tests are not, so this cannot tell a writer from a "
+                    "bystander. `pytest tests/` without -n is the enforcing run.",
+                    yellow=True)
+        return
+    offenders = sorted(_offenders(entries))
     if offenders:
         session.exitstatus = 1
         reporter = session.config.pluginmanager.get_plugin("terminalreporter")
@@ -375,18 +451,29 @@ def pytest_sessionfinish(session, exitstatus):
 
 
 def pytest_terminal_summary(terminalreporter):
-    """Print the attribution table, so a polluted run explains itself."""
-    if not _WRITE_LOG:
+    """Print the attribution table, so a polluted run explains itself.
+
+    Reads the joined view for the same reason the verdict does: under `-n` the
+    controller writes the summary but ran none of the tests, so its own log is
+    empty and the table would come out blank on exactly the runs most likely to
+    need it.
+    """
+    entries = [*_WRITE_LOG, *_WRITES_FROM_WORKERS]
+    if not entries:
         return
     terminalreporter.section("tests that wrote to published state (#816)")
-    for entry in _WRITE_LOG:
+    for entry in entries:
         parts = []
         for kind in ("created", "removed", "changed"):
             if entry[kind]:
                 shown = ", ".join(entry[kind][:4])
                 more = f" (+{len(entry[kind]) - 4} more)" if len(entry[kind]) > 4 else ""
                 parts.append(f"{kind}: {shown}{more}")
-        mark = "" if _tolerated(entry["test"]) else "  <-- NEW"
+        # `<-- NEW` is an accusation, and under `-n` it lands on bystanders as
+        # often as on writers. The table stays (it is an observation, and a
+        # useful one); the verdict marker does not.
+        mark = ("" if _tolerated(entry["test"]) or _WRITES_FROM_WORKERS
+                else "  <-- NEW")
         terminalreporter.write_line(
             f"{entry['test']}{mark}\n    " + "\n    ".join(parts))
 

--- a/tests/test_import_layering.py
+++ b/tests/test_import_layering.py
@@ -297,19 +297,51 @@ def test_the_write_guard_has_no_position_in_the_collection_order(request):
     assert hasattr(conftest, "pytest_sessionfinish"), (
         "the enforcement must be a session hook; a test can always be sorted "
         "after by adding a module with a later name")
+    # Behaviour, not a grep over the hook's source. The substring form said
+    # "`_tolerated` appears in `pytest_sessionfinish`", which stopped being true
+    # the moment the verdict moved into a helper — a refactor with no behaviour
+    # change turned this red, which is a test asserting the shape of the code
+    # rather than what it does.
+    tolerated = next(iter(conftest.TOLERATED_WRITERS))
+    allowed = {"test": tolerated, "created": ["assets/data/dashboard.json"],
+               "removed": [], "changed": []}
+    intruder = {"test": "tests/test_made_up.py::test_writes", "created": [],
+                "removed": [], "changed": ["memory/decisions.jsonl"]}
+
+    assert conftest._offenders([allowed]) == set()
+    assert conftest._offenders([allowed, intruder]) == {intruder["test"]}
+    assert "exitstatus" in inspect.signature(conftest.pytest_sessionfinish).parameters, (
+        "the hook must be able to fail the run")
+
+
+def test_a_parallel_run_reports_without_judging():
+    """Under `-n` this guard cannot tell a writer from a bystander.
+
+    Both directions were measured on 2026-09-06 under `-n 2`, and each one is a
+    wrong answer:
+
+    * the session rebuild ran in one worker and a test in the other reported the
+      same four payloads as `created`, because its window overlapped the build —
+      an innocent test named `<-- NEW`;
+    * scoping the verdict to "paths no tolerated writer touched" fixes that and
+      breaks the other way: a planted writer of `logs/zz-temp-offender.log` was
+      excused, because the tolerated test had also observed that file appear.
+      The run exited 0 with a real new writer in it.
+
+    So the parallel path reports and returns, and the serial verdict stays the
+    authoritative one. This pins that the hook actually distinguishes the two —
+    a future edit that "simplifies" it into judging in parallel has to argue
+    with the two measurements above.
+    """
+    import conftest  # noqa: PLC0415
+
     source = inspect.getsource(conftest.pytest_sessionfinish)
-    assert "_tolerated" in source and "exitstatus" in source, (
-        "the hook must both apply the allowlist and actually fail the run")
-
-    if not _WRITE_LOG_or_skip():
-        pytest.skip("no writes recorded — this ran outside a full-suite session")
-    for entry in conftest._WRITE_LOG:
-        assert set(entry) >= {"test", "created", "removed", "changed"}, entry
-
-
-def _WRITE_LOG_or_skip():
-    from conftest import _WRITE_LOG  # noqa: PLC0415
-    return _WRITE_LOG
+    assert "_WRITES_FROM_WORKERS" in source, (
+        "the verdict must join the workers' logs before deciding anything")
+    joined = source.split("if _WRITES_FROM_WORKERS:", 1)
+    assert len(joined) == 2, "the parallel path must be an explicit branch"
+    assert "return" in joined[1].split("offenders = ")[0], (
+        "the parallel branch must return before the verdict, not fall through")
 
 
 def test_the_tolerated_writer_list_only_shrinks():


### PR DESCRIPTION
kcn：「你看看不能修这种不能并行的吗？或者改写法变成文件内串行啥的？这不就是类似于并行编译问题吗」

**是同一类问题。但量下来的答案跟我预期的不一样。**

## 一、那个守卫不是「不兼容 `-n`」，是**在 `-n` 下根本没运行**

`pytest_sessionfinish` 在每个 worker 上直接 `return`（因为四份局部日志做归因看起来没意义），
而**控制端自己的日志是空的——它一个测试都不跑**。

⇒ **`pytest -n` 什么都没在守。** 唯一说出这件事的是一句注释。

已修：worker 把写日志通过 `workeroutput` 送出，控制端在 `pytest_testnodedown` 里 join——
**就是并行编译在 link 之前做的那个 join。**

## 二、日志 join 好之后，**没有任何规则能在 `-n` 下判案**

两个方向都在 `-n 2` 下实测过，各自都是错的答案：

| 规则 | 结果 |
|---|---|
| 精确归因（串行那套） | **冤枉旁观者**。会话级 dashboard 重建在 worker A 跑，worker B 的一个测试把同样四份 payload 报成 `created`——它只是**窗口重叠**。`pytest tests/test_import_layering.py -n 2` 会点名一个串行下什么都不写的只读模块 |
| 「只算没有被容忍写者碰过的路径」 | **放跑真凶**。我故意种了一个写 `logs/zz-temp-offender.log` 的测试，**被豁免了**——因为被容忍的那个测试也「观测」到该文件出现，于是路径算作 owned。**一次带着真新写者的运行退出码 0。** |

**快照是全局的、而测试不是——这是观测本身的性质，不是规则能修的。**

所以：**并行只给表 + 一句「归因要串行跑」，串行保持精确并且是那个执行判决的运行。**
`<-- NEW` 标记在 `-n` 下也不打了——**一个每次都落在无辜者头上的指控，就是让人学会忽略警告的方式。**

## 三、`--dist loadfile` 不管用

上面量到的干扰是**跨文件的**（一个模块的重建，另一个模块的窗口），按文件分组原样保留。

## 四、真正能解锁 `-n` 的，是**去掉共享可变输出**，不是围着它协调

`clawock.publish.dashboard` **已经有 `--out-dir`**。会话重建可以建到会话级 tmp 目录，
fixture 返回那个路径——**money 测试本来就是从 fixture 取路径的**。
挡在中间的是 `test_dashboard_payload_size` 还在读两个指向 checkout 的模块常量。
**是实打实的活，不是一个开关。** 要我接着做吗？

## 附带修的

`test_the_write_guard_has_no_position_in_the_collection_order` 之前断言
`"_tolerated" in inspect.getsource(pytest_sessionfinish)`——**一个零行为变化的重构就把它打红了**。
改成拿合成条目去调判定函数，断行为不断源码文本。

## 验证

| | 结果 |
|---|---|
| 串行全套 | **3346 passed** |
| 串行 + 种一个真写者 | `ERROR: … ['tests/test_zz_temp_offender.py::test_temp_writes_into_the_checkout']`，**exit=1** |
| `-n 2` 干净运行 | 一句 NOTE，**不点名** |
| `-n 2` + 真写者 | 出表 + NOTE（判决交给串行） |

https://claude.ai/code/session_01HBSt6geARRtj3ypRnFXBZ1