### PR TITLE
weekly review: three 180s attempts inside a 360s budget lost two ISO weeks

### DIFF
--- a/.github/workflows/weekly-review.yml
+++ b/.github/workflows/weekly-review.yml
@@ -13,7 +13,9 @@ concurrency:
 jobs:
   review:
     runs-on: ubuntu-latest
-    timeout-minutes: 12
+    # 15, not 12: the chain deadline below is 700s and the contract test wants a
+    # minute of slack after it for setup, validation and the commit.
+    timeout-minutes: 15
     permissions:
       contents: write
     steps:
@@ -30,11 +32,16 @@ jobs:
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
           MINIMAX_API_KEY: ${{ secrets.MINIMAX_API_KEY }}
           # Chain deadline (brief-fallback 2026-08-17 defect class): without it
-          # a hung primary burns timeout(180)x3 per provider inside a 12-minute
-          # job and the fallback is unreachable. 600s of 720s leaves the
-          # validate + commit steps their share; the review prose fits both
-          # legs at that size.
-          CLAWOCK_LLM_DEADLINE_SECONDS: '600'
+          # a hung primary burns timeout x MAX_RETRIES per provider inside the
+          # job and the fallback is unreachable.
+          #
+          # 700, not 600: the primary's share is PRIMARY_BUDGET_SHARE (0.6) of
+          # this, and that share has to cover ONE full-length generation --
+          # 32000 max_tokens at the slowest throughput measured on the eight
+          # scheduled runs 2026-07-12..08-30 (87 tok/s) is 368s. At 600 the
+          # share was 360s, i.e. under a run this job is expected to produce.
+          # 700 of 900 still leaves the validate + commit steps their share.
+          CLAWOCK_LLM_DEADLINE_SECONDS: '700'
         run: clawock-weekly-review
 
       - name: Validate generated review

--- a/src/clawock/automation/news_digest.py
+++ b/src/clawock/automation/news_digest.py
@@ -39,6 +39,11 @@ DIGEST_REQUIRED_SECTIONS = ('移动信号', 'Per-ticker')
 # inventing around it.
 NEWS_PROMPT_BUDGET_CHARS = 25_000
 
+# Per-attempt seconds for this job's one generation. See the call site in
+# main() for why it must not be smaller than the primary's share of the chain
+# deadline; tests/test_llm_workflow_deadlines.py enforces it for every LLM job.
+NEWS_DIGEST_LLM_TIMEOUT_SECONDS = 300
+
 
 def _compact(value):
     return json.dumps(value, ensure_ascii=False, separators=(',', ':'))
@@ -271,7 +276,13 @@ def main():
     user = build_user_prompt(news_payload, held_via)
 
     # News digest: short output but enable thinking helps prioritize signal vs noise
-    digest = chat(system=system, user=user, max_tokens=32000, temperature=0.5)
+    # timeout, not the 180s default: the chain deadline this workflow sets gives
+    # the primary 0.6 x 360 = 216s, and a per-attempt slice smaller than that
+    # share cannot be finished by adding attempts -- it just spends the share on
+    # copies of the same doomed call. That is how the weekly review lost
+    # 2026-W33 and 2026-W35. Clamped down to the share by _attempt_timeout.
+    digest = chat(system=system, user=user, max_tokens=32000, temperature=0.5,
+                  timeout=NEWS_DIGEST_LLM_TIMEOUT_SECONDS)
     # Refuse before the artifact is written (#1264): us_news_digest.json is
     # read by the brief and by news_evidence_graph, both of which treat an
     # empty digest_markdown as "no news" rather than "the model failed".

