### PR TITLE
deck: a layout read inside the per-card writer, once per card, every frame

### DIFF
--- a/site/assets/js/dashboard.hero.js
+++ b/site/assets/js/dashboard.hero.js
@@ -1487,7 +1487,14 @@
       cards[i].style.zIndex = n - i;
     }
     const W = () => stage.clientWidth || 1;
-    function pose(i) {
+    // `pose` writes transform/opacity/visibility on a card, so a layout read
+    // inside it is a read after a write — and `paint` runs it once per card,
+    // inside the spring's requestAnimationFrame loop. Reading `stage.clientWidth`
+    // there flushed layout again for every card after the first, every frame.
+    // The width is a property of the stage, not of the card: measure once in
+    // `paint` and hand it down. Same order the equity tooltip had to learn in
+    // #1334 — measure once, then place.
+    function pose(i, w) {
       const el = cards[i];
       const d = i - cur;
       let tx = 0, ty = 0, sx = 1, op = 1, vis = true;
@@ -1495,12 +1502,12 @@
         vis = false;                                   // 抽完的 / 太深的
       } else if (d < 0) {
         const u = -d;                                  // 抽走进度 0→1
-        tx = -u * W();
+        tx = -u * w;
         op = u <= 0.5 ? 1 : Math.max(0, 1 - (u - 0.5) / 0.5);
       } else {
         const dd = Math.min(d, DEPTH);                 // 台面第 d 层
         ty = PEEK * dd;
-        sx = Math.max(0, 1 - 2 * INSET * dd / W());
+        sx = Math.max(0, 1 - 2 * INSET * dd / w);
       }
       el.style.visibility = vis ? "visible" : "hidden";
       el.style.opacity = op === 1 ? "" : op.toFixed(3);
@@ -1510,7 +1517,7 @@
       if (el.inert !== !top) el.inert = !top;
       el.setAttribute("aria-hidden", top ? "false" : "true");
     }
-    function paint() { for (let i = 0; i < n; i++) pose(i); }
+    function paint() { const w = W(); for (let i = 0; i < n; i++) pose(i, w); }
     function paintDots() {
       dots.forEach((d, i) => d.setAttribute("aria-current", i === idx ? "true" : "false"));
     }

--- a/site/assets/js/dashboard.render.js
+++ b/site/assets/js/dashboard.render.js
@@ -2809,7 +2809,14 @@
       cards[i].style.zIndex = n - i;
     }
     const W = () => stage.clientWidth || 1;
-    function pose(i) {
+    // `pose` writes transform/opacity/visibility on a card, so a layout read
+    // inside it is a read after a write — and `paint` runs it once per card,
+    // inside the spring's requestAnimationFrame loop. Reading `stage.clientWidth`
+    // there flushed layout again for every card after the first, every frame.
+    // The width is a property of the stage, not of the card: measure once in
+    // `paint` and hand it down. Same order the equity tooltip had to learn in
+    // #1334 — measure once, then place.
+    function pose(i, w) {
       const el = cards[i];
       const d = i - cur;
       let tx = 0, ty = 0, sx = 1, op = 1, vis = true;
@@ -2817,12 +2824,12 @@
         vis = false;                                   // 抽完的 / 太深的
       } else if (d < 0) {
         const u = -d;                                  // 抽走进度 0→1
-        tx = -u * W();
+        tx = -u * w;
         op = u <= 0.5 ? 1 : Math.max(0, 1 - (u - 0.5) / 0.5);
       } else {
         const dd = Math.min(d, DEPTH);                 // 台面第 d 层
         ty = PEEK * dd;
-        sx = Math.max(0, 1 - 2 * INSET * dd / W());
+        sx = Math.max(0, 1 - 2 * INSET * dd / w);
       }
       el.style.visibility = vis ? "visible" : "hidden";
       el.style.opacity = op === 1 ? "" : op.toFixed(3);
@@ -2832,7 +2839,7 @@
       if (el.inert !== !top) el.inert = !top;
       el.setAttribute("aria-hidden", top ? "false" : "true");
     }
-    function paint() { for (let i = 0; i < n; i++) pose(i); }
+    function paint() { const w = W(); for (let i = 0; i < n; i++) pose(i, w); }
     function paintDots() {
       dots.forEach((d, i) => d.setAttribute("aria-current", i === idx ? "true" : "false"));
     }

