### PR TITLE
briefs: four weekdays with no brief, and a page that lists only the files that exist

### DIFF
--- a/ops/pages/stage_site.py
+++ b/ops/pages/stage_site.py
@@ -19,6 +19,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[2]
 
 WEEK_FILE_RE = re.compile(r"^(\d{4})-W(\d{2})\.md$")
+BRIEF_FILE_RE = re.compile(r"^(\d{4})-(\d{2})-(\d{2})-pre-open\.md$")
 
 # The review workflow fires `cron: '0 14 * * 0'` — Sunday 14:00 UTC, the last
 # day of the ISO week it writes. GitHub's scheduled runs drift: the 2026-08-30
@@ -28,6 +29,71 @@ WEEK_FILE_RE = re.compile(r"^(\d{4})-W(\d{2})\.md$")
 _REVIEW_FIRE_WEEKDAY = 6  # Sunday
 _REVIEW_FIRE_HOUR = 14
 _REVIEW_GRACE_HOURS = 8
+
+
+# The daily brief fires `3 8 * * 1-5` in Asia/Shanghai — a host cron, not a
+# GitHub schedule, so it does not drift by hours the way the weekly review does.
+# The grace is still generous: a brief that has not landed by the afternoon is
+# the case this index exists to show, and the 09:05 miss-detector watchdog owns
+# the minutes. Asia/Shanghai has no DST, so a fixed +08:00 is exact.
+_BRIEF_TZ = timezone(timedelta(hours=8))
+_BRIEF_FIRE_HOUR = 8
+_BRIEF_FIRE_MINUTE = 3
+_BRIEF_GRACE_HOURS = 8
+
+
+def _last_due_brief_day(now: datetime) -> date:
+    """The most recent weekday whose 08:03 fire is past its grace."""
+    cutoff = now.astimezone(_BRIEF_TZ) - timedelta(hours=_BRIEF_GRACE_HOURS)
+    candidate = cutoff.replace(hour=_BRIEF_FIRE_HOUR, minute=_BRIEF_FIRE_MINUTE,
+                               second=0, microsecond=0)
+    if candidate > cutoff:
+        candidate -= timedelta(days=1)
+    while candidate.weekday() > 4:  # Sat/Sun carry no fire at all
+        candidate -= timedelta(days=1)
+    return candidate.date()
+
+
+def daily_index(source_root: Path = ROOT, *, now: datetime = None) -> list[dict]:
+    """Every weekday the brief series should contain, newest first.
+
+    Same defect the weekly index was carrying, on the same page, one section
+    higher: the list was `site.pages` — the files that exist — so a weekday the
+    brief never landed on simply is not there. `memory/` has no brief for
+    2026-06-04, 2026-06-12, 2026-08-11 or 2026-08-12, and on all four days the
+    host was up and committing intraday refreshes; the reader's only clue was
+    that a date is absent from a list of dates, and for the newest day there is
+    no clue at all.
+
+    Weekdays, because that is what `3 8 * * 1-5` fires on — market holidays
+    included, which is why 2026-07-01 (HK closed) has a brief. Days outside that
+    rule are listed when a file exists for them (the hand-run weekend briefs of
+    2026-05), never demanded when one does not.
+    """
+    now = now or datetime.now(timezone.utc)
+    directory = source_root / "memory"
+    present = {}
+    for path in sorted(directory.glob("*-pre-open.md")) if directory.is_dir() else []:
+        match = BRIEF_FILE_RE.match(path.name)
+        if match:
+            present[date(*(int(part) for part in match.groups()))] = path.name
+    if not present:
+        return []
+
+    days = set(present)
+    cursor, end = min(present), max(max(present), _last_due_brief_day(now))
+    while cursor <= end:
+        if cursor.weekday() <= 4:
+            days.add(cursor)
+        cursor += timedelta(days=1)
+    return [
+        {
+            "date": day.isoformat(),
+            "present": day in present,
+            "path": f"memory/{day.isoformat()}-pre-open.md",
+        }
+        for day in sorted(days, reverse=True)
+    ]
 
 
 def _iso_weeks(first: tuple[int, int], last: tuple[int, int]) -> list[tuple[int, int]]:
