### PR TITLE
measurement: one capture's failure threw away the other one's data

### DIFF
--- a/.github/workflows/repo-traffic.yml
+++ b/.github/workflows/repo-traffic.yml
@@ -47,6 +47,17 @@ jobs:
           install: none
 
       - name: Capture traffic and package downloads
+        id: traffic
+        # Two perishable measurements share this job, and neither may be lost to
+        # the other's failure. `repo_traffic.py` already honours that rule
+        # internally — a registry outage still writes the GitHub half
+        # (`test_package_downloads_are_advisory_and_never_lose_the_github_half`)
+        # — while the YAML around it did the opposite: `set -euo pipefail` plus a
+        # commit step with no `if` meant a failure in either capture threw away
+        # whatever the other one had already merged. Both 2026-08 failures
+        # (runs 32550935688, 32619875646) died in this step, so the drift
+        # capture never ran at all.
+        continue-on-error: true
         env:
           # The Traffic API does not answer to GITHUB_TOKEN — it only takes a
           # PAT/OAuth token with repo scope (measured 2026-08-23: the workflow
@@ -63,6 +74,8 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Measure how late GitHub delivers the scheduled workflows
+        id: drift
+        continue-on-error: true
         # Every scheduled workflow in this repository is late and nobody kept a
         # number (#781). The Actions API ages runs out too, so this is the same
         # shape of perishable measurement as the traffic above — and the numbers
@@ -85,9 +98,24 @@ jobs:
           echo "COMMIT_MESSAGE=measurement: repo traffic + schedule drift $(date -u +%Y-%m-%d)" >> "$GITHUB_ENV"
 
       - name: Commit the merged history
+        # Whatever did land. A capture that failed leaves its file untouched, so
+        # this commits the half that succeeded rather than discarding it — and
+        # it runs before the verdict below, so the data is safe even as the run
+        # goes red.
         env:
           CLAWOCK_PUBLISH_SSH_KEY: ${{ secrets.CLAWOCK_PUBLISH_SSH_KEY }}
         uses: ./.github/actions/clawock-commit
         with:
           paths: assets/data/repo-traffic.json assets/data/schedule-drift.json
           message: ${{ env.COMMIT_MESSAGE }}
+
+      # `continue-on-error` above keeps one capture's failure from erasing the
+      # other's data — it must not also make the failure invisible. A scheduled
+      # workflow that fails silently is what left news-digest red for three days
+      # in July 2026 (see weekly-health's rollup); the run has to end red so the
+      # rollup can name it.
+      - name: A capture that failed still fails the run
+        if: steps.traffic.outcome == 'failure' || steps.drift.outcome == 'failure'
+        run: |
+          echo "traffic=${{ steps.traffic.outcome }} drift=${{ steps.drift.outcome }}" >&2
+          exit 1

--- a/tests/test_repo_traffic_capture.py
+++ b/tests/test_repo_traffic_capture.py
@@ -13,6 +13,7 @@ import json
 from pathlib import Path
 
 import pytest
+import yaml
 
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = ROOT / "ops" / "growth" / "repo_traffic.py"
@@ -205,3 +206,46 @@ def test_a_contiguous_or_overlapping_window_is_not_a_gap():
     assert repo_traffic.find_gap(stored, [_day("2026-08-20T00:00:00Z", 5, 2)]) is None
     assert repo_traffic.find_gap(stored, [_day("2026-08-21T00:00:00Z", 6, 2)]) is None
     assert repo_traffic.find_gap([], [_day("2026-08-21T00:00:00Z", 6, 2)]) is None
