### PR TITLE
brief context: the default destination for an unclassified field is a bundle nothing opens

### DIFF
--- a/src/clawock/context/brief.py
+++ b/src/clawock/context/brief.py
@@ -41,6 +41,31 @@ CORE_FIELDS = (
     "issues",
 )
 
+#: Fields only code reads. `decision/packet.py` compiles both of these into the
+#: decision packet; no prompt ever opens them, and the SKILL documents a load
+#: command for every bundle except the one they land in.
+#:
+#: Naming them is the point. `extras` is computed as "everything not assigned
+#: above", so it is the *default* destination for a field nobody classified —
+#: and it is the one bundle the model is never told to load. A field that lands
+#: there by omission is written, shipped, and unreachable, with nothing raised
+#: and nothing logged: the mechanism #1337 was, one level up. The contract test
+#: in `tests/test_context_contract.py` is what keeps this list honest.
+CODE_ONLY_FIELDS = (
+    # Compiled into the decision packet by `decision/packet.py`.
+    "open_decisions",
+    "technical_setup_usage",
+    # Rendered by the harness, not read by a prompt: `harness/brief_render.py`
+    # prints all three into the brief and `publish/dashboard.py` puts them on the
+    # add-side card (#1337-#1341). The model reaches the same facts through the
+    # packet's own projections (`quant.add_authority`, `quant.early_trend`,
+    # `packet.add_alpha_activation`), which is why they are code-only here rather
+    # than a bundle the prompt is told to load.
+    "opportunity",
+    "add_alpha_activation",
+    "action_track_record",
+)
+
 BUNDLE_FIELDS = {
     "risk_detail": (
         "breakeven_math",

--- a/tests/test_brief_context_bundle.py
+++ b/tests/test_brief_context_bundle.py
@@ -186,3 +186,78 @@ def test_watch_list_is_a_market_bundle_field_not_extras():
     silently silenced (a field nothing prints is a detector that has been
     silenced, #515)."""
     assert "watch_list" in brief_context.BUNDLE_FIELDS["market"]
+
+
+def _preflight_context_fields() -> set[str]:
+    """The keys of the `context = {...}` literal `brief_preflight` builds.
+
+    Read statically rather than by running preflight: this has to hold for a
+    field the day it is added, and preflight needs the whole live workspace.
+    """
+    import ast
+
+    source = (ROOT / "src/clawock/harness/brief_preflight.py").read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    best: set[str] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assign) or not isinstance(node.value, ast.Dict):
+            continue
+        targets = [t.id for t in node.targets if isinstance(t, ast.Name)]
+        if "context" not in targets:
+            continue
+        keys = {k.value for k in node.value.keys
+                if isinstance(k, ast.Constant) and isinstance(k.value, str)}
+        if len(keys) > len(best):
+            best = keys
+    assert len(best) > 20, "could not find the preflight context literal"
+    return best
+
+
+def test_every_context_field_is_classified_rather_than_defaulted():
+    """`extras` is the destination for a field nobody classified.
+
+    `write_run_bundle` computes it as "everything not assigned above", and it is
+    the one bundle SKILL.md never gives a load command for. So a field that
+    lands there by omission is written, shipped and unreachable, with nothing
+    raised and nothing logged — the shape #1337 was, one level up: the signal
+    exists and the process that writes decisions has no path to it.
+
+    `test_watch_list_is_a_market_bundle_field_not_extras` pins that for one
+    field (#602). This is the same assertion over the set, which is what the
+    coverage-vs-enforcement judgement in #1273 asks for: a gate on N call sites
+    needs a second gate that enumerates N.
+    """
+    classified = (
+        set(brief_context.CORE_FIELDS)
+        | {field for fields in brief_context.BUNDLE_FIELDS.values() for field in fields}
+        | set(brief_context.CODE_ONLY_FIELDS)
+        | {"generation_id"}
+    )
+    unclassified = sorted(_preflight_context_fields() - classified)
+
+    assert not unclassified, (
+        f"these context fields fall through to `extras`: {unclassified}. Classify "
+        "each one: CORE_FIELDS if every prompt must see it, a BUNDLE_FIELDS group "
+        "if the model should be able to load it on demand, CODE_ONLY_FIELDS if "
+        "only the packet builder reads it. Leaving it to the default ships it to "
+        "a bundle nothing opens.")
+
+
+def test_the_skill_documents_a_load_command_for_every_loadable_bundle():
+    """A bundle the SKILL never names is a bundle the model never opens.
+
+    The pairing is the point: `extras` is deliberately absent from the skill,
+    which is exactly why nothing may land there by accident.
+    """
+    import re
+
+    skill = (ROOT / "skills/daily-deep-brief/SKILL.md").read_text(encoding="utf-8")
+    documented = set(re.findall(r"--arg bundle=([a-z_]+)", skill))
+
+    assert documented == set(brief_context.BUNDLE_FIELDS), (
+        f"documented={sorted(documented)} "
+        f"loadable={sorted(brief_context.BUNDLE_FIELDS)}")
+    assert "extras" not in documented, (
+        "documenting `extras` would make the accident survivable instead of "
+        "impossible; the fields that belong there are the ones only code reads")
+


### PR DESCRIPTION
维度 S（信号 → 动作的可达性）.

## The mechanism

`write_run_bundle` splits the brief context into an always-loaded core, five lazy bundles, and then:

```python
extras = tuple(sorted(set(stamped) - assigned))
```

`extras` is **everything nobody classified** — and it is the one bundle `SKILL.md` gives no `--arg bundle=` command for. A field that lands there by omission is computed, written and shipped, and no prompt will ever open it. Nothing raises, nothing logs.

The repo already knows this, one field at a time. `test_watch_list_is_a_market_bundle_field_not_extras` (#602):

> if it ever slips back to `extras`, the feature is silently silenced (a field nothing prints is a detector that has been silenced, #515)

That is exactly the coverage judgement from #1273 — **a gate on one member needs a second gate that enumerates the set**.

## What the enumeration found

Three fields added since that one was pinned:

```
these context fields fall through to `extras`:
['action_track_record', 'add_alpha_activation', 'opportunity']
```

Those are the add-side reads from #1337–#1341 — the batch whose entire subject was *a signal the deciding process could not see*.

They are fine as they stand: `brief_render.py` prints all three, `dashboard.py` puts them on the add-side card, and the model reaches the same facts through the packet's own projections (`quant.add_authority`, `quant.early_trend`, `packet.add_alpha_activation`). **But nothing said so** — and nothing would have said so if they had needed a prompt to read them.

## The change

`CODE_ONLY_FIELDS` names them with the reason, and two tests hold the shape:

- every key of `brief_preflight`'s `context = {...}` literal must be classified — core, a bundle, or code-only — read by **AST**, so it holds the day a field is added rather than the day someone runs preflight;
- the skill must document a load command for **exactly** the loadable bundles, and `extras` must stay undocumented — documenting it would make the accident survivable instead of impossible.

Red on `origin/master`, with the three names in the failure message.

## 用户能看到的差别

SURFACE: 无（基础设施）
先例: #1337 — 48 次突破、0 条加仓，因为写决策的进程看不见机会。这条闸挡的是同一件事的下一次。

https://claude.ai/code/session_01SNNu2J6TV8Y3Gjv3p3Bxup