### PR TITLE
ci: two jobs waited for the whole test suite to read one boolean

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -655,25 +655,43 @@ jobs:
   smoke-data-fetch:
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    needs: validate
-    # Only worth a runner when code changed: a docs-only PR used to pay a full
-    # pip install plus two live FX providers for a probe that cannot be about
-    # the docs. The lane answer comes from validate's detector via its job
-    # output, so no second checkout is spent deciding this.
-    if: needs.validate.outputs.code == 'true'
+    # Only worth the work when code changed: a docs-only PR should not pay a pip
+    # install plus two live FX providers for a probe that cannot be about the
+    # docs. That lane used to be read from `validate`'s job output, which meant
+    # waiting for all of validate to learn it — so the decision is made here now,
+    # by the same one-second script, and the steps below carry the gate instead
+    # of the job.
     continue-on-error: true  # data sources can be flaky; don't fail the pipeline
     steps:
       - uses: actions/checkout@v7
 
+      # The lane, decided here rather than inherited from `validate`. It used to
+      # arrive as `needs.validate.outputs.code`, which cost this job the WHOLE of
+      # validate before it could start: 170s of waiting for a boolean that a 1s
+      # step produces. Measured 2026-09-06 on run 34020103495 — validate 170s,
+      # this job 41s, wall clock 217s, and the two were in series for no reason
+      # but where the value happened to live.
+      - name: Detect code changes
+        id: changes
+        env:
+          BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+          HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+        run: |
+          python3 ops/ci/push_scope.py --base "$BASE_SHA" --head "$HEAD_SHA" \
+            | tee -a "$GITHUB_OUTPUT"
+
       - name: Set up clawock (Python)
+        if: steps.changes.outputs.code == 'true'
         uses: ./.github/actions/clawock-python
 
       - name: FX fallback chain
+        if: steps.changes.outputs.code == 'true'
         run: python3 ops/ci/smoke_fx.py
 
       # Answers the question #1237 left open: the replacement Reddit endpoint
       # was verified from the project VPS, and the producer runs here.
       - name: Reddit search feed reachability
+        if: steps.changes.outputs.code == 'true'
         run: python3 ops/ci/smoke_reddit.py
 
   portable-workflow:
@@ -694,12 +712,51 @@ jobs:
     # rewrites the "Run it on your own book" block must still face it. ~40s.
     runs-on: ubuntu-latest
     timeout-minutes: 8
-    needs: validate
-    if: >-
-      ${{ github.event_name == 'pull_request'
-          || needs.validate.outputs.code == 'true' }}
     steps:
       - uses: actions/checkout@v7
+
+      # The lane, decided here rather than inherited from `validate`. It used to
+      # arrive as `needs.validate.outputs.code`, which cost this job the WHOLE of
+      # validate before it could start: 170s of waiting for a boolean that a 1s
+      # step produces. Measured 2026-09-06 on run 34020103495 — validate 170s,
+      # this job 41s, wall clock 217s, and the two were in series for no reason
+      # but where the value happened to live.
+      - name: Detect code changes
+        id: changes
+        env:
+          BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+          HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+        run: |
+          python3 ops/ci/push_scope.py --base "$BASE_SHA" --head "$HEAD_SHA" \
+            | tee -a "$GITHUB_OUTPUT"
+        # A pull request runs this job regardless — see the paragraph above — so
+        # the lane only decides the push case. Reading it from `validate`'s
+        # output made every PR wait 170s for an answer it was not going to use.
+
+      # Derived in its own step rather than written into each gate below,
+      # because `test_the_heavy_lanes_are_not_gated_on_the_event_that_started
+      # _the_run` forbids `github.event_name` inside a `steps.changes.outputs.*`
+      # condition — and it is right to. That is the #750 shape: those gates read
+      # `event_name == 'pull_request' && changes...` while the detector itself
+      # was PR-only, so on a master push the detector was skipped, the ANDs went
+      # false, and the two most expensive gates in the repository never ran
+      # outside a PR.
+      #
+      # This is the opposite direction — an OR that makes the job run MORE, over
+      # a detector that runs on every event — but a rule that has to be reasoned
+      # about at each call site is a rule that gets it wrong once. So the event
+      # is folded in here, once, and the gates below read one boolean.
+      - name: Lane for this job
+        id: lane
+        env:
+          CODE: ${{ steps.changes.outputs.code }}
+          EVENT: ${{ github.event_name }}
+        run: |
+          if [ "$EVENT" = "pull_request" ] || [ "$CODE" = "true" ]; then
+            echo "run=true" | tee -a "$GITHUB_OUTPUT"
+          else
+            echo "run=false" | tee -a "$GITHUB_OUTPUT"
+          fi
 
       # Same install as release.yml's build job — `build` is declared in the
       # `release` extra, not hand-written here (tests/test_workspace_portability
