### PR TITLE
dashboard: a tab whose data never arrived looked like a tab with nothing in it

### DIFF
--- a/site/assets/css/dashboard.css
+++ b/site/assets/css/dashboard.css
@@ -541,6 +541,38 @@
   .pager { display: contents; }   /* desktop: transparent — panels join the grid */
   .panel { display: block; }
 
+  /* ── The two panel states that had no picture ──
+     A tab's data arrives asynchronously and the markup only ever showed the
+     success state: `aria-busy` was set and removed with nothing styled on it,
+     and a failed load wrote to the console. A panel that never filled in
+     therefore looked exactly like a panel with nothing in it — card chrome, a
+     table header, no rows, which reads as "you hold nothing".
+     The pulse is animation-only, so the global prefers-reduced-motion rule
+     above already flattens it. */
+  .panel[aria-busy="true"] { animation: panel-busy 1.1s var(--ease-out) infinite alternate; }
+  @keyframes panel-busy { from { opacity: .5; } to { opacity: .82; } }
+
+  /* The box is addressed through the state the JS sets, so `data-load-error` is
+     load-bearing rather than a comment: no attribute, no message. */
+  .panel-load-error { display: none; }
+  .panel[data-load-error] > .panel-load-error {
+    display: flex; align-items: center; gap: var(--space-3);
+    flex-wrap: wrap;
+    margin: 0 0 var(--space-4);
+    padding: var(--space-3) var(--space-4);
+    background: var(--card-2);
+    border: 1px dashed var(--border-strong);
+    border-radius: var(--radius-sm);
+    color: var(--text-dim); font-size: var(--fs-sm);
+  }
+  .panel-load-retry {
+    font: inherit; color: var(--text); cursor: pointer;
+    background: transparent;
+    border: 1px solid var(--border-strong); border-radius: var(--radius-sm);
+    padding: 4px 12px;
+  }
+  .panel-load-retry:hover { background: var(--border); }
+
   /* ── Mobile (<1024px): iOS-native paged tabs ──
      Fixed chrome (header + footer), the content area is a horizontal
      scroll-snap pager. Each tab is its own page that scrolls vertically.

--- a/site/assets/js/dashboard.ui.js
+++ b/site/assets/js/dashboard.ui.js
@@ -433,19 +433,60 @@
     return changed.some(Boolean);
   }
 
+  // An async panel has three states and the DOM only ever had a picture for
+  // one of them. `aria-busy` was set and removed with nothing styled on it, and
+  // the failure path below wrote to the console — so a tab whose data never
+  // arrived showed its card chrome and an empty table, which reads as "you hold
+  // nothing" rather than "this did not load". The retry is a real <button> for
+  // the same reason the sort headers became ones in #1316.
+  function _panelErrorBox(panel) {
+    return panel.querySelector(":scope > .panel-load-error");
+  }
+
+  function _showPanelLoadError(panel, t) {
+    if (!panel || _panelErrorBox(panel)) return;
+    const box = document.createElement("div");
+    box.className = "panel-load-error";
+    box.setAttribute("role", "status");
+    const text = document.createElement("span");
+    text.textContent = "这一页的数据没能载入 —— 下面显示的是上一次载入的内容。";
+    const retry = document.createElement("button");
+    retry.type = "button";
+    retry.className = "panel-load-retry";
+    retry.textContent = "重试";
+    retry.addEventListener("click", () => {
+      _clearPanelLoadError(panel);
+      activateTabData(t, true);
+    });
+    box.append(text, retry);
+    panel.prepend(box);
+    panel.setAttribute("data-load-error", "true");
+  }
+
+  function _clearPanelLoadError(panel) {
+    if (!panel) return;
+    panel.removeAttribute("data-load-error");
+    const box = _panelErrorBox(panel);
+    if (box) box.remove();
+  }
+
   function _paintActivatedTab(t) {
     if (!DATA || currentTab() !== t) return;
     renderTab(t);
     ensureTabCharts(t);
     const panel = document.querySelector(`.panel[data-panel="${t}"]`);
     if (panel) panel.removeAttribute("aria-busy");
+    _clearPanelLoadError(panel);
     // Desktop shows one panel at a time. Let its layout settle before resizing
     // an existing chart; mobile's scroll-settle listener owns the same nudge.
     if (!pagerLive()) requestAnimationFrame(() =>
       requestAnimationFrame(() => window.dispatchEvent(new Event("resize"))));
   }
 
-  function activateTabData(t) {
+  // `triggeredByUser` is what the retry button passes: both loaders below take
+  // it and turn it into `no-store`, so pressing 重试 re-hops the network instead
+  // of revalidating its way back to the same failure.
+  function activateTabData(t, triggeredByUser = false) {
     const version = ++TAB_ACTIVATION_VERSION;
     const keys = _sidecarsForTab(t);
     const needsFetch = keys.some(k => {
@@ -470,8 +511,10 @@
     }
     Promise.all([
       _loadTabRuntime(t),
-      needsFull ? _loadFullDashboard(generation) : Promise.resolve(FULL_DASHBOARD),
-      _loadTabSidecars(t),
+      needsFull
+        ? _loadFullDashboard(generation, triggeredByUser)
+        : Promise.resolve(FULL_DASHBOARD),
+      _loadTabSidecars(t, triggeredByUser),
     ])
       .then(() => {
         if (version !== TAB_ACTIVATION_VERSION || !DATA || currentTab() !== t) return;
@@ -481,7 +524,9 @@
       })
       .catch(error => {
         console.error(error);
-        if (version === TAB_ACTIVATION_VERSION && panel) panel.removeAttribute("aria-busy");
+        if (version !== TAB_ACTIVATION_VERSION || !panel) return;
+        panel.removeAttribute("aria-busy");
+        _showPanelLoadError(panel, t);
       });
   }
 

--- a/tests/dashboard_tab_runtime.spec.js
+++ b/tests/dashboard_tab_runtime.spec.js
@@ -1209,6 +1209,57 @@ async function testAddSideCardExplainsWhyThereIsNoAdd(browser, base) {
   await page.close();
 }
 
+async function testAPanelSaysWhenItsDataDidNotLoad(browser, base) {
+  // A detail tab needs dashboard.json (191 KB, normally from the data branch)
+  // before it can paint. When that request failed the only trace was
+  // `console.error`: `aria-busy` came back off and the panel kept its card
+  // chrome and an empty table, which reads as "you hold nothing" rather than
+  // "this did not load". Refuse the document on both origins and check the
+  // panel says so — then let it through and check 重试 actually fills it.
+  const page = await browser.newPage({ viewport: { width: 1280, height: 900 } });
+  await stubLiveOrigin(page);
+  let refuse = true;
+  await page.route(/\/assets\/data\/dashboard\.json(?:\?.*)?$/, async route => {
+    if (refuse) return route.abort("failed");
+    const body = fs.readFileSync(path.resolve(ROOT, "assets/data/dashboard.json"), "utf8");
+    await route.fulfill({
+      status: 200,
+      headers: {
+        "content-type": "application/json; charset=utf-8",
+        "access-control-allow-origin": "*",
+      },
+      body,
+    });
+  });
+  await page.goto(base, { waitUntil: "domcontentloaded" });
+  await waitForData(page);
+
+  await page.click('.tab-btn[data-tab="drill"]');
+  const panel = page.locator('.panel[data-panel="drill"]');
+  const box = panel.locator(".panel-load-error");
+  await box.waitFor({ state: "visible", timeout: 15000 });
+  assert.equal(await panel.getAttribute("data-load-error"), "true",
+    "the state the CSS selects on must be on the panel itself");
+  assert.equal(await panel.getAttribute("aria-busy"), null,
+    "a panel that failed is not still busy");
+  const retry = box.locator("button");
+  assert.equal(await retry.count(), 1, "the retry must be one real button");
+  assert.equal(
+    await retry.evaluate(el => el === document.activeElement ||
+      el.tagName === "BUTTON" && !el.disabled),
+    true, "the retry has to be reachable by keyboard");
+  assert.equal(await panel.locator("#book-table tbody tr").count(), 0,
+    "nothing painted, which is exactly why the message has to be there");
+
+  refuse = false;
+  await retry.click();
+  await waitForTab(page, "drill");
+  assert.equal(await box.count(), 0, "the message must clear once the data lands");
+  assert.ok(await panel.locator("#book-table tbody tr").count() > 0,
+    "retry did not actually re-fetch");
+  await page.close();
+}
+
 async function testCronRailAccountsForEverySlotWithoutASecondVerdict(browser, base) {
   // #1270 拆开这块牌的判据是「某个任务挂了」和「页面上的数字不可信」不能共用
   // 一行判词。时刻表折进来时最容易犯的错就是给它再配一句判词 —— 于是同一件事
@@ -1461,6 +1512,7 @@ async function main() {
     await testVerdictDeckFillsItsBoxAndRanksGatesBySeverity(browser, base);
     await testDataHealthNamesTheDegradedSlotAndWeChatDrops(browser, base);
     await testAddSideCardExplainsWhyThereIsNoAdd(browser, base);
+    await testAPanelSaysWhenItsDataDidNotLoad(browser, base);
     await testCronRailAccountsForEverySlotWithoutASecondVerdict(browser, base);
     await testCronNeedsActionMergesIntoTheOneTodoListButWatchDoesNot(browser, base);
   } finally {

--- a/tests/test_dashboard_motion_and_keyboard_contract.py
+++ b/tests/test_dashboard_motion_and_keyboard_contract.py
@@ -97,3 +97,54 @@ def test_the_sort_button_has_a_visible_focus_ring():
     assert re.search(r"\.sort-btn:focus-visible\s*\{[^}]*outline:", CSS), (
         "the sort button has no :focus-visible outline; the holdings rows next "
         "to it have had one since they became focusable")
+
+
+# Every attribute the tab machinery sets on a `.panel` is a claim about what
+# that panel is doing. A claim with no rule behind it is invisible to the person
+# looking at the screen.
+PANEL_STATE_ATTR = re.compile(r'panel\.setAttribute\("([a-zA-Z-]+)"')
+
+
+def test_every_panel_state_the_code_sets_has_a_picture():
+    """`aria-busy` was set and removed with nothing styled on it.
+
+    A detail tab loads `dashboard.json` (191 KB, from the data branch) plus
+    `dashboard.render.js` (266 KB) before it can paint. While that is in flight
+    the panel showed its card chrome and an empty table; if it failed, the only
+    trace was `console.error` and the same empty table — which reads as "you
+    hold nothing", not "this did not load". Two of the three states had no
+    picture, so this asserts over the set of state attributes rather than over
+    the one that was missing.
+    """
+    ui = (JS_DIR / "dashboard.ui.js").read_text(encoding="utf-8")
+    states = set(PANEL_STATE_ATTR.findall(ui))
+
+    assert states, "the tab machinery no longer marks panel state at all"
+    for attr in sorted(states):
+        assert f"[{attr}" in CSS, (
+            f'the code sets `{attr}` on a panel and dashboard.css never selects '
+            f"on it, so the state it announces is invisible to anyone looking "
+            f"at the page")
+
+
+def test_a_panel_whose_load_failed_offers_a_way_back():
+    """Report the failure, and make the retry reachable the way #1316 required.
+
+    The failure path must write to the DOM rather than to the console, and the
+    control it offers must be a real `<button>` — the sort headers of this same
+    dashboard were mouse-only for exactly the reason a `<div onclick>` is.
+    """
+    ui = (JS_DIR / "dashboard.ui.js").read_text(encoding="utf-8")
+    # The tab activation's own failure path, not the renderer loader's.
+    activation = ui[ui.index("function activateTabData"):]
+    activation = activation[:activation.index("\n  function ")]
+    failure = activation[activation.index(".catch(error => {"):]
+
+    assert "_showPanelLoadError" in failure, (
+        "a tab whose data never arrived still only reaches the console")
+    helper = ui[ui.index("function _showPanelLoadError"):]
+    helper = helper[:helper.index("\n  function ")]
+    assert 'createElement("button")' in helper, "the retry must be focusable"
+    assert "panel.prepend" in helper, "the message has to reach the panel itself"
+    assert ".panel-load-error" in CSS and ".panel-load-retry" in CSS
+

--- a/tests/test_dashboard_tab_lifecycle.py
+++ b/tests/test_dashboard_tab_lifecycle.py
@@ -67,7 +67,12 @@ def test_hidden_tabs_have_no_idle_or_timeout_renderer():
 def test_tab_activation_owns_sidecar_fetch_and_inflight_deduplication():
     for contract in (
         "const SIDECAR_STATE = new Map()",
-        "function activateTabData(t)",
+        # `(t` rather than `(t)`, like the line below it has always been: what
+        # this pins is that tab activation is one named owner of the fetch, not
+        # its arity. The exact form went red when the retry button needed a
+        # `triggeredByUser` argument — a signature is shape, and pinning shape
+        # is how a zero-behaviour change reddens a suite (#1364).
+        "function activateTabData(t",
         "function _loadTabSidecars(t",
         "if (state.inFlight) return state.inFlight",
         "if (state.ready && !state.stale)",


### PR DESCRIPTION
维度 L · 类 3（「一个异步区块的加载/空/错误三态是不是都有画面 —— 只有成功态就是一条 issue」）。

## The three states, as they were

A detail tab needs `dashboard.json` (191 KB, normally from the data branch on `raw.githubusercontent.com`) and `dashboard.render.js` (266 KB) before it can paint:

| state | what the code did | what the user saw |
|---|---|---|
| loading | `panel.setAttribute("aria-busy","true")` | **nothing** — no CSS selects on it |
| success | `renderTab(t)` | the panel |
| failure | `console.error(error)` + remove `aria-busy` | **nothing** — card chrome and a sortable table header with no rows |

So a tab that failed to load was indistinguishable from a tab with no data: it reads as *"you hold nothing"*.

Not hypothetical — the document comes from a second origin the code already knows can be unreachable (`LIVE_ORIGIN_BLOCKED` exists for exactly that case), and `dashboard.render.js` is a 266 KB script that can fail on a phone connection.

RED-CHECK, static (this host may not measure rendering — loop instrument rule):

```
--- the failure path of a detail tab ---
.catch(error => {
        console.error(error);
        if (version === TAB_ACTIVATION_VERSION && panel) panel.removeAttribute("aria-busy");
      });
aria-busy has a CSS rule: False
the failure path reaches the DOM: False
AssertionError: aria-busy is set and removed with nothing styled on it
```

## The change

- the failure path prepends one line plus a real `<button>` — 重试;
- the button re-enters `activateTabData` with `triggeredByUser`, which **both** loaders already turn into `no-store`, so it re-hops the network instead of revalidating its way back to the same failure;
- loading gets an opacity pulse, which the file's global `prefers-reduced-motion` wildcard already flattens;
- the message is addressed as `.panel[data-load-error] > .panel-load-error`, so the attribute the JS sets is load-bearing rather than decorative.

## Two gates, at two levels

- **`test_dashboard_motion_and_keyboard_contract.py`** — over the *set*: every attribute the tab machinery sets on a `.panel` must be selected on in `dashboard.css`, so a third state added tomorrow has to come with a picture. Plus the failure path must reach the DOM, and its control must be a `<button>` — the same reason the sort headers of this same table became ones in #1316.
- **`dashboard_tab_runtime.spec.js`** — over the behaviour: refuse `dashboard.json` on both origins, click Holdings, and the panel must say so with one focusable retry and zero table rows; then let the request through, press 重试, and the table must fill and the message clear.

Red without the fix (15 s timeout waiting for the box), green with it. Full browser spec passes locally, 15/15.

## 用户能看到的差别

SURFACE: 面板
现在: 明细页的数据没载入时，面板显示表头和空表格，看上去像「你没有持仓」，唯一的痕迹在 console 里
修完: 同一情形下面板顶部出现「这一页的数据没能载入」和一个能按、也能 Tab 到的重试按钮

https://claude.ai/code/session_01SNNu2J6TV8Y3Gjv3p3Bxup