### PR TITLE
cron health: a backlog reading with no age attached is presented as now

### DIFF
--- a/ops/host/cron_health_check.py
+++ b/ops/host/cron_health_check.py
@@ -73,6 +73,9 @@ HEARTBEAT_SNAP_MINUTES = 15
 DASHBOARD_STATE_ICONS = {
     'ok': '✓', 'repaired': '🔧', 'degraded': '⚠', 'stale': '⚠',
     'failed': '✗', 'absent': '·',
+    # A reading that is real but too old to describe now. '·', not '⚠': see
+    # `publish_backlog` for why an unknown is not an alarm here.
+    'stale-measurement': '·',
 }
 
 # Cron name → identifying commit msg patterns
@@ -209,7 +212,35 @@ def load_runtime_jobs(jobs_file=None):
 UNPUSHED_WARN_COMMITS = 3
 
 
-def publish_backlog(ledger):
+#: How old a heartbeat's measurement may be and still describe *now*.
+#:
+#: Only the intraday postflight carries `unpushed_commits`, so the newest
+#: reading on a Sunday afternoon is Friday night's — the crons that would
+#: refresh it do not run on a closed market. 24h keeps a weekday reading
+#: current and stops a weekend from presenting Friday as today.
+BACKLOG_MEASUREMENT_MAX_AGE_H = 24
+
+
+def _measured_at(event):
+    """When this heartbeat was written, or None if it cannot be read.
+
+    `updated_at` is the write time; `slot` is the scheduled boundary it belongs
+    to and is the fallback, because it is the field the ledger is sorted and
+    pruned by and so is always present.
+    """
+    for key in ('updated_at', 'slot'):
+        raw = event.get(key)
+        if not raw:
+            continue
+        try:
+            stamp = datetime.fromisoformat(raw)
+        except (TypeError, ValueError):
+            continue
+        return stamp if stamp.tzinfo else stamp.replace(tzinfo=HKT)
+    return None
+
+
+def publish_backlog(ledger, now=None):
     """The newest heartbeat's view of commits the host never published (#1241).
 
     This gate runs on GitHub Actions, against artifacts that were published. A
@@ -223,17 +254,43 @@ def publish_backlog(ledger):
     that could not run git. Absent is reported as absent, never as zero: the
     whole failure being guarded here is a lane that looked fine because nobody
     was looking at it.
+
+    **`state: stale-measurement` when the reading is older than
+    BACKLOG_MEASUREMENT_MAX_AGE_H.** A number with no age attached is presented
+    as the current state, and this one ages the moment the intraday crons stop:
+    on 2026-09-06 the line read "6 commit(s) committed here and never published
+    — check what pre-push is refusing" for the whole weekend, from a Friday
+    02:43 heartbeat, while the checkout had been at `origin/master..HEAD == 0`
+    for over a day. There was nothing to check, and an instruction to go look at
+    something that is not wrong is how a health line stops being read.
+
+    Stale does not escalate. The host measures this live every twenty minutes in
+    `system_check.check_publish_backlog`, which is the authority whenever this
+    mirror can only see history — and a host silent long enough for the reading
+    to age is already saying so through the missing-cron lines above.
     """
+    now = now or datetime.now(timezone.utc)
     for event in reversed(ledger.get('events') or []):
         count = event.get('unpushed_commits')
         if count is None:
             continue
+        measured_at = _measured_at(event)
+        age_h = (None if measured_at is None
+                 else (now - measured_at).total_seconds() / 3600.0)
+        reading = f'{count} unpushed' if count else 'nothing unpushed'
+        if age_h is not None and age_h > BACKLOG_MEASUREMENT_MAX_AGE_H:
+            return {'state': 'stale-measurement', 'count': count,
+                    'age_hours': round(age_h, 1),
+                    'detail': f'last measured {age_h:.0f}h ago: {reading} — no '
+                              f'heartbeat since, so this is history not now'}
         if count >= UNPUSHED_WARN_COMMITS:
             return {'state': 'degraded', 'count': count,
+                    'age_hours': None if age_h is None else round(age_h, 1),
                     'detail': f'{count} commit(s) committed here and never '
                               f'published — check what pre-push is refusing'}
         return {'state': 'ok', 'count': count,
-                'detail': f'{count} unpushed' if count else 'nothing unpushed'}
+                'age_hours': None if age_h is None else round(age_h, 1),
+                'detail': reading}
     return {'state': 'absent', 'count': None,
             'detail': 'no heartbeat carries unpushed_commits (older host?)'}
 
@@ -724,7 +781,7 @@ def main():
     # A backlog is a warn, never a miss: the commits exist and nothing was lost,
     # what failed is that they never left the machine. Escalating it to exit 1
     # would redden a day whose reports all went out (#1241).
-    backlog = publish_backlog(heartbeat_ledger)
+    backlog = publish_backlog(heartbeat_ledger, now=now)
     if backlog['state'] == 'degraded':
         has_warn = True
 

