### PR TITLE
system_check: 61 seconds of every push, and most of it was starting processes

### DIFF
--- a/ops/system_check.py
+++ b/ops/system_check.py
@@ -183,20 +183,29 @@ def check_root_allowlist(r):
 
 
 def check_scripts_compile(r):
-    """All Python scripts compile."""
+    """All Python scripts compile.
+
+    Compiled in-process. This used to spawn `python3 -m py_compile` once per
+    file — 200 interpreter startups for 10.5s of the pre-push hook's 61s, to
+    do work the builtin does in milliseconds. It also left a `__pycache__` for
+    every file it looked at: a check that writes into the tree it is checking.
+
+    `compile()` raises exactly what py_compile reports (SyntaxError, and the
+    null-byte/decoding errors that come with reading source), so the verdict is
+    unchanged — only the process count is.
+    """
     failed = []
     for pat in [
         'src/clawock/**/*.py',
         'ops/**/*.py',
     ]:
-        for f in glob.glob(str(WS / pat), recursive=True):
+        for f in sorted(glob.glob(str(WS / pat), recursive=True)):
             try:
-                rr = subprocess.run(['python3', '-m', 'py_compile', f],
-                                   capture_output=True, text=True, timeout=10)
-                if rr.returncode != 0:
-                    failed.append(f'{Path(f).name}: {rr.stderr[-100:]}')
+                compile(Path(f).read_bytes(), f, 'exec')
+            except SyntaxError as e:
+                failed.append(f'{Path(f).name}: line {e.lineno}: {e.msg}'[:120])
             except Exception as e:
-                failed.append(f'{Path(f).name}: {e}')
+                failed.append(f'{Path(f).name}: {type(e).__name__}: {e}'[:120])
     if failed:
         r.add('scripts compile', CRITICAL, '; '.join(failed))
     else:
@@ -1029,6 +1038,42 @@ def _provider_api_keys():
     return labels
 
 
