### PR TITLE
push: the rebase leg cannot run where the bot is forbidden to configure an identity

### DIFF
--- a/ops/publish/safe_push.sh
+++ b/ops/publish/safe_push.sh
@@ -83,6 +83,31 @@ if [ -n "$PORTFOLIO_TOUCHED" ]; then
   fi
 fi
 
+# ── Replay identity (2026-09-06) ─────────────────────────────────────────────
+# `pull --rebase` REWRITES commits, so it needs a committer identity — and the
+# bot callers are forbidden to configure one. `gha_commit_push.sh` injects the
+# bot per `git commit` with `-c` precisely so that running in a real workspace
+# can never clobber kcn's interactive identity (memory:
+# feedback-commit-identity-kcnyu), and a GitHub-hosted runner supplies nothing
+# else. So on a runner the rebase died on `fatal: empty ident name` and this
+# script announced "✗ rebase conflict — abort" for a push whose only problem was
+# ref lag: sentiment-scan 2026-08-28 and 2026-08-30, where the retry ladder's
+# entire purpose (survive a lost race) never got to run. The script's header
+# promises every committer identical push behaviour; without this it was one
+# attempt on a runner and three everywhere else.
+#
+# Replayed under HEAD's OWN committer, so this adds no second answer to "who is
+# the bot" and is a no-op wherever git can already resolve an identity.
+# Supplied through the environment rather than `-c`: GIT_COMMITTER_* wins over
+# config AND over the empty gecos name that is the actual failure on a runner,
+# and it touches no config file at all.
+REPLAY_ID=()
+if ! git var GIT_COMMITTER_IDENT >/dev/null 2>&1; then
+  REPLAY_ID=(env "GIT_COMMITTER_NAME=$(git log -1 --format=%cn)"
+                 "GIT_COMMITTER_EMAIL=$(git log -1 --format=%ce)")
+  echo "▸ no git identity here — replaying as $(git log -1 --format='%cn <%ce>')"
+fi
+
 for i in $(seq 1 $MAX_RETRIES); do
   if git push "$REMOTE" "$BRANCH"; then
     echo "✓ pushed on attempt $i"
@@ -92,7 +117,7 @@ for i in $(seq 1 $MAX_RETRIES); do
 
   # -c rebase.autoStash=true → tolerate a dirty working tree during the rebase.
   git fetch -q "$REMOTE" "$BRANCH" >/dev/null 2>&1 || true
-  if git -c rebase.autoStash=true pull --rebase "$REMOTE" "$BRANCH"; then
+  if "${REPLAY_ID[@]}" git -c rebase.autoStash=true pull --rebase "$REMOTE" "$BRANCH"; then
     echo "  rebase clean, will retry push"
     sleep $((i * 3))
   else
@@ -110,7 +135,7 @@ for i in $(seq 1 $MAX_RETRIES); do
           [ -d "$(git rev-parse --git-path rebase-apply)" ]; do
       CONFLICTS=$(git diff --name-only --diff-filter=U)
       if [ -z "$CONFLICTS" ]; then
-        GIT_EDITOR=true git rebase --continue >/dev/null 2>&1 || { AUTO_OK=false; break; }
+        GIT_EDITOR=true "${REPLAY_ID[@]}" git rebase --continue >/dev/null 2>&1 || { AUTO_OK=false; break; }
         continue
       fi
       if echo "$CONFLICTS" | grep -vqE "$GENERATED"; then
@@ -121,7 +146,7 @@ for i in $(seq 1 $MAX_RETRIES); do
         git checkout --theirs -- "$f" 2>/dev/null || git checkout --ours -- "$f" || true
         git add -- "$f"
       done
-      GIT_EDITOR=true git rebase --continue >/dev/null 2>&1 || { AUTO_OK=false; break; }
+      GIT_EDITOR=true "${REPLAY_ID[@]}" git rebase --continue >/dev/null 2>&1 || { AUTO_OK=false; break; }
     done
     if [ "$AUTO_OK" = true ] && ! { [ -d "$(git rev-parse --git-path rebase-merge)" ] || [ -d "$(git rev-parse --git-path rebase-apply)" ]; }; then
       echo "  rebase auto-resolved (generated files only), will retry push"

--- a/ops/publish/safe_push.sh
+++ b/ops/publish/safe_push.sh
@@ -101,11 +101,19 @@ fi
 # Supplied through the environment rather than `-c`: GIT_COMMITTER_* wins over
 # config AND over the empty gecos name that is the actual failure on a runner,
 # and it touches no config file at all.
