### PR TITLE
push: a 120s cap on a push that re-runs a 57s hook three times

### DIFF
--- a/ops/host/cron_health_check.py
+++ b/ops/host/cron_health_check.py
@@ -264,6 +264,12 @@ def publish_backlog(ledger, now=None):
     for over a day. There was nothing to check, and an instruction to go look at
     something that is not wrong is how a health line stops being read.
 
+    The instruction is deliberately two-sided. It read "check what pre-push is
+    refusing" until 2026-09-06, and that named the wrong half: every `push
+    failed` in the openclaw session history is `safe_push.sh ... timed out after
+    120 seconds`, none is a refusal. A backlog means the push did not land, and
+    the caller hanging up is as much a cause as the hook saying no.
+
     Stale does not escalate. The host measures this live every twenty minutes in
     `system_check.check_publish_backlog`, which is the authority whenever this
     mirror can only see history — and a host silent long enough for the reading
@@ -287,7 +293,8 @@ def publish_backlog(ledger, now=None):
             return {'state': 'degraded', 'count': count,
                     'age_hours': None if age_h is None else round(age_h, 1),
                     'detail': f'{count} commit(s) committed here and never '
-                              f'published — check what pre-push is refusing'}
+                              f'published — the push did not land: refused by '
+                              f'pre-push, or cut off before it finished'}
         return {'state': 'ok', 'count': count,
                 'age_hours': None if age_h is None else round(age_h, 1),
                 'detail': reading}

--- a/ops/system_check.py
+++ b/ops/system_check.py
@@ -940,7 +940,8 @@ def check_publish_backlog(r):
     if count >= BACKLOG_WARN_COMMITS or (hours is not None and hours >= BACKLOG_WARN_HOURS):
         r.add('publish backlog', WARNING,
               f'{detail} — the desk is committing but not publishing; '
-              f'check what pre-push is refusing')
+              f'the push did not land: refused by pre-push, or cut off '
+              f'before it finished')
     else:
         r.add('publish backlog', OK, detail)
 

--- a/src/clawock/harness/_harness_common.py
+++ b/src/clawock/harness/_harness_common.py
@@ -450,6 +450,35 @@ def dashboard_publication_state(ws=None):
     return 'published'
 
 
+# Every `git push` inside safe_push.sh re-runs `.githooks/pre-push`, and that
+# hook's cost is `ops/system_check.py` — 53.9 / 56.0 / 59.7 / 61.3 s measured
+# four times on the live host (2026-09-06, idle; a loaded, swapping host is
+# slower). safe_push.sh pays that once per attempt, up to MAX_RETRIES=3, with a
+# 3s + 6s backoff between them. So the budget this call needs is a function of
+# the retry ladder, not a round number:
+#
+#   3 attempts x 90s + 9s of backoff = 279s
+#
+# The old cap was 120s, which could not cover two attempts of a hook measured at
+# ~57s — i.e. the retry machinery that exists to survive a lost push race could
+# never run to the end of its second attempt. Every `push failed` recorded in
+# the openclaw session history (30+ occurrences to 2026-09-05) is this timeout;
+# not one is a refusal by the hook. The commits then sit unpushed until some
+# later push happens to win on its first attempt.
+#
+# There is no outer timeout to respect: the cron payloads say explicitly that
+# the postflight is never wrapped in `timeout` and never killed (#765), and the
+# shell publishers (gold_dca_refresh.sh, commit_dreaming.sh) exec safe_push.sh
+# with no cap at all. This one caller was the only place the script was cut off
+# mid-run.
+SAFE_PUSH_ATTEMPTS = 3            # ops/publish/safe_push.sh MAX_RETRIES
+PREPUSH_ATTEMPT_SECONDS = 90      # pre-push hook (57s measured) + fetch/rebase + transfer
+PUSH_RETRY_BACKOFF_SECONDS = 9    # safe_push.sh: sleep i*3 after attempts 1 and 2
+PUSH_TIMEOUT_SECONDS = (
+    SAFE_PUSH_ATTEMPTS * PREPUSH_ATTEMPT_SECONDS + PUSH_RETRY_BACKOFF_SECONDS
+)
+
+
 def push_with_rebase_retry(remote='origin', branch='master', attempts=3):
     """git push via safe_push.sh — THE single hardened push path. Returns
     (pushed_ok, last_output).
@@ -465,11 +494,16 @@ def push_with_rebase_retry(remote='origin', branch='master', attempts=3):
     Delegating keeps every committer's push behaviour identical, per the header
     contract in safe_push.sh. `attempts` is kept for API compat (safe_push.sh has
     its own MAX_RETRIES=3).
+
+    The timeout is PUSH_TIMEOUT_SECONDS — derived from that retry ladder above,
+    because a cap smaller than the ladder turns every lost push race into a
+    stranded commit.
     """
     script = WS / 'ops' / 'publish' / 'safe_push.sh'
     try:
         r = subprocess.run(['bash', str(script), remote, branch],
-                           capture_output=True, text=True, timeout=120, cwd=str(WS))
+                           capture_output=True, text=True,
+                           timeout=PUSH_TIMEOUT_SECONDS, cwd=str(WS))
         return r.returncode == 0, (r.stdout + r.stderr).strip()[-500:]
     except Exception as e:
         return False, str(e)

--- a/tests/test_push_budget_covers_its_retry_ladder.py
+++ b/tests/test_push_budget_covers_its_retry_ladder.py
@@ -1,0 +1,176 @@
+"""Nobody may cap `safe_push.sh` below the retry ladder it is going to run.
+
+2026-09-06. `push_with_rebase_retry` wrapped the script in `timeout=120`. The
+script pushes up to `MAX_RETRIES=3` times, and **every one of those pushes
+re-runs `.githooks/pre-push`**, whose cost is `ops/system_check.py` — measured
+four times on the live host that day, idle: 53.9 / 56.0 / 59.7 / 61.3 s. So the
+cap could not cover two attempts, and the retry machinery that exists to survive
+a lost push race could never reach the end of its second one. Every `push
+failed` string in the openclaw session history is that timeout; not one is a
+refusal by the hook. The commits stayed on the host (10 of 14 slots on the
+2026-09-04 evening reported `data_plane_status: committed_local`).
+
+The gate is the same shape as `test_llm_workflow_deadlines`: a per-attempt
+timeout smaller than the budget the attempt actually needs is not a safety
+margin, it is a guarantee of failure. Two halves:
+
+  1. the constants in `_harness_common` still describe the ladder that
+     `safe_push.sh` really runs (attempts and backoff are read out of the shell
+     script, so changing the script without the budget trips this);
+  2. every caller that hands `safe_push.sh` to `subprocess` either passes no
+     timeout at all (the shell publishers) or one big enough for the ladder.
+"""
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SAFE_PUSH = ROOT / 'ops' / 'publish' / 'safe_push.sh'
+PRE_PUSH = ROOT / '.githooks' / 'pre-push'
+
+import sys
+sys.path.insert(0, str(ROOT / 'src'))
+from clawock.harness._harness_common import (  # noqa: E402
+    PREPUSH_ATTEMPT_SECONDS,
+    PUSH_RETRY_BACKOFF_SECONDS,
+    PUSH_TIMEOUT_SECONDS,
+    SAFE_PUSH_ATTEMPTS,
+)
+
+
+def _shell_attempts() -> int:
+    m = re.search(r'^MAX_RETRIES=(\d+)', SAFE_PUSH.read_text(), re.M)
+    assert m, 'safe_push.sh no longer declares MAX_RETRIES'
+    return int(m.group(1))
+
+
+def _shell_backoff(attempts: int) -> int:
+    """The script sleeps `i * 3` after every attempt but the last."""
+    m = re.search(r'sleep \$\(\(i \* (\d+)\)\)', SAFE_PUSH.read_text())
+    assert m, 'safe_push.sh no longer backs off between attempts'
+    step = int(m.group(1))
+    return sum(i * step for i in range(1, attempts))
+
+
+def test_the_declared_ladder_is_the_one_safe_push_runs():
+    attempts = _shell_attempts()
+    assert SAFE_PUSH_ATTEMPTS == attempts, (
+        f'safe_push.sh retries {attempts}x, the budget assumes '
+        f'{SAFE_PUSH_ATTEMPTS}x')
+    assert PUSH_RETRY_BACKOFF_SECONDS == _shell_backoff(attempts), (
+        'the backoff ladder in safe_push.sh changed; re-derive '
+        'PUSH_RETRY_BACKOFF_SECONDS from it')
+
+
+def test_the_budget_covers_every_attempt_not_just_the_first():
+    assert PUSH_TIMEOUT_SECONDS >= (
+        SAFE_PUSH_ATTEMPTS * PREPUSH_ATTEMPT_SECONDS + PUSH_RETRY_BACKOFF_SECONDS
+    ), ('the push budget cannot pay for the retries safe_push.sh will run — a '
+        'lost race then strands the commit instead of rebasing past it')
+
+
+def test_the_per_attempt_cost_is_still_dominated_by_the_hook_it_names():
+    """PREPUSH_ATTEMPT_SECONDS is a measurement of `ops/system_check.py` running
+    inside the hook. If the hook stops running it, the number is about nothing
+    and has to be re-measured rather than inherited."""
+    hook = PRE_PUSH.read_text()
+    assert 'ops/system_check.py' in hook, (
+        'the pre-push hook no longer runs system_check — re-measure '
+        'PREPUSH_ATTEMPT_SECONDS instead of keeping a number that described it')
+
+
+def _names_bound_to_safe_push(node) -> set[str]:
+    """Locals whose value is (or contains) the path to safe_push.sh.
+
+    `_harness_common` binds it with `script = WS / ... / 'safe_push.sh'`, the
+    gold publisher iterates over argv tuples with the path inline — both have to
+    be reachable from the call site, which only mentions the local.
+    """
+    names = set()
+    for sub in ast.walk(node):
+        if isinstance(sub, ast.Assign) and 'safe_push' in ast.unparse(sub.value):
+            for target in sub.targets:
+                names.update(n.id for n in ast.walk(target)
+                             if isinstance(n, ast.Name))
+        elif isinstance(sub, ast.For) and 'safe_push' in ast.unparse(sub.iter):
+            names.update(n.id for n in ast.walk(sub.target)
+                         if isinstance(n, ast.Name))
+    return names
+
+
+def _subprocess_calls_on_safe_push():
+    """Every subprocess call whose argv is safe_push.sh.
+
+    Argv, not the enclosing function: `system_check.check_publish_backlog` names
+    the script in its docstring and runs `git rev-list` with a 10s cap, which is
+    correct and must not be read as a caller of it.
+    """
+    found = {}
+    for path in sorted(list((ROOT / 'src').rglob('*.py'))
+                       + list((ROOT / 'ops').rglob('*.py'))):
+        source = path.read_text()
+        if 'safe_push' not in source:
+            continue
+        try:
+            tree = ast.parse(source)
+        except SyntaxError:  # pragma: no cover - not our file to fix
+            continue
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef,
+                                     ast.Module)):
+                continue
+            bound = _names_bound_to_safe_push(node)
+            for call in ast.walk(node):
+                if not isinstance(call, ast.Call):
+                    continue
+                fn = ast.unparse(call.func)
+                if not fn.startswith(('subprocess.run', 'subprocess.Popen',
+                                      'subprocess.check_call',
+                                      'subprocess.check_output')):
+                    continue
+                argv = ' '.join(ast.unparse(a) for a in call.args)
+                mentions = 'safe_push' in argv or any(
+                    re.search(rf'\b{re.escape(n)}\b', argv) for n in bound)
+                if not mentions:
+                    continue
+                kw = {k.arg: k.value for k in call.keywords}
+                where = getattr(node, 'name', '<module>')
+                # Walking the module and then each function reaches the same
+                # call twice; the call site, not the walk, is the unit.
+                found[(path, call.lineno)] = (path.relative_to(ROOT), where,
+                                              call.lineno, kw.get('timeout'))
+    return list(found.values())
+
+
+def test_no_caller_cuts_safe_push_off_mid_ladder():
+    calls = _subprocess_calls_on_safe_push()
+    assert calls, 'found no subprocess caller of safe_push.sh — the scan broke'
+    too_small = []
+    for rel, func, lineno, timeout in calls:
+        if timeout is None:
+            continue  # the shell publishers cap nothing, which is allowed
+        if isinstance(timeout, ast.Constant) and isinstance(timeout.value, (int, float)):
+            value = timeout.value
+        elif isinstance(timeout, ast.Name):
+            value = {'PUSH_TIMEOUT_SECONDS': PUSH_TIMEOUT_SECONDS}.get(timeout.id)
+            if value is None:
+                too_small.append(f'{rel}:{lineno} ({func}) timeout={timeout.id} '
+                                 f'— not a budget this gate can read')
+                continue
+        else:
+            too_small.append(f'{rel}:{lineno} ({func}) timeout is an expression '
+                             f'this gate cannot evaluate')
+            continue
+        if value < PUSH_TIMEOUT_SECONDS:
+            too_small.append(
+                f'{rel}:{lineno} ({func}) caps safe_push.sh at {value}s, below '
+                f'the {PUSH_TIMEOUT_SECONDS}s its retry ladder needs')
+    assert not too_small, '\n'.join(too_small)
+
+
+if __name__ == '__main__':  # pragma: no cover
+    raise SystemExit(pytest.main([__file__, '-q']))


### PR DESCRIPTION
维度 H · 「timeout 的秒数跟它包住的那段的 p90 耗时是什么关系」——种子是 #1271。

## The finding

`push_with_rebase_retry` runs the one hardened push path under `timeout=120`:

```python
r = subprocess.run(['bash', str(script), remote, branch], …, timeout=120, cwd=str(WS))
```

`ops/publish/safe_push.sh` is a **retry ladder**:

```bash
MAX_RETRIES=3
for i in $(seq 1 $MAX_RETRIES); do
  if git push "$REMOTE" "$BRANCH"; then … exit 0; fi
  git -c rebase.autoStash=true pull --rebase … && sleep $((i * 3))
