### PR TITLE
weekly index: a week that was never written left no trace on the page

### DIFF
--- a/ops/pages/stage_site.py
+++ b/ops/pages/stage_site.py
@@ -10,11 +10,112 @@ repository root double as the website source directory.
 from __future__ import annotations
 
 import argparse
+import re
 import shutil
+from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[2]
+
+WEEK_FILE_RE = re.compile(r"^(\d{4})-W(\d{2})\.md$")
+
+# The review workflow fires `cron: '0 14 * * 0'` — Sunday 14:00 UTC, the last
+# day of the ISO week it writes. GitHub's scheduled runs drift: the 2026-08-30
+# run started at 17:51 UTC, 3.8 hours late. A week only counts as due once that
+# drift has had time to play out, or the page would announce a missing review
+# every Sunday evening.
+_REVIEW_FIRE_WEEKDAY = 6  # Sunday
+_REVIEW_FIRE_HOUR = 14
+_REVIEW_GRACE_HOURS = 8
+
+
+def _iso_weeks(first: tuple[int, int], last: tuple[int, int]) -> list[tuple[int, int]]:
+    """Every ISO (year, week) from `first` through `last`, inclusive.
+
+    Walked by date rather than by arithmetic on the week number, because a year
+    has 52 or 53 ISO weeks depending on where its days fall and the difference
+    is exactly the one a hand-rolled `range` gets wrong.
+    """
+    cursor = date.fromisocalendar(first[0], first[1], 1)
+    end = date.fromisocalendar(last[0], last[1], 1)
+    out = []
+    while cursor <= end:
+        year, week, _ = cursor.isocalendar()
+        out.append((year, week))
+        cursor += timedelta(days=7)
+    return out
+
+
+def _last_due_week(now: datetime) -> tuple[int, int]:
+    """The ISO week of the most recent review fire whose grace has elapsed."""
+    cutoff = now.astimezone(timezone.utc) - timedelta(hours=_REVIEW_GRACE_HOURS)
+    candidate = cutoff.replace(
+        hour=_REVIEW_FIRE_HOUR, minute=0, second=0, microsecond=0
+    )
+    if candidate > cutoff:
+        candidate -= timedelta(days=1)
+    while candidate.weekday() != _REVIEW_FIRE_WEEKDAY:
+        candidate -= timedelta(days=1)
+    year, week, _ = candidate.isocalendar()
+    return year, week
+
+
+def weekly_index(source_root: Path = ROOT, *, now: datetime = None) -> list[dict]:
+    """Every ISO week the review series should contain, newest first.
+
+    The site used to list the files that exist, so a week the workflow failed to
+    produce left no trace at all: `memory/weekly/` is missing 2026-W33 and
+    2026-W35 (runs 31952091127 and 33326401496, both three `timeout after 180s`
+    lines against a dead fallback), and the reader's only clue was that the week
+    numbers skip. A trailing gap had no clue whatsoever — nothing follows the
+    last file to look wrong next to.
+
+    So the span is computed rather than read: from the first review present
+    through the last fire that is actually due, with every week in between
+    named whether or not it was written.
+    """
+    now = now or datetime.now(timezone.utc)
+    directory = source_root / "memory" / "weekly"
+    present = {}
+    for path in sorted(directory.glob("*.md")) if directory.is_dir() else []:
+        match = WEEK_FILE_RE.match(path.name)
+        if match:
+            present[(int(match.group(1)), int(match.group(2)))] = path.name
+    if not present:
+        return []
+
+    span = _iso_weeks(min(present), max(max(present), _last_due_week(now)))
+    return [
+        {
+            "week": f"{year}-W{week:02d}",
+            "present": (year, week) in present,
+            "path": f"memory/weekly/{year}-W{week:02d}.md",
+        }
+        for year, week in reversed(span)
+    ]
+
+
+def _write_weekly_index(output_dir: Path, source_root: Path) -> None:
+    """Hand the index to Jekyll as data, not as rendered markup.
+
+    Liquid can compare two week numbers, but it cannot answer "is this week due
+    yet" without ISO-week arithmetic over the build clock, and a trailing gap is
+    exactly the case that needs it.
+    """
+    rows = weekly_index(source_root)
+    if not rows:
+        return
+    lines = []
+    for row in rows:
+        lines.append(f"- week: \"{row['week']}\"")
+        lines.append(f"  present: {'true' if row['present'] else 'false'}")
+        lines.append(f"  path: \"{row['path']}\"")
+    data_dir = output_dir / "_data"
+    data_dir.mkdir(parents=True, exist_ok=True)
+    (data_dir / "weekly_reviews.yml").write_text(
+        "\n".join(lines) + "\n", encoding="utf-8"
+    )
 
 
 def _copy(source: Path, destination: Path) -> None:
@@ -47,6 +148,7 @@ def stage(output_dir: Path, *, source_root: Path = ROOT) -> Path:
     for report in sorted((source_root / "memory").glob("*-pre-open.md")):
         _copy(report, output_dir / "memory" / report.name)
     _copy(source_root / "memory" / "weekly", output_dir / "memory" / "weekly")
+    _write_weekly_index(output_dir, source_root)
 
     print(f"staged Jekyll source: {site_source} + public runtime inputs -> {output_dir}")
     return output_dir

--- a/site/_layouts/default.html
+++ b/site/_layouts/default.html
@@ -237,6 +237,15 @@
     color: var(--text); text-decoration: none;
     font-family: var(--mono); font-size: 14px; display: block;
   }
+  /* A week whose scheduled review failed. Same row, same rhythm, no link and
+     no hover affordance — it has to read as a hole in the series, not as an
+     item someone forgot to make clickable. */
+  .brief-missing {
+    color: var(--text-dim); font-family: var(--mono); font-size: 14px;
+    display: block;
+  }
+  .brief-list li:has(.brief-missing) { background: transparent; border: 1px dashed var(--border); }
+  .brief-list li:has(.brief-missing):hover { background: transparent; }
 
   footer {
     max-width: 1024px; margin: 32px auto 0; padding: 16px;

--- a/site/briefs.md
+++ b/site/briefs.md
@@ -21,15 +21,20 @@ description: 全部历史每日深度简报 + 周复盘
 {% endfor %}
 </ul>
 
-## Weekly Reviews · Xiaomi 周复盘
+## Weekly Reviews · 周复盘
 
-由 `.github/workflows/weekly-review.yml` 每周日 22:00 HKT 自动跑（Xiaomi MiMo v2.5-pro · thinking enabled · max 32K）。
+由 `.github/workflows/weekly-review.yml` 每周日 22:00 HKT 自动跑（MiniMax-M3 · thinking enabled · max 32K，失败时回退 OpenCode Zen 的 deepseek-v4-flash）。
+
+列的是**每一个应该有复盘的 ISO 周**，不是每一个存在的文件——2026-W33 与 2026-W35 的排程跑挂了（provider 三次超时 + 回退腿 401），没有任何东西会补跑，所以缺口留在这里给人看见，而不是让周号自己跳过去。
 
 <ul class="brief-list">
-{% assign weeklies = site.pages | where_exp: "p", "p.path contains 'memory/weekly/'" | sort: 'path' | reverse %}
-{% for f in weeklies %}
+{% assign weeklies = site.pages | where_exp: "p", "p.path contains 'memory/weekly/'" %}
+{% for w in site.data.weekly_reviews %}
+  {% assign hit = false %}
+  {% for p in weeklies %}{% if p.path == w.path %}{% assign hit = p %}{% endif %}{% endfor %}
   <li>
-    <a href="{{ f.url | relative_url }}">{{ f.path | split: '/' | last | replace: '.md', '' }}</a>
+    {% if hit %}<a href="{{ hit.url | relative_url }}">{{ w.week }}</a>
+    {% else %}<span class="brief-missing" title="该周的排程跑失败，未生成">{{ w.week }} · 未生成</span>{% endif %}
   </li>
 {% endfor %}
 </ul>

--- a/tests/test_weekly_review_index.py
+++ b/tests/test_weekly_review_index.py
@@ -1,0 +1,130 @@
+"""The weekly review index lists weeks, not files.
+
+`memory/weekly/` is missing 2026-W33 and 2026-W35: both scheduled runs failed
+(31952091127, 33326401496 — three `timeout after 180s` on the primary against a
+fallback answering 401), and nothing re-runs a scheduled workflow. The site's
+Weekly Reviews list rendered `site.pages`, so a week that was never written
+simply was not there. The middle gap was a jump in the numbers nobody reads;
+the trailing gap had nothing after it to look wrong beside.
+
+So `stage_site.weekly_index` computes the span the series *should* cover and
+marks each week present or not. This file pins the three cases that make the
+computation worth having over the old file listing.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "ops" / "pages"))
+sys.path.insert(0, str(ROOT / "src"))
+
+import stage_site  # noqa: E402
+
+from clawock.automation import llm  # noqa: E402
+
+
+def _tree(tmp_path, weeks):
+    directory = tmp_path / "memory" / "weekly"
+    directory.mkdir(parents=True)
+    for week in weeks:
+        (directory / f"{week}.md").write_text("---\nlayout: default\n---\n", encoding="utf-8")
+    return tmp_path
+
+
+def _weeks(rows):
+    return [(row["week"], row["present"]) for row in rows]
+
+
+def test_a_gap_between_two_reviews_is_named(tmp_path):
+    root = _tree(tmp_path, ["2026-W32", "2026-W34"])
+    rows = stage_site.weekly_index(root, now=datetime(2026, 8, 25, tzinfo=timezone.utc))
+    assert _weeks(rows) == [
+        ("2026-W34", True),
+        ("2026-W33", False),
+        ("2026-W32", True),
+    ]
+
+
+def test_a_trailing_gap_is_named_too(tmp_path):
+    """The case a file listing cannot show: the series just stops.
+
+    2026-W35's fire was Sunday 2026-08-30 14:00 UTC. By the following Friday it
+    is long past due, and the newest file is still 2026-W34.
+    """
+    root = _tree(tmp_path, ["2026-W34"])
+    rows = stage_site.weekly_index(root, now=datetime(2026, 9, 4, tzinfo=timezone.utc))
+    assert _weeks(rows) == [("2026-W35", False), ("2026-W34", True)]
+
+
+def test_a_week_whose_fire_has_not_landed_yet_is_not_called_missing(tmp_path):
+    """Sunday 15:00 UTC is one hour after the cron and inside its drift.
+
+    The 2026-08-30 run started 3.8 hours late; announcing a missing review at
+    the first minute past the schedule would put a false hole on the page every
+    Sunday evening.
+    """
+    root = _tree(tmp_path, ["2026-W35"])
+    rows = stage_site.weekly_index(root, now=datetime(2026, 9, 6, 15, tzinfo=timezone.utc))
+    assert _weeks(rows) == [("2026-W35", True)]
+
+
+def test_the_span_crosses_a_year_boundary_by_the_calendar(tmp_path):
+    """2026 has 53 ISO weeks; 2027 starts at W01 four days into January."""
+    root = _tree(tmp_path, ["2026-W52"])
+    rows = stage_site.weekly_index(root, now=datetime(2027, 1, 15, tzinfo=timezone.utc))
+    assert _weeks(rows) == [
+        ("2027-W01", False),
+        ("2026-W53", False),
+        ("2026-W52", True),
+    ]
+
+
+def test_staging_hands_the_index_to_jekyll(tmp_path):
+    output = tmp_path / "site-source"
+    subprocess.run(
+        ["python3", str(ROOT / "ops/pages/stage_site.py"), "--output-dir", str(output)],
+        cwd=ROOT,
+        check=True,
+    )
+    rows = yaml.safe_load(
+        (output / "_data" / "weekly_reviews.yml").read_text(encoding="utf-8")
+    )
+    assert rows and isinstance(rows, list)
+    # Every row the page renders has to be answerable from this file alone, and
+    # `present` has to survive as a boolean rather than the string "false".
+    for row in rows:
+        assert set(row) == {"week", "present", "path"}, row
+        assert isinstance(row["present"], bool), row
+    assert rows[0]["week"] > rows[-1]["week"], "newest first"
+
+
+def test_the_page_reads_the_index_rather_than_the_file_listing():
+    page = (ROOT / "site" / "briefs.md").read_text(encoding="utf-8")
+    weekly = page.split("## Weekly Reviews")[1]
+    assert "site.data.weekly_reviews" in weekly, (
+        "the weekly list is back to rendering whatever files exist, which is "
+        "exactly the rendering that hid 2026-W33 and 2026-W35")
+
+
+def test_the_page_names_the_provider_the_code_actually_calls():
+    """It advertised `Xiaomi MiMo v2.5-pro` for months after that key died.
+
+    The primary moved to MiniMax M3 and the fallback to OpenCode Zen (#695,
+    #697). A public page describing a provider the repository no longer has
+    credentials for is a wrong fact in front of every reader, and nothing was
+    comparing the sentence to the constant it describes.
+    """
+    page = (ROOT / "site" / "briefs.md").read_text(encoding="utf-8")
+    weekly = page.split("## Weekly Reviews")[1].split("##")[0]
+    for model in (llm.MINIMAX_MODEL, llm.OPENCODE_MODEL):
+        assert model in weekly, (
+            f"the weekly section does not name {model}: {weekly[:300]}")
+    assert "Xiaomi" not in weekly and "MiMo" not in weekly, (
+        "the weekly section still advertises the dead Xiaomi route")


### PR DESCRIPTION
Follow-up to #1368 (which fixed *why* the two runs failed). This one is about what the reader sees.

## What was wrong

`site/briefs.md` rendered the Weekly Reviews list from `site.pages`, so it listed the reviews that exist. 2026-W33 and 2026-W35 don't exist — both scheduled runs failed and nothing re-runs a scheduled workflow. On the page:

- the **middle** gap (W32 → W34) was a jump in the week numbers, which is only a signal to someone reading them as numbers;
- the **trailing** gap (nothing after W34) was no signal at all — a series that stops looks exactly like a Sunday that has not arrived yet.

## What it does now

`stage_site.weekly_index()` walks every ISO week from the first review present through the last fire whose grace has elapsed, marking each present or missing. Staging writes it to `_data/weekly_reviews.yml`; the page renders one row per week and a dashed, unlinked `2026-W33 · 未生成` row for the weeks that were never produced.

Today's output on this checkout:

```
2026-W35  missing
2026-W34  present
2026-W33  missing
2026-W32  present
...
```

Two details need the build clock, which is why this is Python and not Liquid:

- **a week is due 8 hours after its `0 14 * * 0` cron.** The 2026-08-30 run started at 17:51 UTC, 3.8 hours late; calling a review missing at 14:01 would put a false hole on the page every Sunday evening.
- **the span is walked by date.** A year has 52 or 53 ISO weeks, and a `range` over week numbers is wrong exactly at the boundary that is hardest to notice.

## Also: the page advertised a dead provider

The section read `Xiaomi MiMo v2.5-pro`, a route whose key died in #695 and was replaced in #697 — a wrong fact in front of every reader of a public page. It now names `MiniMax-M3` and `deepseek-v4-flash`, and `test_the_page_names_the_provider_the_code_actually_calls` compares the sentence to `llm.MINIMAX_MODEL` / `llm.OPENCODE_MODEL` instead of trusting it again.

## Tests

`tests/test_weekly_review_index.py` — middle gap, trailing gap, a fire inside its drift window (must **not** be called missing), the year boundary, the staged YAML being loadable with booleans intact, and the two page contracts. 7 tests, all red on `origin/master`, green here. The Jekyll build itself runs on this PR (`pages.yml` triggers on `site/**`).

https://claude.ai/code/session_01SNNu2J6TV8Y3Gjv3p3Bxup