--- a/src/clawock/automation/weekly_review.py
+++ b/src/clawock/automation/weekly_review.py
@@ -35,6 +35,29 @@ WEEKLY_REQUIRED_SECTIONS = ('本周净值', '决策兑现', '风险演变', '下
 # and declare what was dropped.
 PROMPT_BUDGET_CHARS = 200_000
 
+# Per-attempt seconds for the one generation this job makes.
+#
+# The default (llm.TIMEOUT, 180s) dropped two weeks of review: 2026-W33
+# (run 31952091127) and 2026-W35 (run 33326401496) both died as three
+# consecutive `timeout after 180s` on the primary, and both fallbacks were dead
+# at the time (Xiaomi 401 invalid key / opencode 401 CreditsError), so the whole
+# chain failed and no file was written. Nothing re-runs a scheduled workflow, so
+# an ISO week is simply missing from memory/weekly/ forever.
+#
+# The generation genuinely takes that long. Measured across the eight scheduled
+# runs 2026-07-12..08-30 (`gh run view <id> --log`): 100.6s / 117.5s / 122.8s /
+# 133.2s / 155.6s / 179.5s succeeded, twice it went past 180s. Output is
+# 8.8K-17.6K tokens at 87-150 tok/s, so a full-length answer at the slow end of
+# the observed throughput is 32000 / 87 = 368s.
+#
+# 180 was not too small because the budget was small — the chain deadline gives
+# the primary 0.6 x 700 = 420s. It was too small because a per-attempt timeout
+# below the primary's own share slices that share into pieces, and a generation
+# that needs more than one piece can never finish however many pieces are left:
+# three doomed 180s attempts spend the entire budget. Keep this >= the primary
+# share (tests/test_llm_workflow_deadlines.py enforces it for every LLM job).
+WEEKLY_LLM_TIMEOUT_SECONDS = 420
+
 # Machine-owned fields on decision / episode records that no review question
 # consumes; the harness already distills them into decision_episodes /
 # decision_metrics. signal_provenance alone was ~76% of the decisions bytes in
@@ -457,7 +480,8 @@ def main():
     user = build_user_prompt(payload)
 
     # Weekly review benefits most from thinking + depth (1 turn, complex synthesis)
-    out = chat(system=system, user=user, max_tokens=32000, temperature=0.6)
+    out = chat(system=system, user=user, max_tokens=32000, temperature=0.6,
+               timeout=WEEKLY_LLM_TIMEOUT_SECONDS)
     # Refuse before writing (#1263): a blank or off-prompt reply used to be
     # published as that week's review, and nothing downstream re-reads it.
     # Anchors are the four questions build_user_prompt asks for; the floor is

--- a/tests/test_llm_workflow_deadlines.py
+++ b/tests/test_llm_workflow_deadlines.py
@@ -9,10 +9,14 @@ new workflow cannot forget.
 """
 from __future__ import annotations
 
+import ast
+import importlib
 from pathlib import Path
 
 import pytest
 import yaml
+
+from clawock.automation import llm
 
 ROOT = Path(__file__).resolve().parents[1]
 DEADLINE_KEY = "CLAWOCK_LLM_DEADLINE_SECONDS"
@@ -25,9 +29,70 @@ DEADLINE_KEY = "CLAWOCK_LLM_DEADLINE_SECONDS"
 LLM_JOBS = [
     ("brief-fallback.yml", "fallback", 1),
     ("news-digest.yml", "digest", 1),
-    ("influencer-scan.yml", "scan", 1),
+    # 2, not 1: score_items() wraps its chat() in `for attempt in (1, 2)` and
+    # retries an empty batch, so one run can open two chains back to back. The
+    # table used to say 1 and read "two dispatch invocations, one chain per
+    # RUN" -- which is about the schedule, not about this loop.
+    ("influencer-scan.yml", "scan", 2),
     ("weekly-review.yml", "review", 1),
 ]
+
+# Where each job enters the provider chain. The timeout is read from the call
+# site itself, not from this table -- the table only says which file to open.
+CALL_SITES = {
+    ("brief-fallback.yml", "fallback"): "src/clawock/automation/brief_fallback.py",
+    ("news-digest.yml", "digest"): "src/clawock/automation/news_digest.py",
+    ("influencer-scan.yml", "scan"): "src/clawock/automation/influencer.py",
+    ("weekly-review.yml", "review"): "src/clawock/automation/weekly_review.py",
+}
+
+# llm.py calls chat() in its own `__main__` sanity CLI; that one runs by hand,
+# not on a schedule, so it has no workflow to fit inside.
+CHAT_CALL_EXEMPT = {"src/clawock/automation/llm.py"}
+
+
+def _chat_calls(path: Path):
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    return [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and getattr(node.func, "id", None) == "chat"
+    ]
+
+
+def _call_site_timeout(rel_path: str) -> float:
+    """The per-attempt seconds the caller in `rel_path` actually asks for.
+
+    A call site that passes no `timeout=` gets llm.TIMEOUT, so that is what the
+    invariant has to be measured against -- the defect this file guards was an
+    omission, and an omission has a value.
+    """
+    path = ROOT / rel_path
+    calls = _chat_calls(path)
+    assert calls, f"{rel_path}: no chat() call site found"
+    seen = set()
+    for call in calls:
+        kwarg = next((k for k in call.keywords if k.arg == "timeout"), None)
+        if kwarg is None:
+            seen.add(float(llm.TIMEOUT))
+            continue
+        node = kwarg.value
+        if isinstance(node, ast.Constant):
+            seen.add(float(node.value))
+        elif isinstance(node, ast.Name):
+            module = importlib.import_module(
+                rel_path.removeprefix("src/").removesuffix(".py").replace("/", ".")
+            )
+            value = getattr(module, node.id, None)
+            assert isinstance(value, (int, float)), (
+                f"{rel_path}: chat(timeout={node.id}) is not a module-level "
+                f"number the contract can read"
+            )
+            seen.add(float(value))
+        else:  # pragma: no cover - keeps the failure legible if one appears
+            pytest.fail(f"{rel_path}: chat(timeout=...) is not a literal or a name")
+    assert len(seen) == 1, f"{rel_path}: chat() call sites disagree on timeout: {seen}"
+    return seen.pop()
 
 
 def _workflow(name):
@@ -64,4 +129,46 @@ def test_the_provider_chain_fits_inside_the_job(workflow_name, job_id, chains):
     assert job_seconds - budget >= 60, (
         f"{workflow_name}: setup, validation and commit still have to fit in "
         f"what is left of the job"
+    )
+
+
+def test_every_chat_call_site_belongs_to_a_declared_job():
+    """A new caller must join the table above, not inherit the 180s default.
+
+    The two tests below only cover what CALL_SITES lists, so without this the
+    gate's own coverage silently drops the moment someone adds a fifth caller.
+    """
+    found = {
+        str(path.relative_to(ROOT))
+        for path in sorted((ROOT / "src").rglob("*.py"))
+        if _chat_calls(path)
+    } - CHAT_CALL_EXEMPT
+    assert found == set(CALL_SITES.values()), (
+        "chat() call sites and the declared LLM jobs have drifted apart: "
+        f"undeclared={sorted(found - set(CALL_SITES.values()))} "
+        f"missing={sorted(set(CALL_SITES.values()) - found)}"
+    )
+
+
+@pytest.mark.parametrize("workflow_name,job_id,chains", LLM_JOBS)
+def test_one_attempt_can_use_the_primarys_whole_share(workflow_name, job_id, chains):
+    """A per-attempt timeout below the primary's budget share is unspendable.
+
+    `_attempt_timeout` clamps each attempt to min(timeout, budget left), so a
+    timeout smaller than the share cuts that share into slices -- and a
+    generation that needs more than one slice cannot be finished by adding
+    attempts, however many seconds remain. The weekly review ran with the 180s
+    default against a 360s share and lost 2026-W33 (run 31952091127) and
+    2026-W35 (run 33326401496) to three identical `timeout after 180s` lines,
+    with the whole budget spent and the answer never once given room to land.
+    """
+    job = _workflow(workflow_name)["jobs"][job_id]
+    share = _deadline_seconds(job) * llm.PRIMARY_BUDGET_SHARE
+    timeout = _call_site_timeout(CALL_SITES[(workflow_name, job_id)])
+
+    assert timeout >= share, (
+        f"{workflow_name}: chat(timeout={timeout:.0f}) is smaller than the "
+        f"primary's own share of the deadline ({share:.0f}s), so the ladder "
+        f"spends that share on {llm.MAX_RETRIES} attempts that are each too "
+        f"short to finish the generation"
     )


### PR DESCRIPTION
Closes #1367.

## What is wrong

`memory/weekly/` jumps W32 → W34, and stops at W34 (2026-08-23). Two ISO weeks are missing, and both are scheduled runs that failed the same way:

| week | run | failure |
|---|---|---|
| 2026-W33 | [31952091127](https://github.com/KCNyu/clawock/actions/runs/31952091127) | `minimax: timeout after 180s` x3 → `xiaomi: HTTP 401 Invalid API Key` |
| 2026-W35 | [33326401496](https://github.com/KCNyu/clawock/actions/runs/33326401496) | `minimax: timeout after 180s` x3 → `opencode: HTTP 401 CreditsError` |

Nothing re-runs a scheduled workflow, so those weeks are gone for good. The next run is tonight.

## Why it timed out — not a budget shortage, a slicing bug

`CLAWOCK_LLM_DEADLINE_SECONDS=600` gives the primary `0.6 x 600 = 360s`. But `chat()` was called with the default `timeout=180`, and `_attempt_timeout` clamps each attempt to `min(timeout, budget left)`. A per-attempt timeout below the primary's own share cuts that share into slices — and a generation that needs more than one slice can never finish however many seconds are left. Three doomed attempts spent all 360 seconds.

The generation genuinely needs more than 180s. Measured across the eight scheduled runs 2026-07-12..08-30:

| run | minimax wall | out tokens |
|---|---|---|
| 07-12 | 100.6s | 10,611 |
| 07-19 | 122.8s | 13,811 |
| 07-26 | **179.5s** | 15,574 |
| 08-02 | 117.5s | 8,822 |
| 08-09 | 133.2s | 17,614 |
| 08-16 | **failed** | — |
| 08-23 | 155.6s | 13,538 |
| 08-30 | **failed** | — |

87–150 output tok/s. A full-length answer at `max_tokens=32000` and the slow end of that is `32000 / 87 = 368s`. The timeout was set at the middle of the distribution and the tail fell off it.

## The change

- `weekly_review` asks for **420s** per attempt (derivation in the constant's comment); the workflow deadline goes **600 → 700** (share 420) inside a job raised **12 → 15 minutes**. Verified against the real constants: the first attempt now gets **419s** instead of three of 180, and the fallback still keeps its ~280s.
- Fast failures (disconnects, 5xx) still retry — they hand the seconds back.
- `news_digest` had the same shape latent (180s default against a 216s share) and now names its own timeout.
- `influencer`'s 180s already exceeds its 126s share. What its row had wrong was the **chain count**: `score_items` retries in `for attempt in (1, 2)`, so a run can open two chains, not the one the table claimed.

## Gate

`tests/test_llm_workflow_deadlines.py` gains two checks:

1. every `chat()` call site in `src/` must be in the declared job table — a fifth caller cannot silently inherit the 180s default;
2. each job's per-attempt timeout must be **≥ the primary's share of its deadline**, reading the value from the call site (an omitted `timeout=` counts as `llm.TIMEOUT`, because an omission has a value).

Red on `origin/master` for `weekly-review` and `news-digest`, green here.

## Not done on purpose

**No backfill of W33/W35.** `aggregate_week(today=...)` would accept a past date, but `assets/data/risk.json` is a current-state file with no history, so a backfilled document would carry today's risk numbers under a past week's title — a page that reads correct and is not. The gap stays visible instead.

https://claude.ai/code/session_01SNNu2J6TV8Y3Gjv3p3Bxup