done
```

Each `git push` re-runs `.githooks/pre-push`, and that hook's cost is
`python3 "$WS/ops/system_check.py"`. Measured on the live host, idle, four times
on 2026-09-06: **53.9 / 56.0 / 59.7 / 61.3 s**.

⇒ **two attempts already exceed the cap.** The rebase-retry machinery — which
exists precisely so a lost push race does not strand a commit — can never run to
the end of its second attempt. Whenever `origin/master` has moved since the
last fetch (GH Actions and the other cron legs commit there all day), the push
is guaranteed to die by timeout.

## This is not hypothetical

Every recorded push failure in the openclaw session history is this timeout, and
there is no other kind:

```
$ grep -rhoE "committed \(push failed: [^\"]{0,200}" /root/.openclaw/
     22 …safe_push.sh', 'origin', 'master']' timed out after 120 seconds; dashboard=published
      6 …safe_push.sh', 'origin', 'master']' timed out after 120 seconds
      4 committed (push failed: safe_push.sh timed out after 120s; dashboard=published)
```

`assets/data/workflow-outcomes.json`, 2026-09-04 evening → 09-05 04:03:
**10 of 14 consecutive slots** ended `data_plane_status: committed_local`, with
`unpushed_commits` climbing 4 → 6. The GHA cron-health run that Saturday then
reported `✗ 美股收盘报告 expected 1 commits, got 0` — the report had been
delivered (Telegram), the commit was made, and only the push was cut off.

## RED-CHECK (against `origin/master`)

```
origin/master: cap=120s  attempts=3  one pre-push measured 53.9s
  needs >= 162s, covers 2.2 attempts