+def _cron_history(cron_runs):
+    """Every job's finished runs, read from the live store rather than the CLI.
+
+    `auto` shells out to `openclaw cron runs --id` ONCE PER JOB. That is the
+    right preference for a single read — the CLI is the supported interface —
+    but a whole-history sweep multiplies it by the number of jobs, and
+    `ops/host/cron_token_audit.py` already wrote this down on 2026-07-18:
+    "across 11 jobs that took minutes ... this is a read-only report, the
+    fastest honest source wins". The reader below is the one place that
+    conclusion had not reached, and it is the most expensive place to miss it:
+    system_check runs inside `.githooks/pre-push`, once per push ATTEMPT, and
+    safe_push.sh attempts up to three times.
+
+    Measured on the live host, 2026-09-07, same 11 jobs:
+
+        read_runs via CLI      33.66s      read_jobs via CLI      3.34s
+        read_runs via SQLite    0.16s      read_jobs via SQLite   0.02s
+
+    — 37.0s of a 61.1s system_check, 61% of the whole thing, for a check that
+    can only ever produce a WARN and therefore cannot change the hook's verdict.
+    SQLite is also a superset: the CLI caps at 50 runs per job.
+
+    Falls back to `auto` when the store answers nothing, so a host whose SQLite
+    has moved loses the speed rather than the signal.
+    """
+    for backend in ('sqlite', 'auto'):
+        job_map, _ = cron_runs.load_job_map(backend)
+        if not job_map:
+            continue
+        entries, _ = cron_runs.load_entries('cron', None, None, job_map,
+                                            backend=backend)
+        if entries:
+            return job_map, entries
+    return {}, []
+
+
 def check_model_chain_health(r):
     """A hop that will never recover, told apart from one that just timed out.
 
@@ -1048,10 +1093,9 @@ def check_model_chain_health(r):
     try:
         sys.path.insert(0, str(_REPO_ROOT / 'ops' / 'host'))
         import cron_runs  # noqa: PLC0415 - host-only, imported lazily on purpose
-        job_map, _ = cron_runs.load_job_map()
-        if not job_map:
-            return  # no openclaw on this host
-        entries, _ = cron_runs.load_entries('cron', None, None, job_map)
+        job_map, entries = _cron_history(cron_runs)
+        if not entries:
+            return  # no openclaw on this host, or no run history to read
     except Exception:
         return
     dead = {}

--- a/src/clawock/harness/_harness_common.py
+++ b/src/clawock/harness/_harness_common.py
@@ -471,6 +471,12 @@ def dashboard_publication_state(ws=None):
 # shell publishers (gold_dca_refresh.sh, commit_dreaming.sh) exec safe_push.sh
 # with no cap at all. This one caller was the only place the script was cut off
 # mid-run.
+# 2026-09-07: the hook's own cost is now ~9s — check_model_chain_health was
+# reading the cron history one `openclaw` process per job and
+# check_scripts_compile was spawning py_compile once per file. The ceiling below
+# is deliberately NOT lowered to match: it is sized for a loaded, swapping host,
+# and the failure it prevents (a stranded commit on a lost race) costs more than
+# the seconds it reserves.
 SAFE_PUSH_ATTEMPTS = 3            # ops/publish/safe_push.sh MAX_RETRIES
 PREPUSH_ATTEMPT_SECONDS = 90      # pre-push hook (57s measured) + fetch/rebase + transfer
 PUSH_RETRY_BACKOFF_SECONDS = 9    # safe_push.sh: sleep i*3 after attempts 1 and 2

--- a/tests/test_system_check_reads_without_spawning.py
+++ b/tests/test_system_check_reads_without_spawning.py
@@ -1,0 +1,186 @@
+"""`ops/system_check.py` runs inside `.githooks/pre-push`, once per push ATTEMPT.
+
+`safe_push.sh` attempts up to three times, so every second this script spends is
+paid up to three times before anything is published. Profiled per check on the
+live host, 2026-09-07 (11 cron jobs, 200 Python files):
+
+    check_model_chain_health   37.32s   61.1%
+    check_scripts_compile      10.49s   17.2%
+    ...                                        61.06s total
+
+Neither number was work. `check_model_chain_health` read the run history through
+`auto`, which shells out to `openclaw cron runs --id` **once per job** —
+33.66s where the same live SQLite answers in 0.16s, a conclusion
+`ops/host/cron_token_audit.py` had already written down on 2026-07-18 and this
+caller never got. `check_scripts_compile` spawned `python3 -m py_compile` **once
+per file** — 200 interpreter startups to do what the builtin does in
+milliseconds, and it left a `__pycache__` behind for each one: a check that
+writes into the tree it is checking.
+
+After: 8.7 / 9.0 / 9.5s for the same 25 checks and the same verdicts.
+
+These tests are behavioural — the process is denied, not counted — because the
+defect was never visible in what the checks *said*, only in what they did.
+"""
+import importlib.util
+import json
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+@pytest.fixture(scope="module")
+def system_check():
+    for path in (ROOT, ROOT / "src", ROOT / "ops" / "host"):
+        if str(path) not in sys.path:
+            sys.path.insert(0, str(path))
+    spec = importlib.util.spec_from_file_location(
+        "spawnless_system_check", ROOT / "ops" / "system_check.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+# ── the cron history ────────────────────────────────────────────────────────
+
+def _state_db(path, runs):
+    """A live openclaw store: two jobs, and the run rows given."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(path) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE cron_jobs (
+                store_key TEXT NOT NULL, job_id TEXT NOT NULL,
+                job_json TEXT NOT NULL, state_json TEXT NOT NULL,
+                sort_order INTEGER NOT NULL, updated_at INTEGER NOT NULL);
+            CREATE TABLE cron_run_logs (
+                store_key TEXT NOT NULL, job_id TEXT NOT NULL,
+                seq INTEGER NOT NULL, ts INTEGER NOT NULL,
+                entry_json TEXT NOT NULL);
+            """
+        )
+        for order, job_id in enumerate(("job-a", "job-b")):
+            job = {"id": job_id, "name": f"cron {job_id}", "enabled": True,
+                   "schedule": {"kind": "cron", "expr": "0 8 * * 1-5"}}
+            conn.execute("INSERT INTO cron_jobs VALUES (?, ?, ?, ?, ?, ?)",
+                         ("store", job_id, json.dumps(job), "{}", order, 1))
+        for seq, (job_id, ts, error) in enumerate(runs, start=1):
+            entry = {"jobId": job_id, "ts": ts, "status": "error",
+                     "action": "finished", "runId": f"cron:{seq}", "error": error}
+            conn.execute("INSERT INTO cron_run_logs VALUES (?, ?, ?, ?, ?)",
+                         ("store", job_id, seq, ts, json.dumps(entry)))
+
+
+def _no_cli(monkeypatch):
+    """Deny the openclaw CLI. A per-job shell-out is the defect itself."""
+    from clawock.providers import openclaw
+
+    def refuse(*_args, **_kwargs):
+        raise AssertionError(
+            "system_check spawned the openclaw CLI — that is one process per "
+            "job inside the pre-push hook")
+
+    monkeypatch.setattr(openclaw, "cron_cli_json", refuse)
+
+
+def test_a_dead_hop_is_still_named_without_spawning_a_cli_per_job(
+        system_check, tmp_path, monkeypatch):
+    _state_db(tmp_path / "state" / "openclaw.sqlite",
+              [("job-a", 200, "opencode: Insufficient balance (billing)"),
+               ("job-b", 100, "minimax: timeout after 180s")])
+    monkeypatch.setenv("CLAWOCK_OPENCLAW_HOME", str(tmp_path))
+    _no_cli(monkeypatch)
+
+    result = system_check.Result()
+    system_check.check_model_chain_health(result)
+
+    assert result.checks, "the check produced no row at all"
+    name, severity, message = result.checks[0]
+    assert name == "model chain"
+    assert severity == system_check.WARNING, (name, severity, message)
+    assert "opencode" in message, message
+    assert "minimax" not in message, (
+        "a timeout is the chain working as designed; only billing/auth counts")
+
+
+def test_a_healthy_chain_is_read_from_the_store_too(
+        system_check, tmp_path, monkeypatch):
+    _state_db(tmp_path / "state" / "openclaw.sqlite",
+              [("job-a", 200, "minimax: timeout after 180s")])
+    monkeypatch.setenv("CLAWOCK_OPENCLAW_HOME", str(tmp_path))
+    _no_cli(monkeypatch)
+
+    result = system_check.Result()
+    system_check.check_model_chain_health(result)
+
+    assert [(n, s) for n, s, _ in result.checks] == [("model chain",
+                                                      system_check.OK)]
+
+
+# ── compiling the sources ───────────────────────────────────────────────────
+
+def _workspace(tmp_path, files):
+    for relative, source in files.items():
+        path = tmp_path / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(source, encoding="utf-8")
+    return tmp_path
+
+
+def _no_subprocess(monkeypatch, system_check):
+    def refuse(*_args, **_kwargs):
+        raise AssertionError(
+            "check_scripts_compile spawned a process — that is one interpreter "
+            "startup per file inside the pre-push hook")
+
+    monkeypatch.setattr(system_check.subprocess, "run", refuse)
+
+
+def test_a_file_that_does_not_compile_is_still_critical(
+        system_check, tmp_path, monkeypatch):
+    workspace = _workspace(tmp_path, {
+        "src/clawock/fine.py": "x = 1\n",
+        "src/clawock/broken.py": "def f(:\n",
+        "ops/also_fine.py": "y = 2\n",
+    })
+    monkeypatch.setattr(system_check, "WS", workspace)
+    _no_subprocess(monkeypatch, system_check)
+
+    result = system_check.Result()
+    system_check.check_scripts_compile(result)
+
+    name, severity, message = result.checks[0]
+    assert severity == system_check.CRITICAL, (severity, message)
+    assert "broken.py" in message and "fine.py" not in message, message
+
+
+def test_checking_the_tree_does_not_write_into_it(
+        system_check, tmp_path, monkeypatch):
+    """py_compile's whole job is to emit bytecode; the check only ever wanted
+    the verdict. A health check must not modify what it inspects."""
+    workspace = _workspace(tmp_path, {"src/clawock/fine.py": "x = 1\n"})
+    monkeypatch.setattr(system_check, "WS", workspace)
+    _no_subprocess(monkeypatch, system_check)
+
+    result = system_check.Result()
+    system_check.check_scripts_compile(result)
+
+    assert [s for _, s, _ in result.checks] == [system_check.OK]
+    assert not list(workspace.rglob("__pycache__")), (
+        "the check left bytecode behind in the tree it was checking")
+
+
+def test_the_real_repository_still_compiles(system_check):
+    """The check has to keep answering the question it exists for."""
+    result = system_check.Result()
+    system_check.check_scripts_compile(result)
+    assert [s for _, s, _ in result.checks] == [system_check.OK], result.checks
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
性能/稳定性 · 承接 #1382——那条 PR 把预算调大到能装下这个成本，这条 PR 去掉成本本身。

## Where the 61 seconds went

`ops/system_check.py` runs inside `.githooks/pre-push`, **once per push
attempt**, and `safe_push.sh` attempts up to three times. Profiled per check on
the live host (11 cron jobs, 200 Python files):

```
 37.32s   61.1%  check_model_chain_health
 10.49s   17.2%  check_scripts_compile
  7.49s   12.3%  check_context_capability
  3.27s    5.4%  check_cron_paths_exist
  1.92s    3.1%  check_dashboard_buildable
  ...
 61.06s   total (25 checks)
```

**Neither of the top two was work.**

### 1. One `openclaw` process per cron job (37.3s)

`check_model_chain_health` reads the run history through `cron_runs.load_entries`
with the default `auto` source. `auto` prefers the CLI — the right preference
for *a* read, since the CLI is the supported interface — but this reader makes
one call **per job**:

```
read_jobs  via CLI     3.34s        read_jobs  via SQLite   0.02s
read_runs  via CLI    33.66s        read_runs  via SQLite   0.16s     (11 jobs)
```

The same conclusion is already in the repository, written on 2026-07-18 in
`ops/host/cron_token_audit.py`:

> `auto` shells out to `openclaw cron runs --id` once per job; across 11 jobs
> that took minutes … this is a read-only report — the fastest honest source wins.

This caller is the one place it had not reached, and the most expensive place to
miss it. SQLite is also a **superset**: the CLI caps at 50 runs per job, so the
newest-40 window this check reads is identical either way.

Falls back to `auto` when the store answers nothing — a host whose SQLite has
moved should lose the speed, not the signal.

### 2. One interpreter per Python file (10.5s)

`check_scripts_compile` spawned `python3 -m py_compile` for each of 200 files.
The builtin `compile()` raises exactly what py_compile reports, so the verdict
is unchanged — and the old version left a `__pycache__` behind for every file it
looked at: a health check writing into the tree it inspects.

## After

Same 25 checks, same verdicts:

```
run1 9.54 s   run2 8.71 s   run3 9.00 s
```

61.1s → ~9s. Against the retry ladder that is up to 3 × 52 seconds returned to
every publish.

The push budget from #1382 is deliberately **not** lowered to match — it is
sized for a loaded, swapping host, and a stranded commit costs more than the
seconds it reserves. The comment there now says so instead of citing a
measurement this PR invalidates.

## Gate

`tests/test_system_check_reads_without_spawning.py` — behavioural, because the
defect was never visible in what the checks *said*, only in what they did. The
process is **denied**, not counted: `openclaw.cron_cli_json` raises, and
`subprocess.run` raises. Both checks are then driven against a synthetic openclaw
SQLite store and a synthetic source tree, so the verdicts are pinned beside the
speed:

- a `(billing)` hop is still named, a `timeout` hop still is not;
- a file that does not compile is still CRITICAL and names itself;
- checking a tree leaves no `__pycache__` in it;
- the real repository still compiles (the equivalence anchor — green both ways).

Four of the five are red on `origin/master`.

## 用户能看到的差别

SURFACE: 无（基础设施）
先例: #1382