+# Both reads are guarded: under `set -e` a failing command substitution inside
+# an array assignment aborts the whole script, which would turn "git could not
+# answer a question about HEAD" into "nothing was published". With no answer we
+# simply have nothing better to offer than the behaviour that was here before.
 REPLAY_ID=()
 if ! git var GIT_COMMITTER_IDENT >/dev/null 2>&1; then
-  REPLAY_ID=(env "GIT_COMMITTER_NAME=$(git log -1 --format=%cn)"
-                 "GIT_COMMITTER_EMAIL=$(git log -1 --format=%ce)")
-  echo "▸ no git identity here — replaying as $(git log -1 --format='%cn <%ce>')"
+  _REPLAY_NAME="$(git log -1 --format=%cn 2>/dev/null || true)"
+  _REPLAY_EMAIL="$(git log -1 --format=%ce 2>/dev/null || true)"
+  if [ -n "$_REPLAY_NAME" ] && [ -n "$_REPLAY_EMAIL" ]; then
+    REPLAY_ID=(env "GIT_COMMITTER_NAME=$_REPLAY_NAME"
+                   "GIT_COMMITTER_EMAIL=$_REPLAY_EMAIL")
+    echo "▸ no git identity here — replaying as $_REPLAY_NAME <$_REPLAY_EMAIL>"
+  fi
 fi
 
 for i in $(seq 1 $MAX_RETRIES); do

