### PR TITLE
tests: the restore that could not tell "put it back" from "touch it"

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -499,6 +499,33 @@ def pytest_terminal_summary(terminalreporter):
             f"{entry['test']}{mark}\n    " + "\n    ".join(parts))
 
 
+def _restore_publish_owned(before):
+    """Put back what moved, and touch nothing that did not.
+
+    An unconditional rewrite puts the same bytes on disk with a new mtime, and
+    the write guard above watches (size, mtime_ns). The fixture below is
+    session-scoped, and under `-n` a session is a WORKER — so the restore ran
+    while the other workers were still running tests, and their windows recorded
+    the four payloads changing. CI named a different innocent module on each run
+    (2026-09-06, PR #1369), and only on branches that touch `site/**` or the UI,
+    because those are the ones where `fetch_data_plane.py` puts these files in
+    the checkout in the first place.
+
+    This is the last of the shared mutable outputs #1365 went after: the session
+    rebuild got its own output tree, and what was left was a restore that could
+    not tell "put it back" from "touch it".
+
+    Returns the paths it actually wrote, so the difference can be asserted.
+    """
+    written = []
+    for path, blob in before.items():
+        target = ROOT / path
+        if not target.exists() or target.read_bytes() != blob:
+            target.write_bytes(blob)
+            written.append(path)
+    return written
+
+
 @pytest.fixture(scope="session", autouse=True)
 def publish_owned_artifacts_are_left_as_found():
     from clawock.publish.outputs import output_paths
@@ -510,8 +537,7 @@ def publish_owned_artifacts_are_left_as_found():
 
     yield
 
-    for path, blob in before.items():
-        (ROOT / path).write_bytes(blob)
+    _restore_publish_owned(before)
 
     status_after = _git_status(outputs)
     if status_before is not None:

--- a/tests/test_import_layering.py
+++ b/tests/test_import_layering.py
@@ -284,13 +284,14 @@ def test_the_write_guard_has_no_position_in_the_collection_order(request):
     What is left here is the reason it moved, plus the attribution log's own
     shape. The enforcement is a session hook, which nothing can sort after.
 
-    On parallelism, measured rather than assumed — and the measurement killed
-    the idea. #816 claimed emptying the tolerated list would unlock `-n auto`
-    and take the pytest step from 89s to ~30s. With the writers isolated and the
-    session rebuild behind a file lock, `-n 4` does pass, three runs at
-    175/182/191s against ~195s serial: **5-10%, not 3x**. The top twelve tests
-    account for ~121s of a 208s run and every one of them is subprocess-bound.
-    So xdist stays off: a few percent is not worth a flake class.
+    On parallelism, measured rather than assumed, twice — and the second
+    measurement reversed the first. While the top twelve tests were
+    subprocess-bound waiting on network and the live host, `-n 4` bought
+    5-10% (175/182/191s against ~195s serial) and xdist stayed off. #1362 took
+    that waiting out, #1365 gave the session rebuild its own output tree, and
+    then `-n auto` was worth it: CI's pytest step went 197s -> 129s. It is on in
+    `ci.yml` now, which is why every shared mutable output in this suite is a
+    flake class rather than an inefficiency.
     """
     import conftest  # noqa: PLC0415
 
@@ -364,6 +365,36 @@ def test_the_verdict_is_reached_once_over_the_whole_run():
     assert hasattr(conftest, "pytest_testnodedown"), (
         "the controller needs the join hook; without it every worker's log is "
         "dropped and -n enforces nothing")
+
+
+def test_restoring_an_unchanged_artifact_does_not_touch_it(tmp_path, monkeypatch):
+    """The restore must be able to be a no-op, or it is itself a writer.
+
+    `publish_owned_artifacts_are_left_as_found` is session-scoped, and under
+    `-n` a session is a worker — so a restore that rewrites unconditionally
+    lands the same bytes with a new mtime while the other workers are mid-test,
+    and the write guard, which watches (size, mtime_ns), records the four
+    payloads as changed against whoever happened to be running. Two CI runs on
+    2026-09-06 named four different innocent modules between them.
+    """
+    import conftest  # noqa: PLC0415
+
+    artifact = tmp_path / "assets" / "data" / "overview.json"
+    artifact.parent.mkdir(parents=True)
+    artifact.write_bytes(b'{"kept": true}')
+    monkeypatch.setattr(conftest, "ROOT", tmp_path)
+    before = {"assets/data/overview.json": artifact.read_bytes()}
+    stat_before = artifact.stat()
+
+    assert conftest._restore_publish_owned(before) == [], (
+        "an unchanged artifact was rewritten; that write is what the guard sees")
+    assert artifact.stat().st_mtime_ns == stat_before.st_mtime_ns
+
+    # And it still restores — the no-op must not have been bought by doing
+    # nothing at all.
+    artifact.write_bytes(b'{"clobbered": true}')
+    assert conftest._restore_publish_owned(before) == ["assets/data/overview.json"]
+    assert artifact.read_bytes() == b'{"kept": true}'
 
 
 def test_the_tolerated_writer_list_is_empty_and_stays_empty():


### PR DESCRIPTION
Found while `validate` went red twice on #1369 with **zero test failures** — `3356 passed`, exit 1, and a different set of innocent modules blamed each run.

## The write

`tests/conftest.py::publish_owned_artifacts_are_left_as_found` snapshots the four publish-owned payloads at session start and writes them back at session end, unconditionally — the same bytes with a new mtime. The write guard watches `(size, mtime_ns)`.

- **Serially** the write-back happens after the last test's window closes, so nothing observes it.
- **Under `-n` a session is a worker.** Each worker's teardown rewrites the four files while the other workers are still running tests, and their windows record `changed: assets/data/{dashboard,decision_audit,overview,shadow_portfolio}.json` against whoever happened to be executing.

Two CI runs blamed `test_regime_hmm`, `test_wheel_contains_the_package`, `test_runtime_coupling_ratchet` and `test_research_provenance` between them. None of them writes anything.

## Why now, and only on some branches

The four payloads are gitignored — they live on the data branch. A normal PR's checkout does not have them, so there is nothing to rewrite. `ci.yml` fetches them for the browser contract when `changes.ui == true`, and from that moment every worker teardown is a write into the checkout.

`-n auto` landed in #1365; #1369 is the first UI-touching branch since. So: latent since #1365, and it would have hit every future UI PR.

## Measurement

In a worktree with `ops/pages/fetch_data_plane.py` run first, exactly as CI has it:

| | serial | `-n 2` |
|---|---|---|
| before | exit 0 | **exit 1**, four payloads flagged against a bystander |
| after | exit 0 | **exit 0**, only the two tolerated `memory/.tmp/preserve-absent-` entries |

Content was identical in every case (`md5sum -c` clean) — it was always only the mtime, which is exactly why it never showed up as a diff.

## The fix

Restore only what actually moved. `test_restoring_an_unchanged_artifact_does_not_touch_it` pins both halves — an unchanged artifact keeps its `mtime_ns`, and a clobbered one is still put back, so the no-op cannot be bought by doing nothing. It goes red the moment the write-back is unconditional again.

## Also in this diff

`test_import_layering.py`'s docstring still said *"So xdist stays off: a few percent is not worth a flake class."* That measurement was taken when the twelve slowest tests were waiting on the network and the live host. #1362 removed that wait and #1365 turned `-n auto` on (CI pytest 197s → 129s). Left as written it tells the next reader the opposite of what `ci.yml` does.

https://claude.ai/code/session_01SNNu2J6TV8Y3Gjv3p3Bxup