AssertionError: 120s cannot cover 3 attempts of 53.9s each
```

## The change

The budget is now **derived from the ladder** instead of picked:

```python
SAFE_PUSH_ATTEMPTS = 3            # ops/publish/safe_push.sh MAX_RETRIES
PREPUSH_ATTEMPT_SECONDS = 90      # pre-push hook (57s measured) + fetch/rebase + transfer
PUSH_RETRY_BACKOFF_SECONDS = 9    # safe_push.sh: sleep i*3 after attempts 1 and 2
PUSH_TIMEOUT_SECONDS = 3 * 90 + 9  # 279
```

Nothing outside wants a smaller number: `config/cron-payloads/intraday.md` and
`brief.md` say in as many words that the postflight is never wrapped in
`timeout` and never killed (#765), and the shell publishers
(`gold_dca_refresh.sh`, `commit_dreaming.sh`) `exec` the same script with no cap
at all. This one caller was the only place safe_push.sh was cut off mid-run.

Both copies of the health line — `ops/host/cron_health_check.py` and
`ops/system_check.py` — said **"check what pre-push is refusing"**. Nothing was
ever refusing. They now name the other half: *the push did not land: refused by
pre-push, or cut off before it finished*.

## Gate

`tests/test_push_budget_covers_its_retry_ladder.py`:

- reads `MAX_RETRIES` and the `sleep $((i * 3))` ladder **out of safe_push.sh**
  and asserts the Python constants still describe it;
- asserts `PUSH_TIMEOUT_SECONDS >= attempts × per-attempt + backoff`;
- asserts the hook still runs `system_check.py`, because that is what the
  per-attempt number measures — if the hook gets cheap the constant must be
  re-measured, not inherited;
- **enumerates every `subprocess` caller of the script by argv** (not by
  filename or by the enclosing function — `check_publish_backlog` mentions
  safe_push.sh in a docstring and correctly caps `git rev-list` at 10s), and
  fails any that caps it below the budget. Today that is
  `_harness_common.py:504` and `gold/update.py:122` (no cap, allowed).

## 用户能看到的差别

SURFACE: 面板
现在: 每当 origin/master 在这一槽期间前进过，那一槽的账本/快照/dashboard 状态就留在本机，公开仓库上看不见；周六的健康页把它读成「pre-push 在拒绝」，而没有任何东西被拒绝过
修完: 同一槽的推送有 279 秒把三次重试跑完，竞争到的提交靠 rebase 追上去；真的没推上去时，那行字不再指着一个从来没发生过的原因

https://claude.ai/code/session_01XmfyuJBfqFbidQNoN7SGaP