@@ -118,6 +184,25 @@ def _write_weekly_index(output_dir: Path, source_root: Path) -> None:
     )
 
 
+def _write_daily_index(output_dir: Path, source_root: Path) -> None:
+    """Same reason as the weekly index: "is this day due yet" is clock
+    arithmetic, and Liquid gets the newest row — the one with nothing after it —
+    wrong precisely because there is nothing after it to compare against."""
+    rows = daily_index(source_root)
+    if not rows:
+        return
+    lines = []
+    for row in rows:
+        lines.append(f"- date: \"{row['date']}\"")
+        lines.append(f"  present: {'true' if row['present'] else 'false'}")
+        lines.append(f"  path: \"{row['path']}\"")
+    data_dir = output_dir / "_data"
+    data_dir.mkdir(parents=True, exist_ok=True)
+    (data_dir / "daily_briefs.yml").write_text(
+        "\n".join(lines) + "\n", encoding="utf-8"
+    )
+
+
 def _copy(source: Path, destination: Path) -> None:
     if source.is_dir():
         shutil.copytree(source, destination, dirs_exist_ok=True)
@@ -149,6 +234,7 @@ def stage(output_dir: Path, *, source_root: Path = ROOT) -> Path:
         _copy(report, output_dir / "memory" / report.name)
     _copy(source_root / "memory" / "weekly", output_dir / "memory" / "weekly")
     _write_weekly_index(output_dir, source_root)
+    _write_daily_index(output_dir, source_root)
 
     print(f"staged Jekyll source: {site_source} + public runtime inputs -> {output_dir}")
     return output_dir

--- a/site/briefs.md
+++ b/site/briefs.md
@@ -10,13 +10,16 @@ description: 全部历史每日深度简报 + 周复盘
 
 ## Daily Deep Brief · 盘前深度简报
 
-按日期倒序（Pages 站内渲染，不跳 GitHub）：
+列的是**每一个应该有简报的工作日**（`3 8 * * 1-5`），不是每一个存在的文件——2026-06-04 / 06-12 / 08-11 / 08-12 四天主机活着、盘中刷新照跑，但 08:03 那一份没有落盘。缺口留在这里给人看见，而不是让日期自己跳过去。按日期倒序（Pages 站内渲染，不跳 GitHub）：
 
 <ul class="brief-list">
-{% assign briefs = site.pages | where_exp: "p", "p.path contains 'memory/'" | where_exp: "p", "p.path contains '-pre-open'" | sort: 'path' | reverse %}
-{% for f in briefs %}
+{% assign briefs = site.pages | where_exp: "p", "p.path contains 'memory/'" | where_exp: "p", "p.path contains '-pre-open'" %}
+{% for d in site.data.daily_briefs %}
+  {% assign hit = false %}
+  {% for p in briefs %}{% if p.path == d.path %}{% assign hit = p %}{% endif %}{% endfor %}
   <li>
-    <a href="{{ f.url | relative_url }}">{{ f.path | split: '/' | last | replace: '.md', '' | replace: '-pre-open', '' }}</a>
+    {% if hit %}<a href="{{ hit.url | relative_url }}">{{ d.date }}</a>
+    {% else %}<span class="brief-missing" title="当天的简报没有生成">{{ d.date }} · 未生成</span>{% endif %}
   </li>
 {% endfor %}
 </ul>

