### PR TITLE
packet: 18KB of arithmetic nobody reads, in the one place bytes are a hard cap

### DIFF
--- a/src/clawock/decision/packet.py
+++ b/src/clawock/decision/packet.py
@@ -46,6 +46,31 @@ SUMMARY_BUDGET_WARN_RATIO = 0.8
 #: The packet ceiling needs the same early word as the summary's; see
 #: the note at the raise in `compile_packet` for why it was missing.
 PACKET_BUDGET_WARN_RATIO = 0.8
+
+#: The per-event arithmetic behind `information`'s scores. #1039 tiered these
+#: out of the persisted ledger provenance as "zero-reader bulk"; the same two
+#: lists were still copied into the packet itself, where the cap is hard and a
+#: crossing is a `ValueError` that takes the whole pre-open brief down.
+INFORMATION_COLD_KEYS = ("attention_components", "event_components")
+
+
+def _without_cold_components(information: dict) -> dict:
+    """`information` minus the per-event component lists.
+
+    They have to exist while the packet is being built — `classify_authority`
+    reads `event_components` to find the positive events that authorise an add,
+    and both lists to collect the evidence ids it cites — so this drops them at
+    the point of storage, never at the point of computation. What survives is
+    what any reader of the stored packet uses: the scores, the ranks, the
+    counts, and (in `quant.add_authority`) the event ids the authority decision
+    actually cited.
+
+    Their canonical store is `assets/data/news_evidence_graph.json`, committed
+    daily under the #951 rolling windows — the same store #1039 named.
+    """
+    return {k: v for k, v in (information or {}).items()
+            if k not in INFORMATION_COLD_KEYS}
+
 ADD_ALPHA_POLICY = workspace_root() / "config" / "add-alpha-policy.json"
 VERDICTS = {"bullish", "neutral", "bearish", "mixed"}
 DISPOSITIONS = {"candidate", "wait", "reject"}
@@ -1139,7 +1164,11 @@ def compile_packet(context: dict, generation_id: str | None = None) -> dict:
             },
             "sentiment": _sentiment_view(sentiment_rows, ticker, source_ticker),
             "history": _history_view(context, ticker),
-            "information": information_view,
+            # Trimmed here, not in `_information_view`: the full view is what
+            # `classify_authority` and `_information_sizing_overlay` above were
+            # given, and stripping it earlier would quietly withdraw the add
+            # authority those two grant.
+            "information": _without_cold_components(information_view),
             "evidence": matching_events,
             "risk": ticker_risks,
             "status": _status(technical, ticker_risks),
@@ -1387,9 +1416,9 @@ def _decision_provenance(packet: dict, ticker: str) -> dict | None:
         return None
     execution = row.get("execution") or {}
     quant = row.get("quant") or {}
