### PR TITLE
dashboard: three published blocks, no reader — one rendered, two removed

### DIFF
--- a/site/assets/js/dashboard.render.js
+++ b/site/assets/js/dashboard.render.js
@@ -386,6 +386,17 @@
     rows.push(row("今日决策变化", `新增 ${(delta.new || []).length} · 修改 ${(delta.changed || []).length} · 触发 ${(delta.triggered || []).length} · override ${(delta.active_overrides || []).length}`, "var(--text-dim)"));
     if (dm && dm.decisiveness_pct != null)
       rows.push(row("辩论决断率", `${dm.decisiveness_pct}% · 其余=默认 HOLD`, "var(--text-dim)"));
+    // 幅度校准（#1159）。这一行的价值全在它的符号：方向判对、幅度系统性夸大的账本，
+    // 命中率那几格照样好看，而这里是负的 —— 卡上没有第二个数看得出这件事。
+    // `expected_move_pct` 是选填字段，所以先是一条覆盖率序列。
+    const mag = safe(DATA, "magnitude_metrics");
+    if (mag && mag.decisions)
+      rows.push(row("幅度校准",
+        mag.mean_error_pct == null
+          ? `填了预期 ${mag.with_expected_move}/${mag.decisions} · 还没有可打分的 t1`
+          : `填了预期 ${mag.with_expected_move}/${mag.decisions} · 平均偏差 `
+            + `${mag.mean_error_pct > 0 ? "+" : ""}${mag.mean_error_pct.toFixed(1)}% · n=${mag.scored_t1}`,
+        "var(--text-dim)"));
     const fe = [];
     ["catalyst", "technical", "macro", "peer"].forEach(k => {
       const e = drv[k]; if (!e || e.win_rate == null) return;

--- a/src/clawock/publish/dashboard.py
+++ b/src/clawock/publish/dashboard.py
@@ -2731,15 +2731,6 @@ def compute_sector_exposure(portfolio):
     return result
 
 
-def compute_lookthrough_exposure(portfolio):
-    """Dashboard-safe wrapper around the canonical exposure computation."""
-    try:
-        return instrument_registry.compute_lookthrough_exposure(portfolio)
-    except Exception as e:
-        print(f'  warn: compute_lookthrough_exposure failed: {e}', file=sys.stderr)
-        return {leg.key: {} for leg in resolve_legs(portfolio)}
-
-
 def compute_reentry_radar(lev_regime, portfolio):
     """再入场雷达 — 把「持币等回 200MA 再布局」的隐性计划显式化。
 
@@ -2820,35 +2811,6 @@ def compute_leveraged_etf_exposure(portfolio, fx_rate):
         ))
     except Exception as e:
         print(f'  warn: compute_leveraged_etf_exposure failed: {e}', file=sys.stderr)
-    return out
-
-
-def compute_current_holdings_extremes(portfolio, top_n=3):
-    """Top-N winners + bottom-N losers across all active holdings (by pnl_percent)."""
-    out = {'winners': [], 'losers': []}
-    try:
-        rows = []
-        for leg in resolve_legs(portfolio):
-            r_key = leg.key
-            for h in portfolio['portfolios'][leg.bucket].get('holdings', []):
-                if h.get('shares', 0) <= 0:
-                    continue
-                p = h.get('pnl_percent')
-                if p is None:
-                    continue
-                rows.append({
-                    'ticker':      h['ticker'],
-                    'name':        h.get('stock_name') or h.get('name', h['ticker']),
-                    'region':      r_key,
-                    'pnl_percent': round(float(p), 2),
-                    'pnl_abs':     h.get('pnl_abs'),
-                    'current_value': h.get('current_value'),
-                })
-        rows.sort(key=lambda x: x['pnl_percent'], reverse=True)
-        out['winners'] = rows[:top_n]
-        out['losers']  = sorted(rows, key=lambda x: x['pnl_percent'])[:top_n]
-    except Exception as e:
-        print(f'  warn: compute_current_holdings_extremes failed: {e}', file=sys.stderr)
     return out
 
 
@@ -3890,7 +3852,6 @@ def build_projection(previous_source=None, shadow_previous=None):
     fx_rate = (out.get('fx') or {}).get('usdhkd')
     out['drawdown'] = compute_drawdown(snapshots, fx_rate)
     out['sector_exposure'] = compute_sector_exposure(portfolio)
-    out['lookthrough_exposure'] = compute_lookthrough_exposure(portfolio)
     out['leveraged_etf'] = compute_leveraged_etf_exposure(portfolio, fx_rate)
     # Tier 2: pull pre-computed risk metrics (from `clawock portfolio-risk`)
     risk_path = WS_ROOT / 'assets' / 'data' / 'risk.json'
@@ -4046,7 +4007,6 @@ def build_projection(previous_source=None, shadow_previous=None):
     except Exception as e:
         print(f'  warn: regime classify failed: {e}', file=sys.stderr)
 
-    out['current_holdings_extremes'] = compute_current_holdings_extremes(portfolio, top_n=3)
     out['today_ranges'] = compute_today_ranges(portfolio, top_n=8)
     out['realized_vs_unrealized'] = compute_realized_vs_unrealized(portfolio, fx_rate)
     out['capital_deployed'] = compute_capital_deployed(portfolio, fx_rate)

--- a/tests/test_dashboard_payload_readers.py
+++ b/tests/test_dashboard_payload_readers.py
@@ -1,0 +1,86 @@
+"""Every block the dashboard publishes has to be read by the page it is for.
+
+维度 E — 写了没人读. `dashboard.json` is built on every generation and fetched by
+every visitor who opens a detail tab, and it has a hard 200,000-byte cap whose
+overflow is a real loss: `build_dashboard` drops `recent_plans` and then trims
+the embedded snapshot series until the payload fits. So a block nobody renders
+is not free — it is paid for out of the same budget as the history the page
+actually shows.
+
+Two were being paid for on 2026-09-06:
+
+* `current_holdings_extremes` — the 最强最弱 table read it until 46b87e04
+  (2026-08-23) merged four per-ticker tables into one. The reader went; the
+  producer stayed. `today_ranges`, its sibling from that same merge, survived
+  because the merged table reads it — which is what makes this an omission
+  rather than a decision.
+* `lookthrough_exposure` — a fail-soft wrapper around
+  `clawock.instruments.compute_lookthrough_exposure` whose only consumer was
+  this key. The brief reads the canonical function directly and is unaffected.
+
+`magnitude_metrics` was the third, and it went the other way: its own test says
+the signed error "shows up here and in no other number on the dashboard", which
+was true of the number and false of the dashboard. It is now a row on the
+honesty card.
+"""
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SITE = ROOT / "site"
+
+#: Keys that are artifact metadata rather than content: they describe how the
+#: payload was cut, and their readers are `clawock validate-sidecar`, the
+#: dashboard build itself and the tests around them — never the page. Adding to
+#: this list is a claim that a key is not for the reader; make it deliberately.
+METADATA_KEYS = {
+    "snapshots_total",
+    "snapshots_embedded_cap",
+    "plans_count",
+    "recent_plans_cap",
+    "decision_schema_version",
+    "recent_plans_dropped",
+    "payload_over_cap",
+}
+
+SITE_SUFFIXES = {".js", ".html", ".css", ".md"}
+
+
+def _site_text() -> str:
+    return "\n".join(
+        path.read_text(encoding="utf-8", errors="ignore")
+        for path in sorted(SITE.rglob("*"))
+        if path.is_file() and path.suffix in SITE_SUFFIXES and "min.js" not in path.name
+    )
+
+
+def test_every_published_block_has_a_reader_on_the_page(freshly_built_dashboard):
+    """Built from the real tree, so the set is what today's generation carries."""
+    payload = json.loads(freshly_built_dashboard.read_text(encoding="utf-8"))
+    site = _site_text()
+
+    unread = sorted(
+        key for key in payload
+        if key not in METADATA_KEYS
+        and not re.search(r"\b" + re.escape(key) + r"\b", site)
+    )
+    assert not unread, (
+        "these blocks are published on every generation and named nowhere under "
+        f"site/: {unread}. Either render them or stop paying for them out of the "
+        "200,000-byte cap — the overflow path drops recent_plans and trims the "
+        "snapshot series, so unread bytes are taken from the history the page "
+        "does show.")
+
+
+def test_the_metadata_allowlist_does_not_outlive_its_keys():
+    """An allowlist that keeps names the payload no longer has stops describing
+    anything, and quietly grants an exemption to whatever is added with that
+    name later."""
+    source = (ROOT / "src" / "clawock" / "publish" / "dashboard.py").read_text(
+        encoding="utf-8")
+    for key in sorted(METADATA_KEYS):
+        assert f"'{key}'" in source or f'"{key}"' in source, (
+            f"{key} is exempted here but the build no longer writes it")

--- a/tests/test_instrument_registry.py
+++ b/tests/test_instrument_registry.py
@@ -155,7 +155,9 @@ def test_live_dashboard_exposure_has_no_other_and_matches_risk_leverage():
         and h["ticker"] in instrument_registry.leveraged_symbols()
     }
 
-    lookthrough = build_dashboard.compute_lookthrough_exposure(portfolio)
+    # The canonical one. `publish.dashboard` used to re-export it through a
+    # fail-soft wrapper whose only caller was a payload key nothing read.
+    lookthrough = instrument_registry.compute_lookthrough_exposure(portfolio)
     assert lookthrough["us"]["metadata_coverage_pct"] == 100.0
     spacex = next(
         row for row in lookthrough["us"]["factors"] if row["factor"] == "SPACEX"


### PR DESCRIPTION
维度 E（写了没人读），applied to the published payload.

## Why an unread block costs something

`dashboard.json` is rebuilt on every generation, fetched by every visitor who opens a detail tab, and capped at **200,000 bytes**. The overflow path is not cosmetic: it drops `recent_plans`, then trims the embedded snapshot series toward `MIN_SNAPSHOTS_UNDER_BUDGET`. The published payload sits at **191,388 / 200,000 = 95.7%**.

So a block nobody renders is paid for out of the same budget as the history the page does show.

Three top-level keys were named nowhere under `site/`:

### `magnitude_metrics` → rendered

Its own test says the signed error *"shows up here and in no other number on the dashboard"* — true of the number, false of the dashboard. Live it reads:

```
decisions 789 · with_expected_move 20 (2.5%) · scored_t1 6
mean_error_pct −6.3 · direction_agreement 0.5
```

A book that calls direction and overstates size — the shape no other cell on the 诚实自评卡 can show. It is now a row on that card, beside the debate decisiveness it was modelled on (#1159, #1117).

### `current_holdings_extremes` → removed

The 最强最弱 table read it until [`46b87e04`](https://github.com/KCNyu/clawock/commit/46b87e04) (2026-08-23) merged four per-ticker tables into one. The reader went, the producer stayed. `today_ranges` — its sibling from that same merge — survived because the merged table reads it at `dashboard.render.js:2151`, which is what makes this an omission rather than a decision.

### `lookthrough_exposure` → removed from the payload

The producer was a fail-soft wrapper around `clawock.instruments.compute_lookthrough_exposure` whose only consumer was the key. The brief calls the canonical function directly (`brief_preflight.py:1729`) and is untouched; `test_instrument_registry` now calls it there too instead of through a re-export that existed for the deleted key.

## Measured

Same tree built both ways:

```
master build : 171,433
this build   : 168,933
freed        :   2,500
keys removed : current_holdings_extremes, lookthrough_exposure   (added: none)
```

## Gate

`tests/test_dashboard_payload_readers.py` builds the payload from the real tree and asserts **every top-level key is either read somewhere under `site/` or declared as artifact metadata** — plus a second test that the metadata allowlist cannot outlive the keys it names. Red on `origin/master` with all three.

## 用户能看到的差别

SURFACE: 面板
现在: 诚实自评卡上看不到「幅度」这一维 —— 账本里方向对、幅度系统性夸大 6.3% 这件事，面板上没有任何一格显示得出来
修完: 同一张卡多一行「幅度校准 · 填了预期 20/789 · 平均偏差 -6.3% · n=6」

https://claude.ai/code/session_01SNNu2J6TV8Y3Gjv3p3Bxup