--- a/tests/test_cron_health_check.py
+++ b/tests/test_cron_health_check.py
@@ -430,14 +430,20 @@ def test_a_us_holiday_suppresses_the_previous_evening_slots_without_a_red(monkey
 # stayed green. Only the host can measure it; it carries the number in the
 # heartbeat and these read it.
 
+#: The heartbeats below are written between 10:00 and 19:00 HKT on 2026-08-31;
+#: judge them from that evening, i.e. while they still describe the machine.
+_JUDGED_AT = datetime(2026, 8, 31, 20, 0, tzinfo=ZoneInfo("Asia/Hong_Kong"))
+
+
 def _ledger(*counts):
     return {"events": [{"slot": f"2026-08-31T1{i}:00:00+08:00",
+                        "updated_at": f"2026-08-31T1{i}:05:00+08:00",
                         **({} if count is None else {"unpushed_commits": count})}
                        for i, count in enumerate(counts)]}
 
 
 def test_a_backlog_the_size_of_the_incident_is_degraded():
-    result = cron_health_check.publish_backlog(_ledger(0, 6))
+    result = cron_health_check.publish_backlog(_ledger(0, 6), now=_JUDGED_AT)
 
     assert result["state"] == "degraded"
     assert result["count"] == 6
@@ -445,14 +451,58 @@ def test_a_backlog_the_size_of_the_incident_is_degraded():
 
 
 def test_a_normal_publish_cycle_is_not_a_backlog():
-    assert cron_health_check.publish_backlog(_ledger(0, 1))["state"] == "ok"
+    assert cron_health_check.publish_backlog(
+        _ledger(0, 1), now=_JUDGED_AT)["state"] == "ok"
 
 
 def test_only_the_newest_heartbeat_that_carries_the_field_decides():
     """An old degraded reading must not outlive the recovery that followed it."""
-    result = cron_health_check.publish_backlog(_ledger(9, 9, 0))
+    result = cron_health_check.publish_backlog(_ledger(9, 9, 0), now=_JUDGED_AT)
 
     assert (result["state"], result["count"]) == ("ok", 0)
+
+
+def test_a_reading_older_than_the_heartbeats_that_refresh_it_is_not_now():
+    """Measured 2026-09-06: the line read "6 commit(s) committed here and never
+    published — check what pre-push is refusing" all weekend, off a Friday 02:43
+    heartbeat, while `origin/master..HEAD` had been 0 for over a day. Only the
+    intraday postflight writes this number, and those crons do not run on a
+    closed market, so the reading ages every weekend by design.
+
+    An instruction to go look at something that is not wrong is how a health
+    line stops being read.
+    """
+    stale = _JUDGED_AT + timedelta(hours=40)
+    result = cron_health_check.publish_backlog(_ledger(0, 6), now=stale)
+
+    assert result["state"] == "stale-measurement"
+    assert result["count"] == 6, "the last reading is still worth carrying"
+    assert result["age_hours"] > cron_health_check.BACKLOG_MEASUREMENT_MAX_AGE_H
+    assert "history not now" in result["detail"]
+    assert "pre-push" not in result["detail"], (
+        "a stale reading must not tell anyone to go check a refusal that has "
+        "had a day and a half to clear")
+
+
+def test_a_stale_reading_is_printed_as_nothing_to_do():
+    """`⚠` is a claim that something is wrong, and "I last looked on Friday" is
+    not one. The host measures this live every twenty minutes in
+    `system_check.check_publish_backlog`, so the mirror escalating its own
+    unknown would fire every weekend and mean nothing both times."""
+    assert cron_health_check.DASHBOARD_STATE_ICONS["stale-measurement"] == "·"
+    assert cron_health_check.publish_backlog(
+        _ledger(0, 6), now=_JUDGED_AT + timedelta(hours=40)
+    )["state"] != "degraded", "only a fresh reading may escalate"
+
+
+def test_a_measurement_with_no_timestamp_is_still_judged():
+    """`updated_at` is the write time and `slot` the boundary it belongs to;
+    an event carrying neither cannot be aged, and a backlog that cannot be aged
+    is still a backlog."""
+    ledger = {"events": [{"unpushed_commits": 6}]}
+
+    assert cron_health_check.publish_backlog(ledger, now=_JUDGED_AT)["state"] == (
+        "degraded")
 
 
 def test_a_host_that_cannot_measure_it_is_absent_not_zero():


### PR DESCRIPTION
## What it says now, and what is true

Run on this host a few minutes ago:

```
⚠ publish backlog   6 commit(s) committed here and never published — check what pre-push is refusing
```

```
$ git -C /root/.openclaw/workspace rev-list --count origin/master..master
0
```

The 6 came from a heartbeat written **2026-09-05T02:43 HKT** — 40 hours before the line was printed. `publish_backlog` walks back to the newest heartbeat that carries `unpushed_commits` and returns it, with no regard for when it was written.

## Why it is every weekend, not an edge case

Only `intraday_postflight` writes `unpushed_commits`, and the intraday crons do not run on a closed market. After Friday's last US overnight slot the reading stops moving, and whatever it said then is reported as the present state until Monday. If Friday's last reading happened to be over the threshold — as it was — the line stays on all weekend telling the reader to go look at a `pre-push` refusal that cleared a day and a half ago.

That is how a health line stops being read, which matters here more than usual: two weekly reviews failed in Actions this month (#1368) and nothing surfaced either.

## The change

The reading carries its age; one older than 24h keeps the number and drops the claim:

```
· publish backlog   last measured 40h ago: 6 unpushed — no heartbeat since, so this is history not now
```

`stale-measurement` does not escalate, and `·` rather than `⚠` is deliberate:

- the host measures this **live every twenty minutes** in `system_check.check_publish_backlog` — that is the authority whenever this mirror can only see history;
- a host silent long enough for the reading to age is already saying so through the missing-cron lines above.

## Tests

The three existing tests judged a `2026-08-31` ledger from whatever today happens to be — the very fact the old code was missing. They now state when they judge from. Three added: a stale reading keeps its count and drops the instruction; a stale reading may not escalate; an event with neither `updated_at` nor `slot` cannot be aged and is still judged on its number (a backlog that cannot be aged is still a backlog).

https://claude.ai/code/session_01SNNu2J6TV8Y3Gjv3p3Bxup