--- a/tests/test_dashboard_motion_and_keyboard_contract.py
+++ b/tests/test_dashboard_motion_and_keyboard_contract.py
@@ -148,3 +148,48 @@ def test_a_panel_whose_load_failed_offers_a_way_back():
     assert "panel.prepend" in helper, "the message has to reach the panel itself"
     assert ".panel-load-error" in CSS and ".panel-load-retry" in CSS
 
+
+#: Properties whose read forces the browser to flush pending style writes.
+LAYOUT_READS = re.compile(
+    r"clientWidth|clientHeight|offsetWidth|offsetHeight|scrollWidth|scrollHeight"
+    r"|getBoundingClientRect")
+
+
+def _function_body(source: str, name: str) -> str:
+    """The braces-balanced body of `function <name>(`."""
+    start = source.index(f"function {name}(")
+    depth = 0
+    for i in range(source.index("{", start), len(source)):
+        if source[i] == "{":
+            depth += 1
+        elif source[i] == "}":
+            depth -= 1
+            if depth == 0:
+                return source[start:i + 1]
+    raise AssertionError(f"unbalanced body for {name}")
+
+
+def test_the_deck_measures_once_per_paint_not_once_per_card():
+    """A layout read inside a per-card writer is a read after a write.
+
+    `pose` sets `visibility`, `opacity` and `transform` on one card, and `paint`
+    runs it once per card from inside the spring's `requestAnimationFrame` loop.
+    Reading `stage.clientWidth` inside `pose` therefore flushed layout again for
+    every card after the first, on every frame of every deck transition — the
+    read-write-read-write alternation the worklist defines as thrash, as opposed
+    to the one-read-then-write that computing a position legitimately needs.
+
+    The width belongs to the stage, not to the card, so `paint` measures once and
+    hands it down. Both bundles carry this deck by hand (see
+    `test_dashboard_bundle_parity`), so both are asserted.
+    """
+    for path in (JS_DIR / "dashboard.hero.js", JS_DIR / "dashboard.render.js"):
+        source = path.read_text(encoding="utf-8")
+        pose = _function_body(source, "pose")
+        assert not LAYOUT_READS.search(pose), (
+            f"{path.name}: `pose` reads layout while writing card styles; "
+            "measure in `paint` and pass the value in")
+        paint = _function_body(source, "paint")
+        assert "W()" in paint and "pose(i, w)" in paint, (
+            f"{path.name}: `paint` must take the one measurement the cards share")
+


### PR DESCRIPTION
维度 L · 类 2（布局稳定性与渲染成本）。The worklist says a finding here has to **name the function and the read-after-write pair**. This one:

```js
const W = () => stage.clientWidth || 1;
function pose(i) {
  …
  tx = -u * W();                                  // READ  (layout flush)
  sx = Math.max(0, 1 - 2 * INSET * dd / W());     // READ  (again)
  el.style.visibility = …;                        // WRITE
  el.style.opacity    = …;                        // WRITE
  el.style.transform  = …;                        // WRITE
}
function paint() { for (let i = 0; i < n; i++) pose(i); }
```

and `paint()` is called from the spring's `requestAnimationFrame` step. So every card after the first read `clientWidth` with style writes pending, and the browser had to flush layout to answer — **n times per frame, for the whole length of every deck transition**.

That is the read-write-read-write alternation the worklist defines as thrash, as opposed to the one-read-then-write that computing a position legitimately needs — the same distinction that made #1332 not a defect and #1334 one.

## The change

The width belongs to the stage, not to the card:

```js
function pose(i, w) { … }
function paint() { const w = W(); for (let i = 0; i < n; i++) pose(i, w); }
```

Behaviour is identical — `stage.clientWidth` cannot change between two cards of the same frame, and the resize listener already repaints. Both bundles carry this deck by hand (`test_dashboard_bundle_parity`), so both are patched identically.

## Gate

`test_the_deck_measures_once_per_paint_not_once_per_card`: `pose` may contain no layout-reading property in either bundle, and `paint` must take the one measurement they share. Red on `origin/master` for both files.

`tests/dashboard_tab_runtime.spec.js` passes locally, 15/15 — the deck's own spec (`testVerdictDeckFillsItsBoxAndRanksGatesBySeverity`) included.

## 用户能看到的差别

SURFACE: 面板
现在: 翻判定牌时，每一帧都为每张牌各强制一次同步布局，牌越多越明显（手机上最先看出来）
修完: 同样的动画每帧只量一次；牌数不再影响每帧的布局次数

https://claude.ai/code/session_01SNNu2J6TV8Y3Gjv3p3Bxup