### PR TITLE
coverage: the badge said 76% of a list nobody was keeping

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -358,45 +358,21 @@ jobs:
           install: '.[test]'
 
       - name: Unit tests — money-integrity derivations
+        # `--cov=clawock --cov=ops`, not a list of modules. The list was 34
+        # hand-written targets that reached 75 of the 169 modules under
+        # `src/clawock`; the other 94 — 11,385 statements, a third of the
+        # package — sat outside every floor and outside the number the README
+        # badge publishes. Nothing
+        # enumerated the gap, so a new module joined the unmeasured side by
+        # default (`decision/settlement.py`, `decision/add_alpha.py`,
+        # `decision/regime.py`, `decision/plans.py`, `cli.py` all had).
         if: steps.changes.outputs.code == 'true'
         run: |
           python3 -m pytest tests/ -q \
             -n auto \
             --durations=20 \
-            --cov=clawock.publish.dashboard \
-            --cov=clawock.evaluation \
-            --cov=clawock.harness \
-            --cov=clawock.automation \
+            --cov=clawock \
             --cov=ops \
-            --cov=clawock.market_data.integrity \
-            --cov=clawock.market_data.macro \
-            --cov=clawock.market_data.mover_evidence \
-            --cov=clawock.market_data.sentiment \
-            --cov=clawock.context.brief \
-            --cov=clawock.decision.packet \
-            --cov=clawock.evidence.build_evidence \
-            --cov=clawock.decision.ledger \
-            --cov=clawock.decision.earnings \
-            --cov=clawock.decision.entry \
-            --cov=clawock.portfolio.fx \
-            --cov=clawock.instruments \
-            --cov=clawock.json_repair \
-            --cov=clawock.evidence.news_evidence_graph \
-            --cov=clawock.provenance \
-            --cov=clawock.portfolio.realized \
-            --cov=clawock.portfolio.aggregates \
-            --cov=clawock.portfolio.cash \
-            --cov=clawock.portfolio.math \
-            --cov=clawock.portfolio.risk \
-            --cov=clawock.portfolio.integrity \
-            --cov=clawock.decision.risk \
-            --cov=clawock.safe_io \
-            --cov=clawock.evidence.research_surface \
-            --cov=clawock.portfolio.snapshots \
-            --cov=clawock.decision.shadow \
-            --cov=clawock.decision.theses \
-            --cov=clawock.sessions \
-            --cov=clawock.publish.artifacts \
             --cov-report=term-missing:skip-covered \
             --cov-report=json:coverage-report.json
 

--- a/tests/test_ci_consolidation_contract.py
+++ b/tests/test_ci_consolidation_contract.py
@@ -204,3 +204,40 @@ def test_the_shared_probe_reads_the_phase_registry():
 
     assert set(ran) == {f"{w} {p}" for w, p in PHASE_MODULES}, (
         "the probe does not walk PHASE_MODULES; a new phase would land unprobed")
+
+
+def test_the_coverage_gate_measures_the_whole_package_not_a_list():
+    """A hand-kept `--cov=` list makes a new module unmeasured by default.
+
+    It was 34 targets and it reached 75 of the 169 modules under
+    `src/clawock`. The other 94 — 11,385 statements, a third of the package —
+    had no floor over them and were outside the number `assets/data/coverage.json`
+    publishes to the README badge and the dashboard tile. Nothing enumerated the
+    difference, so `decision/settlement.py`, `decision/add_alpha.py`,
+    `decision/regime.py`, `decision/plans.py` and `cli.py` had all joined the
+    unmeasured side simply by being written after the list was.
+
+    Measured whole-package on 2026-09-06: total 73.2% (floor 52), settlement
+    core 84.2% (floor 75) — the floors hold, so the list was buying nothing the
+    package-level target does not.
+    """
+    targets = set(re.findall(r"--cov=([A-Za-z0-9_.]+)", TEXT))
+    assert targets, "the unit-test step no longer measures coverage at all"
+
+    def measured(dotted: str) -> bool:
+        return any(dotted == t or dotted.startswith(t + ".") for t in targets)
+
+    src = ROOT / "src"
+    missing = sorted(
+        str(path.relative_to(ROOT))
+        for path in src.rglob("*.py")
+        if "__pycache__" not in str(path)
+        and not measured(
+            str(path.relative_to(src))[:-3].replace("/", ".").removesuffix(".__init__")
+        )
+    )
+    assert not missing, (
+        "these modules are outside every --cov= target, so no floor covers them "
+        f"and the published percentage does not describe them: {missing[:8]}"
+        f"{'…' if len(missing) > 8 else ''}")
+


### PR DESCRIPTION
维度 I（闸的盲区普查），第 2 问：**新增一个成员，这个闸会自动看见吗？**

## The gate's set was 34 hand-written flags

The unit-test step measured coverage through 34 `--cov=` targets written out in `ci.yml`. They reach **75 of the 169** modules under `src/clawock`. The other **94 — 11,385 statements, a third of the package** — are outside every floor *and* outside the number `assets/data/coverage.json` publishes to the README badge and the dashboard's 测试覆盖率 tile.

Nothing enumerated the difference, so a module written after the list joined the unmeasured side by default. Today that includes:

- `decision/settlement.py`
- `decision/add_alpha.py` — the code that decides whether an add is authorised
- `decision/regime.py`, `decision/plans.py`, `cli.py`

## Measured, not argued

Whole-package run on this checkout (`3371 passed`, `-n 2`):

| | statements | covered | floor |
|---|---:|---:|---:|
| total | 34,816 | **73.2%** | 52 |
| settlement core | 5,768 | **84.2%** | 75 |

Both floors hold with room, and the core percentage is unchanged by definition — same files. **The list was buying nothing the package-level target does not**, while costing the published number its meaning: 76% described 23,431 of 34,816 statements and said so nowhere.

## The change

`--cov=clawock --cov=ops` replaces the list, and `test_the_coverage_gate_measures_the_whole_package_not_a_list` maps every module under `src/` onto the `--cov=` targets and names the ones that fall outside — the enumerating gate this axis asks for, so the list cannot grow back one forgotten module at a time. Red on `origin/master` with all 94 named.

`CORE_MODULES` stays hand-picked on purpose: *"is this money-critical"* is a judgement, not a glob, and `core_summary` already fails loudly when one of them leaves the report.

## 用户能看到的差别

SURFACE: 站点静态页
现在: README 的 COVERAGE 徽章与面板的「测试覆盖率」写着 76%，量的是被人手挑出来的三分之二个代码库，读的人无从知道
修完: 同两个地方写 73%，量的是整个包 —— 少掉的三个点就是那一直没被算进去的一万一千行

https://claude.ai/code/session_01SNNu2J6TV8Y3Gjv3p3Bxup