--- a/tests/test_daily_brief_index.py
+++ b/tests/test_daily_brief_index.py
@@ -1,0 +1,117 @@
+"""The daily brief index lists weekdays, not files.
+
+The same defect the weekly list was carrying, on the same page, one section
+higher. `memory/` has no pre-open brief for 2026-06-04, 2026-06-12, 2026-08-11
+or 2026-08-12; on all four days the host was up and committing intraday
+refreshes, so nothing else looked wrong. The list rendered `site.pages` — the
+files that exist — so a weekday the brief never landed on was simply not in it,
+and for the newest day there is nothing after it to look wrong beside.
+
+`stage_site.daily_index` computes the span the series should cover from the
+cron that writes it (`3 8 * * 1-5`, Asia/Shanghai) and marks each day present or
+not. This file pins the cases that make the computation worth having.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "ops" / "pages"))
+
+import stage_site  # noqa: E402
+
+UTC = timezone.utc
+
+
+def _tree(tmp_path, days):
+    directory = tmp_path / "memory"
+    directory.mkdir(parents=True, exist_ok=True)
+    for day in days:
+        (directory / f"{day}-pre-open.md").write_text(
+            "---\nlayout: default\n---\n", encoding="utf-8")
+    return tmp_path
+
+
+def _days(rows):
+    return [(row["date"], row["present"]) for row in rows]
+
+
+def test_a_weekday_with_no_brief_is_named(tmp_path):
+    # 2026-08-10 Mon .. 2026-08-13 Thu, with Tue and Wed missing — the real gap.
+    root = _tree(tmp_path, ["2026-08-10", "2026-08-13"])
+    rows = stage_site.daily_index(root, now=datetime(2026, 8, 14, 12, tzinfo=UTC))
+    assert _days(rows) == [
+        ("2026-08-14", False),
+        ("2026-08-13", True),
+        ("2026-08-12", False),
+        ("2026-08-11", False),
+        ("2026-08-10", True),
+    ]
+
+
+def test_a_trailing_gap_is_named_too(tmp_path):
+    """The case the file listing cannot express at all."""
+    root = _tree(tmp_path, ["2026-08-10"])
+    rows = stage_site.daily_index(root, now=datetime(2026, 8, 12, 12, tzinfo=UTC))
+    assert _days(rows) == [
+        ("2026-08-12", False),
+        ("2026-08-11", False),
+        ("2026-08-10", True),
+    ]
+
+
+def test_today_is_not_called_missing_before_its_grace_has_passed(tmp_path):
+    """08:03 Asia/Shanghai on 2026-08-11 is 00:03 UTC; at 02:00 UTC the brief is
+    still landing. Calling it missing every morning is how a page like this
+    stops being read."""
+    root = _tree(tmp_path, ["2026-08-10"])
+    rows = stage_site.daily_index(root, now=datetime(2026, 8, 11, 2, tzinfo=UTC))
+    assert _days(rows) == [("2026-08-10", True)]
+
+
+def test_the_weekend_is_never_demanded(tmp_path):
+    """`3 8 * * 1-5` does not fire on Saturday or Sunday, so a Monday-morning
+    index must end on Friday — not report two silent misses every weekend."""
+    root = _tree(tmp_path, ["2026-09-04"])  # Friday
+    rows = stage_site.daily_index(root, now=datetime(2026, 9, 6, 15, tzinfo=UTC))
+    assert _days(rows) == [("2026-09-04", True)]
+
+
+def test_a_brief_written_off_schedule_is_still_listed(tmp_path):
+    """The hand-run weekend briefs of 2026-05 exist. A day outside the cron's
+    rule is listed when a file is there, and never demanded when it is not."""
+    root = _tree(tmp_path, ["2026-05-16", "2026-05-18"])  # Sat, Mon
+    rows = stage_site.daily_index(root, now=datetime(2026, 5, 18, 12, tzinfo=UTC))
+    assert _days(rows) == [("2026-05-18", True), ("2026-05-16", True)]
+
+
+def test_staging_hands_the_index_to_jekyll(tmp_path):
+    output = tmp_path / "site-source"
+    subprocess.run(
+        ["python3", str(ROOT / "ops/pages/stage_site.py"), "--output-dir", str(output)],
+        cwd=ROOT,
+        check=True,
+    )
+    rows = yaml.safe_load(
+        (output / "_data" / "daily_briefs.yml").read_text(encoding="utf-8"))
+    assert rows and isinstance(rows, list)
+    for row in rows:
+        assert set(row) == {"date", "present", "path"}, row
+        assert isinstance(row["present"], bool), row
+        assert isinstance(row["date"], str), (
+            "an unquoted date becomes a datetime.date and the page prints "
+            "something else than the file name")
+    assert rows[0]["date"] > rows[-1]["date"], "newest first"
+
+
+def test_the_page_reads_the_index_rather_than_the_file_listing():
+    page = (ROOT / "site" / "briefs.md").read_text(encoding="utf-8")
+    daily = page.split("## Daily Deep Brief")[1].split("## Weekly Reviews")[0]
+    assert "site.data.daily_briefs" in daily, (
+        "the daily list is back to rendering whatever files exist, which is "
+        "the rendering that hid four missing weekday briefs")


### PR DESCRIPTION
维度 J/L · 与 #1369 同一机制的**另一个载体**——而且就在同一页、上一节。

## The finding

`site/briefs.md` got its Weekly Reviews list rebuilt yesterday so that it names
**every ISO week that should have a review**, because a missing week left no
trace. The Daily Deep Brief list, one section above it, still did this:

```liquid
{% assign briefs = site.pages | where_exp: "p", "p.path contains '-pre-open'" | sort: 'path' | reverse %}
```

— the files that exist. A weekday the brief never landed on is absent from a
list of dates, and the newest missing day has nothing after it to look wrong
beside. The page carries the lesson and its unfixed sibling side by side.

## Four real gaps

Every weekday since the first brief, against `memory/*-pre-open.md`:

```
missing: ['2026-06-04', '2026-06-12', '2026-08-11', '2026-08-12']
```

None of them is a holiday: `sessions.is_trading_day` says both markets were open
on all four, and `3 8 * * 1-5` fires on market holidays anyway (2026-07-01 has a
brief with HK closed). And the host was alive on each of them — `git log` for
those days is full of `dashboard: intraday refresh` and the nightly gold
reconciliation. Only the 08:03 brief is missing. 2026-08-11 and 08-12 are
consecutive: two mornings with no brief, and no trace anywhere a reader looks.

## The change

`stage_site.daily_index(source_root, now)` — the same shape as `weekly_index`:

- the span runs from the first brief present through `_last_due_brief_day(now)`;
- **weekdays**, because that is what the cron fires on. Asia/Shanghai has no
  DST, so the fire instant is a fixed +08:00 and needs no zone database;
- **an 8h grace**, so a morning that is still landing is never called missing —
  the 09:05 miss-detector watchdog owns the minutes, this page owns the record;
- days outside that rule are listed when a file exists (the hand-run weekend
  briefs of 2026-05-16/17/31) and never demanded when one does not;
- written to `_data/daily_briefs.yml` for the same reason as the weekly index:
  "is this day due yet" is clock arithmetic, and Liquid gets the newest row
  wrong precisely because there is nothing after it to compare against.

The missing rows reuse the `.brief-missing` style the weekly list already has —
dashed border, not a link.

## Gate

`tests/test_daily_brief_index.py` — the middle gap, the trailing gap, the
morning before the grace has passed, **the weekend** (a Monday-morning index
must end on Friday, not report two silent misses every weekend), the
off-schedule file, the staged YAML shape (including that `date` survives as a
string rather than becoming a `datetime.date`), and that the page reads the
index rather than the file listing.

## 用户能看到的差别

SURFACE: 站点静态页
现在: 打开 briefs 页，2026-08-11 和 08-12 这两天根本不在列表里——看起来就像那两天不存在，而实际上是那两早的简报没生成
修完: 同一页把那两天列出来，虚线、不可点、标「未生成」；最新一天没生成时也会立刻出现在最上面

https://claude.ai/code/session_01XmfyuJBfqFbidQNoN7SGaP
