### PR TITLE
packet: the summary's budget warning had no caller

### DIFF
--- a/src/clawock/decision/packet.py
+++ b/src/clawock/decision/packet.py
@@ -1407,6 +1407,23 @@ def compile_packet(context: dict, generation_id: str | None = None) -> dict:
               f"ceiling ({len(tickers)} tickers) — overrunning it fails preflight "
               f"outright, so trim a projection before the next holding lands",
               file=sys.stderr)
+    # …and the summary's own warning, which is the one the comment above credits
+    # with the lesson. `SUMMARY_BUDGET_WARN_RATIO` and `summary_budget_report`
+    # were written for 2026-08-17 and then never called outside the tests, so
+    # `near_budget` — "the signal that has to fire while there is still room" —
+    # had nowhere to fire. Both budgets are crossed by the same act (buying a
+    # stock), so both belong on the same alarm, at the one place that runs on
+    # every generation.
+    summary = summary_budget_report(packet)
+    if summary["over_budget"] or summary["near_budget"]:
+        print(f"warn: decision packet summary at {summary['bytes']} bytes is "
+              f"{summary['ratio']:.1%} of the {summary['budget']}-byte ceiling "
+              f"({summary['tickers']} tickers) — "
+              + ("`decision_packet_summary` is already refusing, and it is the "
+                 "brief's only resident input"
+                 if summary["over_budget"] else
+                 "`decision_packet_summary` refuses outright at the line"),
+              file=sys.stderr)
     return packet
 
 

--- a/tests/test_brief_decision_packet.py
+++ b/tests/test_brief_decision_packet.py
@@ -1082,6 +1082,48 @@ def test_the_summary_budget_is_measured_against_a_real_sized_book():
     assert report["bytes"] < packet_mod.MAX_PACKET_BYTES
 
 
+def test_the_summary_warning_is_wired_to_something_that_runs(capsys):
+    """The warning existed and nothing ever asked for it.
+
+    `summary_budget_report` and `SUMMARY_BUDGET_WARN_RATIO` were written after
+    2026-08-17, when the summary crossed its cap silently and
+    `decision_packet_summary` — Step 2's 唯一常驻输入 — began refusing. Both
+    were then called only from this file: `near_budget`, described one test
+    below as "the signal that has to fire while there is still room", had
+    nowhere to fire. The packet's own ceiling got its warning in #1349 and its
+    comment credits this one with the lesson, which is how the gap stayed
+    invisible.
+
+    Both budgets are crossed by the same act — buying a stock — so the check
+    belongs where the packet's does: in the one function that runs on every
+    generation.
+    """
+    context = _book_with(2)
+    packet_mod.compile_packet(context, brief_context.compute_generation_id(context))
+    assert "summary at" not in capsys.readouterr().err, (
+        "a small book must not warn, or the signal is noise by the second week")
+
+    # Same code path, a book big enough to be near the line.
+    context = _book_with(2)
+    packet = packet_mod.compile_packet(
+        context, brief_context.compute_generation_id(context))
+    near = int(
+        packet_mod.summary_budget_report(packet)["bytes"]
+        / packet_mod.SUMMARY_BUDGET_WARN_RATIO
+    ) - 1
+    original = packet_mod.MAX_SUMMARY_BYTES
+    packet_mod.MAX_SUMMARY_BYTES = near
+    try:
+        packet_mod.compile_packet(
+            context, brief_context.compute_generation_id(context))
+        warned = capsys.readouterr().err
+    finally:
+        packet_mod.MAX_SUMMARY_BYTES = original
+
+    assert "summary at" in warned, warned
+    assert "resident input" in warned or "refuses outright" in warned, warned
+
+
 def test_a_section_query_keeps_the_tight_cap_the_summary_does_not_use():
     """Two budgets, deliberately: conflating them is what broke production."""
     assert packet_mod.MAX_SUMMARY_BYTES > packet_mod.MAX_QUERY_BYTES


### PR DESCRIPTION
```
$ grep -rn "summary_budget_report" --include=* . | grep -v '^./.git/'
src/clawock/decision/packet.py:2063:def summary_budget_report(packet) -> dict:
tests/test_brief_decision_packet.py:1074:    report = packet_mod.summary_budget_report(packet)
tests/test_brief_decision_packet.py:1117:    small = packet_mod.summary_budget_report(packet)
```

Its own docstring: *"Exists so the next crossing is loud. The 2026-08-17 outage was silent precisely because nothing measured this until the tool already refused to run."* It has never been called outside the tests, so `near_budget` — which `test_the_budget_report_warns_before_it_refuses` calls *"the signal that has to fire while there is still room"* — had nowhere to fire.

The gap was easy to miss: the **packet's** ceiling did get a warning in #1349, and the comment introducing it credits this one with the lesson —

> `SUMMARY_BUDGET_WARN_RATIO` was the answer — and the packet's own ceiling never got one, so the lesson stopped at the smaller of the two numbers.

— while that answer was a function nobody called.

## Why it matters now

Both budgets are crossed by the same act: buying a stock. On the live 2026-09-04 book:

| | bytes | of cap | per holding |
|---|---:|---:|---:|
| summary | 37,520 | 76.3% of 49,152 | 3,752 |

- the **11th** holding crosses the 80% warn line
- the **14th** makes `decision_packet_summary` refuse — and that tool is Step 2's 唯一常驻输入

So this is one holding away from being the useful warning it was written to be, and three from being the outage it was written about.

## The change

`compile_packet` — the one function that runs on every generation, and where the packet's own warning already lives — now also reports the summary's. The test asserts both directions: a small book stays **silent** (a warning that fires every run is noise by the second week), and a book near the line prints one that names the tool which will refuse.

Red on `origin/master`, green here.

https://claude.ai/code/session_01SNNu2J6TV8Y3Gjv3p3Bxup