--- a/tests/test_safe_push_replays_without_a_configured_identity.py
+++ b/tests/test_safe_push_replays_without_a_configured_identity.py
@@ -1,0 +1,153 @@
+"""A lost push race has to be survivable where the pusher owns no git identity.
+
+`safe_push.sh` promises, in its own header, that every committer gets identical
+push behaviour. It did not: `pull --rebase` REWRITES commits and therefore needs
+a committer identity, and the bot callers are forbidden to configure one —
+`gha_commit_push.sh` injects the bot per `git commit` with `-c` precisely so a
+run inside a real workspace can never clobber kcn's interactive identity. On a
+GitHub-hosted runner nothing else supplies one (the `runner` account's gecos
+name is empty), so the rebase died on `fatal: empty ident name` and the script
+reported
+
+    ✗ rebase conflict — abort, leaving commit local
+    Manual resolution needed: git pull --rebase + resolve + git push
+
+for a push whose only problem was ref lag. The retry ladder — the whole reason
+this script exists — was one attempt on a runner and three everywhere else.
+Observed on sentiment-scan 2026-08-28 and 2026-08-30 (run 33343134261).
+
+These tests drive the real script against real repositories, in an environment
+where git cannot resolve an identity, because the bug lived entirely in what git
+does with the environment it is handed.
+"""
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "ops" / "publish" / "safe_push.sh"
+
+#: An environment in which git cannot answer "who is committing". `git var
+#: GIT_COMMITTER_IDENT` fails here exactly as it does on a runner; forcing an
+#: empty name is only how the condition is reached on a developer box, where the
+#: passwd gecos would otherwise supply one.
+NO_IDENTITY = {
+    "GIT_CONFIG_GLOBAL": "/dev/null",
+    "GIT_CONFIG_SYSTEM": "/dev/null",
+    "GIT_COMMITTER_NAME": "",
+    "GIT_AUTHOR_NAME": "",
+}
+
+BOT = "github-actions[bot]"
+BOT_EMAIL = "41898282+github-actions[bot]@users.noreply.github.com"
+
+
+def _git(cwd, *args, env=None):
+    return subprocess.run(["git", *args], cwd=cwd, check=True,
+                          capture_output=True, text=True, env=env)
+
+
+def _env(base=None, **extra):
+    import os
+    env = dict(os.environ)
+    env.pop("CLAWOCK_PUBLISH_SSH_KEY", None)
+    env.update(base or {})
+    env.update(extra)
+    return env
+
+
+@pytest.fixture
+def repos(tmp_path):
+    """A bare origin, a rival that wins the race, and a pusher with no identity."""
+    origin = tmp_path / "origin.git"
+    subprocess.run(["git", "init", "--bare", "-b", "master", str(origin)],
+                   check=True, capture_output=True)
+
+    seed = tmp_path / "seed"
+    subprocess.run(["git", "clone", str(origin), str(seed)],
+                   check=True, capture_output=True)
+    _git(seed, "-c", "user.name=seed", "-c", "user.email=seed@example.invalid",
+         "commit", "--allow-empty", "-m", "seed")
+    _git(seed, "push", "origin", "master")
+
+    # The pusher clones BEFORE the rival lands, or there is no race to lose and
+    # the push succeeds on attempt 1 without ever reaching the rebase — which is
+    # how the first draft of this test passed against the unfixed script.
+    runner = tmp_path / "runner"
+    subprocess.run(["git", "clone", str(origin), str(runner)],
+                   check=True, capture_output=True)
+
+    rival = tmp_path / "rival"
+    subprocess.run(["git", "clone", str(origin), str(rival)],
+                   check=True, capture_output=True)
+    (rival / "rival.json").write_text("{}\n", encoding="utf-8")
+    _git(rival, "add", "rival.json")
+    _git(rival, "-c", "user.name=rival", "-c", "user.email=rival@example.invalid",
+         "commit", "-m", "rival wins the race")
+    _git(rival, "push", "origin", "master")
+
+    # Carrying a commit made the way the bot makes them: identity injected for
+    # this one command, never written to config.
+    (runner / "mine.json").write_text("{}\n", encoding="utf-8")
+    _git(runner, "add", "mine.json")
+    _git(runner, "-c", f"user.name={BOT}", "-c", f"user.email={BOT_EMAIL}",
+         "commit", "-m", "sentiment: daily scan")
+    return origin, runner
+
+
+def test_the_environment_this_reproduces_really_has_no_identity(repos):
+    """Guard the fixture, not the fix: if git can answer this, the test below
+    proves nothing about a runner."""
+    _origin, runner = repos
+    probe = subprocess.run(["git", "var", "GIT_COMMITTER_IDENT"], cwd=runner,
+                           capture_output=True, text=True, env=_env(NO_IDENTITY))
+    assert probe.returncode != 0, (
+        "this environment resolves a committer identity, so it is not the "
+        "runner condition the rebase failed under")
+
+
+def test_a_lost_race_is_replayed_when_nobody_configured_an_identity(repos):
+    origin, runner = repos
+    result = subprocess.run(["bash", str(SCRIPT), "origin", "master"],
+                            cwd=runner, capture_output=True, text=True,
+                            env=_env(NO_IDENTITY))
+    assert result.returncode == 0, (
+        f"safe_push.sh gave up on a lost race with no identity configured:\n"
+        f"{result.stdout}\n{result.stderr}")
+    assert "rebase conflict" not in (result.stdout + result.stderr), (
+        "a ref-lag rejection was reported as a content conflict")
+
+    log = subprocess.run(["git", "log", "--format=%s|%cn", "-3"],
+                         cwd=origin, capture_output=True, text=True).stdout
+    assert "sentiment: daily scan" in log, "the pusher's commit never landed"
+    assert "rival wins the race" in log, "the winner's commit was overwritten"
+
+
+def test_the_replayed_commit_keeps_the_committer_it_was_made_with(repos):
+    """The replay identity is HEAD's own committer, so this introduces no second
+    answer to "who is the bot" — and a rewritten commit must not become
+    `root <root@…>` on whatever box happened to run the retry."""
+    origin, runner = repos
+    subprocess.run(["bash", str(SCRIPT), "origin", "master"], cwd=runner,
+                   capture_output=True, text=True, env=_env(NO_IDENTITY))
+    line = subprocess.run(
+        ["git", "log", "-1", "--format=%cn <%ce>", "master"],
+        cwd=origin, capture_output=True, text=True).stdout.strip()
+    assert line == f"{BOT} <{BOT_EMAIL}>", line
+
+
+def test_a_configured_identity_is_left_alone(repos):
+    """Where git can resolve an identity the script must behave exactly as
+    before — the replay prefix is empty and nothing is injected."""
+    origin, runner = repos
+    env = _env({"GIT_CONFIG_GLOBAL": "/dev/null", "GIT_CONFIG_SYSTEM": "/dev/null"})
+    _git(runner, "config", "user.name", "configured")
+    _git(runner, "config", "user.email", "configured@example.invalid")
+    result = subprocess.run(["bash", str(SCRIPT), "origin", "master"],
+                            cwd=runner, capture_output=True, text=True, env=env)
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "no git identity here" not in result.stdout
+    line = subprocess.run(["git", "log", "-1", "--format=%cn", "master"],
+                          cwd=origin, capture_output=True, text=True).stdout.strip()
+    assert line == "configured", line