@@ -708,17 +765,21 @@ jobs:
       # their own virtualenv and assert that the `clawock` they import came
       # from it, so this cannot be what makes them pass.
       - name: Set up clawock (Python)
+        if: steps.lane.outputs.run == 'true'
         uses: ./.github/actions/clawock-python
         with:
           install: '.[release]'
 
       - name: Build the wheel under test
+        if: steps.lane.outputs.run == 'true'
         run: python -m build --wheel --outdir dist
 
       - name: Foreign workspace publishes a real decision.json
+        if: steps.lane.outputs.run == 'true'
         run: examples/cli/workflow-run/run.sh dist/*.whl
 
       - name: Isolated install completes one base run
+        if: steps.lane.outputs.run == 'true'
         # The release-time check, moved forward to the PR that would break it.
         run: examples/cli/minimal-run/run.sh dist/*.whl
 

--- a/tests/test_ci_consolidation_contract.py
+++ b/tests/test_ci_consolidation_contract.py
@@ -59,11 +59,44 @@ def test_prs_are_never_cancelled_and_master_never_is():
         "part of the ledger and never are")
 
 
-def test_smoke_data_fetch_only_boots_for_code_changes():
-    """A docs-only PR used to pay a full pip install plus two live FX providers."""
-    job = TEXT.split("\n  smoke-data-fetch:", 1)[1].split("\n  analyze:", 1)[0]
-    assert "needs: validate" in job
-    assert "if: needs.validate.outputs.code == 'true'" in job
+def _job(name):
+    rest = TEXT.split(f"\n  {name}:", 1)[1]
+    return rest.split("\n  analyze:", 1)[0].split("\n  portable-workflow:", 1)[0]
+
+
+def test_smoke_data_fetch_does_no_work_for_a_docs_only_change():
+    """A docs-only PR must not pay a pip install plus two live FX providers.
+
+    Asserted on the steps rather than on the job's `needs:`. The gate used to be
+    `if: needs.validate.outputs.code == 'true'` at job level, which bought this
+    property by making the job wait for ALL of validate — 170s for a boolean a
+    1s script produces (measured on run 34020103495). The lane is decided in the
+    job now; what must not come back is the work happening on a docs-only PR.
+    """
+    job = _job("smoke-data-fetch")
+    assert "python3 ops/ci/push_scope.py" in job, (
+        "the job must decide its own lane rather than waiting for validate's")
+    for step in ("clawock-python", "smoke_fx.py", "smoke_reddit.py"):
+        head = job.split(step, 1)[0]
+        assert "steps.changes.outputs.code == 'true'" in head.rsplit("- name:", 1)[-1], (
+            f"{step} runs without the code-lane gate; a docs-only PR pays for it")
+
+
+def test_nothing_waits_for_validate_just_to_read_its_lane():
+    """The two lane-gated jobs run beside validate, not after it.
+
+    `needs: validate` on a job that only reads `needs.validate.outputs.code` puts
+    the whole test suite on its critical path for a value that is available in a
+    second. Run 34020103495: validate 170s, portable-workflow 41s, wall 217s,
+    with the 41s starting only when the 170s finished.
+    """
+    for name in ("smoke-data-fetch", "portable-workflow"):
+        job = _job(name)
+        assert "needs: validate" not in job, (
+            f"{name} is serialised behind the whole test suite to read one boolean")
+    # The one that genuinely consumes validate's artifact keeps its edge.
+    assert "needs: validate" in _job("publish-coverage"), (
+        "publish-coverage downloads coverage-report.json and must not outlive it")
 
 
 def test_coverage_publish_chain_reads_the_lane_that_produces_the_artifact():


### PR DESCRIPTION
kcn：「你看看 ci 整个有没有优化的空间，链路好长」——量了一遍，长的不是活，是**串行**。

## 现状（run 34020103495，code PR，浏览器 lane 关着）

```
wall                217s
  validate          170s   t=0 开始
  portable-workflow  41s   等 validate 跑完才开始  ←
  smoke-data-fetch   17s   同上                    ←
  Analyze × 3       ~50s   与 validate 并行
  lint                6s
```

`smoke-data-fetch` 和 `portable-workflow` 都写着 `needs: validate`，
而它们从 validate 拿的**只有一样东西**：`needs.validate.outputs.code` ——
`ops/ci/push_scope.py` 一秒就能算出来的 lane 布尔值。

**整套测试挂在它们的关键路径上，只为了递一个布尔。**

而 `portable-workflow` 在 PR 上**根本用不到它**：条件是 `pull_request || code == 'true'`，
所以每个 PR 都在等一个自己不会用的值等 170 秒。

## 改法

两个 job 各自跑那个一秒的探测器，**闸从 job 移到 step**。
**什么时候跑什么，一点没变**：docs-only PR 照样不装 pip、不叫 FX provider。

`portable-workflow` 把 event 折进一个 `lane` step，而不是把
`event_name == 'pull_request' || steps.changes.outputs.code` 写进每个闸——
因为 `test_the_heavy_lanes_are_not_gated_on_the_event_that_started_the_run`
**明确禁止**这种写法，而且它是对的：#750 就是 `event_name && changes…` 配一个 PR-only 探测器，
结果**仓里最贵的两个闸在 master push 上永远跑不到**。这次是反方向（OR，且探测器每个 event 都跑），
但**一条需要在每个调用点重新推理的规则，总有一次会推错**，所以 event 只折一次，下面的闸读一个布尔。

`publish-coverage` 的边留着 —— 它下载 `coverage-report.json`，缺了会死在 download-artifact。
**那是对产物的依赖，不是对一个标志的依赖。**

## 顺带：一条钉了接线而不是性质的测试

`test_smoke_data_fetch_only_boots_for_code_changes` 断言的是
`assert "needs: validate" in job` —— **一个保持了它所声称行为的改动把它打红了**。
改成断言那些昂贵的 step 带着 lane 闸，并新增
`test_nothing_waits_for_validate_just_to_read_its_lane` 钉住「不许再串回去」。

| 变异 | 结果 |
|---|---|
| 把 `needs: validate` 加回 smoke-data-fetch | `test_nothing_waits_…` 红 |
| 去掉 `smoke_fx` 的 lane 闸 | `test_smoke_data_fetch_does_no_work…` 红 |

## 预期

wall **217s → ~180s**。**这个 PR 自己的运行就是那次测量。**

（另外量过、没动的：`Set up clawock (Python)` 14s 已经有 pip 缓存（键在 pyproject.toml，
我上个 PR 改了它所以那次是冷的）；`Analyze × 3` 和 `lint` 本来就并行、不在关键路径上；
validate 里除 pytest 外所有 step 加起来 < 35s。）

https://claude.ai/code/session_01HBSt6geARRtj3ypRnFXBZ1