+
+
+def test_one_capture_failing_does_not_discard_the_other_measurement():
+    """The rule this file already enforces inside the script, enforced around it.
+
+    `test_package_downloads_are_advisory_and_never_lose_the_github_half` pins
+    that a registry outage still writes the GitHub half. The workflow that runs
+    the script did the opposite: two perishable captures in one job under
+    `set -euo pipefail`, and a commit step with no condition — so a failure in
+    either one threw away whatever the other had already merged. Both 2026-08
+    failures (runs 32550935688, 32619875646) died in the first step, and the
+    drift capture never ran at all.
+
+    Neither window can be re-fetched: the Traffic API keeps 14 days and the
+    Actions API ages runs out. Losing one because the other failed is the one
+    kind of loss the header of this workflow says cannot be repaired later.
+    """
+    job = yaml.safe_load(
+        (ROOT / ".github/workflows/repo-traffic.yml").read_text(encoding="utf-8")
+    )["jobs"]["capture"]
+    steps = job["steps"]
+    names = [step.get("name") for step in steps]
+    by_name = {step.get("name"): step for step in steps}
+
+    captures = [s for s in steps if s.get("id") in {"traffic", "drift"}]
+    assert len(captures) == 2, "both perishable captures must be identifiable by id"
+    for step in captures:
+        assert step.get("continue-on-error") is True, (
+            f"{step.get('name')!r} still ends the job, taking the other "
+            f"measurement's data with it")
+
+    commit = next(n for n in names if n and n.startswith("Commit"))
+    verdict = next(n for n in names if n and "fails the run" in n)
+    assert names.index(commit) < names.index(verdict), (
+        "the commit has to land before the run is failed, or tolerating the "
+        "capture failure buys nothing")
+
+    # Tolerating the failure must not hide it: a scheduled workflow that ends
+    # green when a capture died is invisible to weekly-health's rollup.
+    condition = by_name[verdict]["if"]
+    assert "steps.traffic.outcome" in condition and "steps.drift.outcome" in condition
+    assert "exit 1" in by_name[verdict]["run"]
+


### PR DESCRIPTION
维度 H（副作用与标记的先后顺序）。The seed for this axis is #1271 — a timeout that landed inside a "deliver, then commit" window. Same shape here, one level up: two side effects share a job, and either one's failure discards the other's.

## What is coupled to what

`repo-traffic.yml` captures **two perishable measurements**:

| step | source | how long the source keeps it |
|---|---|---|
| `repo_traffic.py` | GitHub Traffic API | **14 days** |
| `schedule_drift.py` | Actions run history | ages out |

The workflow's own header: *"This is the one kind of data loss that cannot be repaired later by trying harder."* It is careful about the schedule for exactly that reason — twice a week, four days apart, so a single missed run is harmless.

But each step ran under `set -euo pipefail` and the commit step had no condition, so:

- drift fails → the traffic merge that **already succeeded** is never committed;
- traffic fails → the job stops and drift never runs at all. Both 2026-08 failures ([32550935688](https://github.com/KCNyu/clawock/actions/runs/32550935688), [32619875646](https://github.com/KCNyu/clawock/actions/runs/32619875646)) are this direction.

## The script already honours the rule the YAML broke

`tests/test_repo_traffic_capture.py::test_package_downloads_are_advisory_and_never_lose_the_github_half` pins that a registry outage still writes the GitHub half — *"PyPI and npm both expose longer history through their own APIs, so a registry outage is recoverable. The GitHub window is not."* The invariant held inside the Python and not around it.

## The change

- each capture gets an `id` and `continue-on-error: true`;
- the commit runs **before** the verdict, so the half that landed is safe even as the run goes red;
- a final step fails the run when either capture failed.

That last step is the point: tolerating the failure must not also hide it. A scheduled workflow that ends green with a dead capture is invisible to weekly-health's rollup — which is how `news-digest` failed three days running in July 2026, and how the weekly review lost two weeks this month (#1368).

## Gate

`test_one_capture_failing_does_not_discard_the_other_measurement` — both captures tolerated, commit ordered before verdict, and the verdict naming both step outcomes with a real `exit 1`. Red on `origin/master`.

## 用户能看到的差别

SURFACE: 无（基础设施）
先例: #789 — before it existed, every week that passed permanently erased the only first-party measurement of who reaches this project.

https://claude.ai/code/session_01SNNu2J6TV8Y3Gjv3p3Bxup