### PR DESCRIPTION
维度 H · 「副作用有没有一条腿会重跑」——这次坏掉的正是那条腿本身。

## The finding

`ops/publish/safe_push.sh` is documented as **THE one hardened push path**, so
that "every committer gets identical push behaviour". Its resilience is the
retry ladder: push → `pull --rebase` → push again, up to three times.

`pull --rebase` **rewrites commits**, so it needs a committer identity. And the
bot callers are *forbidden* to configure one — `ops/publish/gha_commit_push.sh`
injects the bot per `git commit`:

```bash
BOT_ID=(-c "user.name=github-actions[bot]" -c "user.email=…")
git "${BOT_ID[@]}" commit -m "$MSG"
```

…precisely so that a run inside a real workspace can never clobber kcn's
interactive identity. A GitHub-hosted runner supplies nothing else: the `runner`
account's gecos name is empty. So the rebase died, every time:

```
push failed attempt 1, trying rebase (autostash)…
Rebasing (1/1)
fatal: empty ident name (for <runner@runnervmgx7h7…internal.cloudapp.net>) not allowed
  ✗ rebase conflict — abort, leaving commit local
  Manual resolution needed: git pull --rebase + resolve + git push
```

— for a push whose only problem was ref lag, between two disjoint sidecars that
cannot content-conflict. **On a runner the ladder was one attempt; everywhere
else it is three.**

Real occurrences: sentiment-scan runs 33145968498 (2026-08-28) and 33343134261
(2026-08-30). Both days' scan data was dropped. The `cp -a` half of that failure
was fixed on 08-31 (the outer script's reset-and-reapply now saves the data);
this half was never touched, so the ladder is still dead on all four scan jobs
(`ci.yml` coverage, influencer, macro, sentiment) and on any future caller that
respects the identity rule.

## RED-CHECK (real repos, no network)

Before:

```
push failed attempt 1, trying rebase (autostash)…
Rebasing (1/1)fatal: empty ident name (for <root@…>) not allowed
  ✗ rebase conflict — abort, leaving commit local
exit=2
```

After:

```
▸ no git identity here — replaying as github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
push failed attempt 1, trying rebase (autostash)…
Rebasing (1/1) Successfully rebased and updated refs/heads/master.
  rebase clean, will retry push
✓ pushed on attempt 2
exit=0
```

## The change

```bash
REPLAY_ID=()
if ! git var GIT_COMMITTER_IDENT >/dev/null 2>&1; then
  REPLAY_ID=(env "GIT_COMMITTER_NAME=$(git log -1 --format=%cn)"
                 "GIT_COMMITTER_EMAIL=$(git log -1 --format=%ce)")
fi
```

Two deliberate choices:

- **HEAD's own committer**, not a bot constant — this adds no second answer to
  "who is the bot", and a replayed commit keeps the identity it was made with
  instead of becoming `root <root@…>` on whatever box ran the retry.
- **Through the environment, not `-c`** — `GIT_COMMITTER_*` beats config *and*
  the empty gecos name that is the actual failure, and touches no config file,
  which is the whole point of the identity rule.

Where git can already resolve an identity the prefix is empty and behaviour is
byte-identical to before.

## Gate

`tests/test_safe_push_replays_without_a_configured_identity.py` drives the real
script against real repositories with `git var GIT_COMMITTER_IDENT` failing, and
asserts the un-fixed script's exact failure is gone: exit 0, no "rebase
conflict" string, both commits on origin, committer preserved.

It also asserts **the fixture's own premise** in a separate test. The first
draft cloned the pusher *after* the rival had already pushed — no race to lose,
push succeeded on attempt 1, the rebase never ran, and the whole file passed
against the unfixed script. A gate whose setup does not reach the branch it
guards is the failure this loop keeps finding.

## 用户能看到的差别

SURFACE: 面板
现在: 情绪/宏观/影响力扫描只要撞上一次推送竞争，那天的数据就靠外层脚本的 reset 兜底救回来；救不回来时（08-28 / 08-30 两次）面板上那一格就没有当天的行
修完: 同一次竞争由 safe_push 自己 rebase 过去，第二次尝试推上，当天的行照常出现

https://claude.ai/code/session_01XmfyuJBfqFbidQNoN7SGaP