-    information = copy.deepcopy(row.get("information") or {})
-    for cold_key in ("attention_components", "event_components"):
-        information.pop(cold_key, None)
+    # Still stripped here: a packet written before the components stopped being
+    # stored (or read back from an older run bundle) carries them.
+    information = _without_cold_components(copy.deepcopy(row.get("information") or {}))
     return {
         "schema_version": 1,
         "context_generation_id": (packet.get("_meta") or {}).get("generation_id"),

--- a/tests/test_brief_decision_packet.py
+++ b/tests/test_brief_decision_packet.py
@@ -284,6 +284,62 @@ def test_production_factor_and_peer_keys_reach_add_authority():
     assert "tranche_below_market_unit" in row["execution"]["blockers"]
 
 
+def test_the_authority_reads_the_components_and_the_packet_does_not_store_them():
+    """Trim at storage, never at computation.
+
+    `classify_authority` reads `event_components` to find the positive events
+    that authorise an add and both lists to collect the evidence ids it cites,
+    so a fix that stripped them inside `_information_view` would quietly
+    withdraw the authority instead of shrinking the packet. This asserts both
+    halves at once: the exploration tier is still granted off `positive-1`, and
+    the stored row carries none of the arithmetic that granted it.
+
+    Why it matters that they are gone (#1039 tiered the same two lists out of
+    the ledger for the same reason): on the 2026-09-04 book they were 17,969 of
+    93,780 bytes against a 98,304 hard cap — 95.4% full, one holding from the
+    `ValueError` that took the pre-open brief down on 2026-08-17. Their
+    canonical store is `assets/data/news_evidence_graph.json`, committed daily.
+    """
+    context = _exploration_context()
+
+    packet = packet_mod.compile_packet(
+        context, brief_context.compute_generation_id(context)
+    )
+    row = packet["tickers"]["00100"]
+    authority = row["quant"]["add_authority"]
+
+    assert authority["tier"] == "exploration", (
+        "the components were withdrawn before the decision that reads them")
+    assert "point_in_time_information" in authority["evidence_families"]
+    # The ids the decision cited survive; the rows it read them from do not.
+    assert "positive-1" in authority["information_event_ids"]
+    assert "attention-1" in authority["information_event_ids"]
+    for cold_key in packet_mod.INFORMATION_COLD_KEYS:
+        assert cold_key not in row["information"], (
+            f"{cold_key} is back in the stored packet; it is per-event "
+            f"arithmetic with no reader of the stored copy, and the packet is "
+            f"the one place where bytes are a hard cap")
+    # Everything a reader of the stored packet uses is still there.
+    for kept in ("signed_score", "attention_rank", "attention_acceleration",
+                 "attention_event_count", "attention_source_type_count",
+                 "status", "usable_for_decisions"):
+        assert kept in row["information"]
+
+
+def test_the_summary_the_model_reads_is_unchanged_by_the_trim():
+    """The components were never in the resident input, which is why dropping
+    them buys headroom without taking anything off the model's desk."""
+    context = _exploration_context()
+    packet = packet_mod.compile_packet(
+        context, brief_context.compute_generation_id(context)
+    )
+    summary = packet_mod.summary_view(packet)
+
+    assert "information" not in summary["tickers"][0], (
+        "if the summary ever projects `information`, the cold keys have to be "
+        "reconsidered along with it")
+
+
 def test_exploration_max_book_pct_zero_means_zero_exploration_budget():
     """#666: `exploration_max_book_pct: 0` (0 = 封死探索敞口) is legal config;
     `X or DEFAULT` would silently swallow it into 0.03."""


### PR DESCRIPTION
Found by walking the S-axis worklist ("which signal can the deciding process actually see") into the packet's own budget, since that budget is what every future answer to that question has to fit inside.

## The measurement

`information.attention_components` / `information.event_components` are the per-event rows behind that section's scores. On the 2026-09-04 book (10 holdings):

| | bytes | of cap | headroom |
|---|---:|---:|---:|
| cap (`MAX_PACKET_BYTES`) | 98,304 | | |
| before | 93,780 | **95.4%** | 4,524 |
| after | 75,811 | 77.1% | **22,493** |
| freed | **17,969** | | |

A ticker row costs ~7.8KB. **Before this, the eleventh holding is the one that raises** — and `MAX_PACKET_BYTES` raising is not a warning, it is the pre-open brief getting no packet at all (the 2026-08-17 outage). Buying a stock is not a change anybody runs the packet tests for.

It also means #1349 spent yesterday cutting a decision-relevant field from 3,868 bytes to 810 to fit under a cap that 18KB of unread arithmetic was holding up, and that the `PACKET_BUDGET_WARN_RATIO` added with it has been firing on every preflight since.

## Nothing reads the stored copies

- **Build-time consumers run before the row is assembled**: `classify_authority` (reads `event_components` for the positive events that authorise an add, both lists for the evidence ids it cites) and `_information_sizing_overlay`. Their conclusions are stored — `quant.add_authority.information_modes` / `information_event_ids`.
- `summary_view` — the model's resident input — never projected `information`.
- The pages projection names its fields one by one; `information` is not among them.
- `entry_document` **deletes both keys** on the way to the ledger (#1039, which called them "zero-reader bulk").
- `assets/data/news_evidence_graph.json` carries the same rows and is committed daily under the #951 rolling windows — the canonical store #1039 named.

## Trim at storage, never at computation

The obvious fix — dropping them inside `_information_view` — would have **withdrawn the add authority** rather than shrinking the packet, and silently: fewer authorised adds is not a shape anyone would trace back to a byte count. So the full view still goes to the two consumers and only the stored row is trimmed.

`test_the_authority_reads_the_components_and_the_packet_does_not_store_them` asserts both halves at once — the exploration tier is still granted off `positive-1`, cites both event ids, and the stored row carries none of the arithmetic that granted it. `test_the_summary_the_model_reads_is_unchanged_by_the_trim` pins why this costs the model nothing: the summary does not project `information` at all, and is byte-identical before and after (35,363 both ways on the real book).

https://claude.ai/code/session_01SNNu2J6TV8Y3Gjv3p3Bxup