### PR TITLE
packet: five of the twelve sections could not be asked for

### DIFF
--- a/skills/daily-deep-brief/SKILL.md
+++ b/skills/daily-deep-brief/SKILL.md
@@ -131,7 +131,7 @@ summary 包含 book/concentration、每票 deterministic status、技术/因子�
   --arg ticker=00100 --arg section=technical
 ```
 
-可选 section：`facts|technical|quant|sentiment|evidence|risk|constraints`。一次查询硬上限 24 KiB，并同时校验 manifest hash 与 generation。正常分析禁止 `cat brief-context-{date}.json`，也禁止为了省一次查询而整份读 core/research/market bundle。
+可选 section：`facts|technical|thesis|execution|quant|sentiment|history|information|evidence|risk|status|constraints`。一次查询硬上限 24 KiB，并同时校验 manifest hash 与 generation。正常分析禁止 `cat brief-context-{date}.json`，也禁止为了省一次查询而整份读 core/research/market bundle。
 
 > **为什么走 `clawock tool`**：工具注册表是这套上下文协议唯一机器可读的定义（`clawock tool --list` 直接吐 JSON schema），而 24 KiB 预算是在注册表里强制的。协议实现随 `clawock` wheel 安装；workspace 只提供本次生成的数据，不再提供可执行 Python 源码。输出含 `_meta.generation_id` 代次钉扎。
 

--- a/src/clawock/decision/packet.py
+++ b/src/clawock/decision/packet.py
@@ -54,6 +54,21 @@ PACKET_BUDGET_WARN_RATIO = 0.8
 INFORMATION_COLD_KEYS = ("attention_components", "event_components")
 
 
+#: Sections `decision_packet_query` may narrow a ticker row to.
+#:
+#: Every structured key a compiled row carries belongs here. The list used to
+#: live in `tools/context_tools.py` and had drifted to seven of the twelve:
+#: `information` — the one section `summary_view` does not project either — had
+#: no path of its own at all, so the only way to read it was the whole-row query
+#: both the tool description and SKILL.md tell the agent not to make. Owned here
+#: because this module is what builds the rows; `test_brief_decision_packet`
+#: compiles one and compares.
+QUERYABLE_SECTIONS = (
+    "facts", "technical", "thesis", "execution", "quant", "sentiment",
+    "history", "information", "evidence", "risk", "status", "constraints",
+)
+
+
 def _without_cold_components(information: dict) -> dict:
     """`information` minus the per-event component lists.
 

--- a/src/clawock/tools/context_tools.py
+++ b/src/clawock/tools/context_tools.py
@@ -11,8 +11,9 @@ from clawock.context import brief as brief_context
 from clawock.decision import packet as brief_decision_packet
 from clawock.tools.base import BaseTool, ToolError
 
-SECTIONS = ("facts", "technical", "quant", "sentiment", "evidence", "risk",
-            "constraints")
+# The packet module owns this: it is what builds the rows, and a hand-kept
+# second copy here is how `information` (and four others) ended up unqueryable.
+SECTIONS = brief_decision_packet.QUERYABLE_SECTIONS
 
 
 def _manifest(workspace, manifest) -> Path:

--- a/tests/test_brief_decision_packet.py
+++ b/tests/test_brief_decision_packet.py
@@ -326,6 +326,35 @@ def test_the_authority_reads_the_components_and_the_packet_does_not_store_them()
         assert kept in row["information"]
 
 
+def test_every_structured_section_of_a_row_can_be_asked_for_on_its_own():
+    """A dimension with no section is a dimension nobody narrows to.
+
+    `SECTIONS` was hand-kept in the tool layer and had drifted to seven of the
+    twelve structured keys a row carries. `information` was the expensive one:
+    `summary_view` does not project it either, so the only way to read a
+    ticker's information state was the whole-row query that both the tool
+    description ("Prefer a section") and SKILL.md ("需要单一维度时必须带
+    --section") tell the agent not to make. `history` arrived with #1349 and
+    was never added either.
+    """
+    from clawock.tools import context_tools
+
+    context = _exploration_context()
+    packet = packet_mod.compile_packet(
+        context, brief_context.compute_generation_id(context)
+    )
+    row = packet["tickers"]["00100"]
+    structured = {key for key, value in row.items()
+                  if isinstance(value, (dict, list))}
+
+    assert set(packet_mod.QUERYABLE_SECTIONS) == structured, (
+        "a compiled row and the queryable sections have drifted: "
+        f"unqueryable={sorted(structured - set(packet_mod.QUERYABLE_SECTIONS))} "
+        f"unbuilt={sorted(set(packet_mod.QUERYABLE_SECTIONS) - structured)}")
+    # And the tool layer must not keep a second copy of the answer.
+    assert context_tools.SECTIONS is packet_mod.QUERYABLE_SECTIONS
+
+
 def test_the_summary_the_model_reads_is_unchanged_by_the_trim():
     """The components were never in the resident input, which is why dropping
     them buys headroom without taking anything off the model's desk."""

--- a/tests/test_skill_commands_are_runnable.py
+++ b/tests/test_skill_commands_are_runnable.py
@@ -71,3 +71,29 @@ def test_every_documented_script_path_resolves(doc, lineno, raw):
         f"{doc}:{lineno} tells the agent to run `{raw}`, which resolves to no file "
         f"in this repository — the agent will improvise a path instead"
     )
+
+
+def test_the_documented_section_list_is_one_the_tool_accepts():
+    """Same invariant, one step in: an argument a SKILL.md tells the agent to
+    pass has to be one the tool takes.
+
+    The list is written out three times — the packet builds the sections, the
+    tool enum accepts them, and this document tells the agent which to ask for.
+    The middle copy had drifted to seven of twelve; this pins the third one to
+    the first so it cannot drift on its own. A documented value the tool refuses
+    is a `ToolError` in the middle of a brief, which is the same silent no-op
+    #777 was about.
+    """
+    import sys
+
+    sys.path.insert(0, str(ROOT / "src"))
+    from clawock.decision import packet as packet_mod
+
+    text = (SKILLS / "daily-deep-brief" / "SKILL.md").read_text(encoding="utf-8")
+    match = re.search(r"可选 section：`([^`]+)`", text)
+    assert match, "the skill no longer documents the section list"
+    documented = match.group(1).split("|")
+
+    assert documented == list(packet_mod.QUERYABLE_SECTIONS), (
+        f"documented={documented} accepted={list(packet_mod.QUERYABLE_SECTIONS)}")
+


### PR DESCRIPTION
## The drift

`decision_packet_query`'s `section` enum listed seven names. A compiled row carries twelve structured keys:

| in the enum | not in the enum |
|---|---|
| facts, technical, quant, sentiment, evidence, risk, constraints | **thesis, execution, history, information, status** |

Asking for one of the five returned `unknown section`. The only way to read it was the whole-row query — which the tool description ("Prefer a section") and SKILL.md ("需要单一维度时必须带 `--section`") both tell the agent not to make.

`information` is the one that cost something: `summary_view` does not project it either, so **it was the only section of the packet with no path of its own**. `history` (episode win rates) arrived with #1349 yesterday and was never added.

Measured against the stored 2026-09-04 packet, through the real CLI:

```
--arg section=information    3,967 bytes     (≈800 now that #1373 dropped
--arg section=history          164 bytes      the per-event components)
--arg section=execution        871 bytes
whole row                   10,905 bytes
```

## One owner, two gates

The list is written three times — the packet **builds** the sections, the enum **accepts** them, the skill tells the agent which to **ask for**. Ownership moves to the module that builds the rows (`packet.QUERYABLE_SECTIONS`); the tool layer aliases it rather than keeping a copy.

- `test_every_structured_section_of_a_row_can_be_asked_for_on_its_own` — compiles a real packet, compares its structured keys with the enum in both directions, and asserts the tool layer holds no second copy.
- `test_the_documented_section_list_is_one_the_tool_accepts` — parses the list out of SKILL.md and compares it with the same constant. This is the invariant `test_skill_commands_are_runnable.py` already enforces for commands, one step in: **an argument a SKILL.md tells the agent to pass has to be one the tool takes**, or it is a `ToolError` in the middle of a brief.

Both red on `origin/master`, green here.

https://claude.ai/code/session_01SNNu2J6TV8Y3Gjv3p3Bxup