### PR TITLE
tests: a node stub that never reads stdin makes the publish look failed

### DIFF
--- a/tests/test_rick_broadcast.py
+++ b/tests/test_rick_broadcast.py
@@ -81,7 +81,17 @@ def test_high_confidence_rate_is_active_only_and_renders_its_sample_size():
 # not on the script's text.
 # ---------------------------------------------------------------------------
 
+# `cat >/dev/null` is not decoration. The wrapper publishes with
+# `printf '%s\n' "$POST" | node …` under `set -o pipefail`, so if the stub exits
+# without draining stdin the pipeline's status can be printf's SIGPIPE (141)
+# rather than node's 0 — the wrapper then reports "publish failed; digest not
+# recorded" for a publish that was accepted. Whether it happens is a scheduling
+# race between printf's write and the reader closing the pipe, which is why it
+# only appeared once CI started running four workers on one runner (2026-09-06,
+# run 34029531224). The real `nostr_publish.js` reads its post from stdin; a
+# stub that does not is the part that was wrong.
 STUB_NODE = r'''#!/usr/bin/env bash
+cat >/dev/null
 echo "$@" >> "$GATE_TEST_LOG"
 if [[ -f "$GATE_TEST_NODE_FAIL" ]]; then exit 1; fi
 exit 0


### PR DESCRIPTION
`tests/test_rick_broadcast.py::test_wrapper_state_only_advances_after_a_confirmed_publish` failed on [run 34029531224](https://github.com/KCNyu/clawock/actions/runs/34029531224) with

```
AssertionError: 2026-09-06T11:12:52+00:00 publish failed; digest not recorded — will retry next run
```

on a publish the stub had accepted. It passes serially, and it passed on the same commit's re-run — a race, not a defect in the branch under test.

## Mechanism

`ops/growth/rick_broadcast_nostr.sh` publishes with

```sh
printf '%s\n' "$POST" | node ops/growth/nostr_publish.js
```

under `set -o pipefail`, and `STUB_NODE` exits **without reading stdin**. If the stub closes the pipe before printf's write lands, printf dies of SIGPIPE and `pipefail` gives the pipeline printf's **141** instead of node's 0 — so the wrapper reports a failed publish and refuses to record the digest, which is exactly what the assertion saw.

Measured here, 400 pipelines per process:

| reader | load | non-zero |
|---|---|---|
| non-draining | idle | 0 / 400 |
| non-draining | 6 concurrent | **1 / 2400** (status 141) |
| draining | 6 concurrent | 0 / 2400 |

Which explains the timing: it needed four workers on one runner (`-n auto`, #1365) to show up at all, and it is one run in many rather than every run.

## The fix is in the stub

The real `nostr_publish.js` reads its post from stdin. A stub that does not is not standing in for it. The wrapper's `pipefail` is doing its job here — a publisher that exits before reading the post has not published it — so nothing in production changes.

https://claude.ai/code/session_01SNNu2J6TV8Y3Gjv3p3Bxup