### PR TITLE
signal panel: 20s of every dashboard rebuild, recomputing a number that moves once a day

### DIFF
--- a/src/clawock/evaluation/signal_panel.py
+++ b/src/clawock/evaluation/signal_panel.py
@@ -90,6 +90,7 @@ observed, not a registration.
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import math
 import statistics
@@ -1124,6 +1125,100 @@ def _barrier_mix(panel) -> dict:
     return out
 
 
+#: Files whose bytes decide what `evaluate` returns for a given panel. The memo
+#: below is keyed on these as well as on the panel, so editing the scoring code
+#: invalidates every cached answer instead of serving pre-edit numbers. Globs
+#: rather than a list of names: a helper written next to these is covered the
+#: day it appears, and the gate asserts every first-party module this one
+#: imports lands inside them.
+EVALUATION_SOURCES = (
+    'evaluation/*.py',
+    'labeling/*.py',
+    'seeds.py',
+    'decision/setup_review.py',
+)
+
+
+#: The rest of what this module imports from the package: everything that
+#: cannot change what `evaluate` returns. These build the panel, print it, or
+#: write the memo itself — a new bar arriving changes the panel, and the panel
+#: is already the other half of the key. The split is asserted, not assumed: the
+#: gate reads this module's imports and fails on one in neither tuple, so an
+#: import that lands on the evaluation path has to be classified.
+MEMO_NEUTRAL_IMPORTS = (
+    'clawock.history_store',
+    'clawock.decision.ledger',
+    'clawock.instruments',
+    'clawock.workspace',
+    'clawock.evidence.run_card',
+    'clawock.safe_io',
+)
+
+
+def _source_fingerprint() -> str:
+    root = Path(__file__).resolve().parents[1]
+    digest = hashlib.sha256()
+    for pattern in EVALUATION_SOURCES:
+        for path in sorted(root.glob(pattern)):
+            digest.update(path.name.encode('utf-8'))
+            digest.update(path.read_bytes())
+    return digest.hexdigest()
+
+
+def evaluation_key(panel) -> str:
+    """What `evaluate(panel)` is a function of: the rows, and the code."""
+    digest = hashlib.sha256()
+    digest.update(json.dumps(panel, sort_keys=True, default=str,
+                             ensure_ascii=False).encode('utf-8'))
+    digest.update(_source_fingerprint().encode('utf-8'))
+    return digest.hexdigest()
+
+
+def memo_path() -> Path:
+    return WS / 'memory' / '.tmp' / 'signal-panel-evaluation.json'
+
+
+def evaluate_cached(panel, *, path: Path | None = None) -> dict:
+    """`evaluate(panel)`, memoised on what it is a function of.
+
+    This is not a staleness trade. `evaluate` is pure, and every draw inside it
+    is seeded — `_cluster_ci`'s `random.Random(seed)` and the placebo's
+    `np.random.default_rng(seed)` — so the same panel through the same code
+    always produces the same dict. Verified byte for byte before this was
+    written: two runs over the live panel, one 138,027-byte JSON, one hash.
+
+    It is worth having because the panel's leading edge lags the calendar. A row
+    needs its t20 forward returns, so on 2026-09-06 the newest session in the
+    panel was 2026-09-01 — the content changes about once a day, while
+    `rebuild_dashboard` recomputes it on every intraday slot: 20.663s of
+    `timings_s.decision_map` on the live host (2026-09-04), inside the half of
+    the postflight that the cron payloads had to forbid a `timeout` around,
+    because a kill there delivers the report and loses the commit (#765).
+
+    A missing, unreadable, or differently-keyed memo costs one recomputation and
+    nothing else. The file is never authoritative for anything except its own
+    key, and it is written atomically, so a concurrent reader sees one whole
+    answer or the other.
+    """
+    path = path or memo_path()
+    key = evaluation_key(panel)
+    try:
+        cached = json.loads(path.read_text(encoding='utf-8'))
+        if isinstance(cached, dict) and cached.get('key') == key:
+            return cached['evaluation']
+    except Exception:
+        pass  # no memo, a torn one, or one from other code — recompute
+    result = evaluate(panel)
+    try:
+        from clawock.safe_io import safe_write_text
+        path.parent.mkdir(parents=True, exist_ok=True)
+        safe_write_text(str(path), json.dumps(
+            {'key': key, 'evaluation': result}, ensure_ascii=False))
+    except Exception:
+        pass  # a memo that cannot be written is a memo that is not used
+    return result
+
+
 def evaluate(panel) -> dict:
     by_signal = defaultdict(list)
     for row in panel:
@@ -1217,7 +1312,7 @@ def main(argv=None) -> int:
     if args.panel:
         print(json.dumps(panel, ensure_ascii=False, indent=2))
         return 0
-    result = evaluate(panel)
+    result = evaluate_cached(panel)
     if args.json:
         print(json.dumps(result, ensure_ascii=False, indent=2))
         return 0

--- a/src/clawock/publish/decision_map.py
+++ b/src/clawock/publish/decision_map.py
@@ -252,7 +252,7 @@ def panel_scores(data_dir: Path | None = None, evaluation: dict | None = None) -
     from clawock.evaluation import signal_panel
 
     if evaluation is None:
-        evaluation = signal_panel.evaluate(signal_panel.build_panel(
+        evaluation = signal_panel.evaluate_cached(signal_panel.build_panel(
             Path(data_dir or DATA)))
     coverage = evaluation['coverage']
     by_signal = {

--- a/tests/test_signal_panel_memo.py
+++ b/tests/test_signal_panel_memo.py
@@ -1,0 +1,153 @@
+"""`evaluate` is recomputed every intraday slot from inputs that move once a day.
+
+`rebuild_dashboard` runs `clawock decision-map` on every dashboard rebuild, and
+`decision_map.panel_scores` calls `signal_panel.evaluate` — 20.663s of
+`timings_s.decision_map` on the live host (2026-09-04), inside the half of the
+postflight that the cron payloads had to forbid a `timeout` around, because a
+kill there delivers the report and loses the commit (#765).
+
+It does not need recomputing that often. A panel row needs its t20 forward
+returns, so the panel's leading edge lags the calendar: on 2026-09-06 its newest
+session was 2026-09-01. And `evaluate` is pure with every draw seeded, so the
+same panel through the same code gives the same dict — verified byte for byte
+before the memo was written.
+
+These tests pin the two halves of that claim: a hit returns exactly what a
+recomputation returns, and it really is a hit (the recomputation is *denied*,
+not counted). The third pins the part that is easy to get wrong — a memo keyed
+only on data serves pre-edit numbers after the scoring code changes.
+"""
+from __future__ import annotations
+
+import ast
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from clawock.evaluation import signal_panel  # noqa: E402
+
+
+def _panel():
+    """Three sessions of a two-name cross-section — enough for `_cluster_ci`."""
+    rows = []
+    for index, day in enumerate(("2026-08-03", "2026-08-04", "2026-08-05")):
+        for ticker, value in (("AAA", 1.0 + index), ("BBB", -1.0 - index)):
+            rows.append({
+                "as_of": day, "ticker": ticker, "leg": "us",
+                "signal": "quant.demo", "value": value,
+                "t1": value / 100, "t5": value / 50, "t20": value / 25,
+            })
+    return rows
+
+
+def test_the_memo_returns_what_a_recomputation_returns(tmp_path):
+    panel = _panel()
+    memo = tmp_path / "memo.json"
+
+    fresh = signal_panel.evaluate(panel)
+    first = signal_panel.evaluate_cached(panel, path=memo)
+    second = signal_panel.evaluate_cached(panel, path=memo)
+
+    dump = lambda value: json.dumps(value, sort_keys=True, default=str)  # noqa: E731
+    assert dump(first) == dump(fresh)
+    assert dump(second) == dump(fresh)
+    assert memo.exists(), "the memo was never written, so every call recomputes"
+
+
+def test_a_hit_does_not_recompute(tmp_path, monkeypatch):
+    """Denied, not counted — and a memo that recursed into itself would fail
+    here too, which is how that draft was caught."""
+    panel = _panel()
+    memo = tmp_path / "memo.json"
+    warm = signal_panel.evaluate_cached(panel, path=memo)
+
+    monkeypatch.setattr(signal_panel, "evaluate", lambda _panel: pytest.fail(
+        "the memo recomputed an answer it already had"))
+    again = signal_panel.evaluate_cached(panel, path=memo)
+
+    assert json.dumps(again, sort_keys=True) == json.dumps(warm, sort_keys=True)
+
+
+def test_a_different_panel_is_a_miss(tmp_path):
+    panel = _panel()
+    memo = tmp_path / "memo.json"
+    signal_panel.evaluate_cached(panel, path=memo)
+
+    moved = [dict(row) for row in panel]
+    moved[0]["value"] += 5.0
+    result = signal_panel.evaluate_cached(moved, path=memo)
+
+    assert json.dumps(result, sort_keys=True, default=str) == json.dumps(
+        signal_panel.evaluate(moved), sort_keys=True, default=str)
+
+
+def test_editing_the_scoring_code_invalidates_the_memo(tmp_path, monkeypatch):
+    """A memo keyed only on data would answer with pre-edit numbers."""
+    panel = _panel()
+    memo = tmp_path / "memo.json"
+    signal_panel.evaluate_cached(panel, path=memo)
+    before = json.loads(memo.read_text(encoding="utf-8"))["key"]
+
+    monkeypatch.setattr(signal_panel, "_source_fingerprint",
+                        lambda: "pretend the scoring code changed")
+    signal_panel.evaluate_cached(panel, path=memo)
+    after = json.loads(memo.read_text(encoding="utf-8"))["key"]
+
+    assert before != after, (
+        "the key ignores the code, so an edit to score_signal would be served "
+        "the answer from before it")
+
+
+def test_an_unreadable_memo_costs_a_recomputation_and_nothing_else(tmp_path):
+    memo = tmp_path / "memo.json"
+    memo.write_text("{not json", encoding="utf-8")
+    panel = _panel()
+
+    result = signal_panel.evaluate_cached(panel, path=memo)
+
+    assert json.dumps(result, sort_keys=True, default=str) == json.dumps(
+        signal_panel.evaluate(panel), sort_keys=True, default=str)
+    assert json.loads(memo.read_text(encoding="utf-8"))["key"]
+
+
+def test_every_first_party_import_is_classified():
+    """Either it decides what `evaluate` returns — and is fingerprinted — or it
+    provably cannot. An import in neither tuple is an unanswered question about
+    whether the memo can go stale."""
+    source = (ROOT / "src" / "clawock" / "evaluation" / "signal_panel.py")
+    tree = ast.parse(source.read_text(encoding="utf-8"))
+    imported = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and (node.module or "").startswith("clawock"):
+            for alias in node.names:
+                imported.add(f"{node.module}.{alias.name}")
+        elif isinstance(node, ast.Import):
+            imported.update(a.name for a in node.names if a.name.startswith("clawock"))
+
+    package = ROOT / "src" / "clawock"
+    fingerprinted = {path.relative_to(package).with_suffix("")
+                     for pattern in signal_panel.EVALUATION_SOURCES
+                     for path in package.glob(pattern)}
+    fingerprinted = {"clawock." + str(rel).replace("/", ".") for rel in fingerprinted}
+
+    unclassified = []
+    for name in sorted(imported):
+        module = name
+        # `from clawock.x import y` — y may be a symbol, not a module.
+        candidates = {module, module.rsplit(".", 1)[0]}
+        if candidates & fingerprinted:
+            continue
+        if any(candidate in signal_panel.MEMO_NEUTRAL_IMPORTS
+               for candidate in candidates):
+            continue
+        unclassified.append(name)
+
+    assert not unclassified, (
+        f"neither fingerprinted nor declared panel-build-only: {unclassified}. "
+        f"If it can change what evaluate() returns it belongs in "
+        f"EVALUATION_SOURCES; if it cannot, say so in MEMO_NEUTRAL_IMPORTS.")


### PR DESCRIPTION
性能/稳定性 · 接着 #1385 往热路径里走一层。

## Where the postflight's commit half goes

`logs/dashboard_build_status.json` already records the breakdown of every
rebuild. The last real (non-skipped) one on the live host, 2026-09-04:

```json
"timings_s": {
  "prepare_inputs": 0.887, "fetch_data_plane": 1.045, "workflow_outcomes": 1.58,
  "dashboard_build": 4.049, "decision_map": 20.663, "publish_generation": 11.149
}
```

`decision_map` is 53% of it. Under cProfile the shape is unambiguous:

```
 36.904s  decision_map.main
 36.870s   └ build
 36.478s     └ panel_scores
 31.965s        └ signal_panel.evaluate
 28.516s           └ _cluster_ci            (275 calls)
 23.332s              └ random.choice       (14,270,000 calls)
```

A seeded session bootstrap, 2000 resamples per signal per horizon, drawing one
element at a time.

## Why it does not need recomputing

A panel row needs its **t20 forward returns**, so the panel's leading edge lags
the calendar. On 2026-09-06:

```
rows 11923  sessions 89  newest ['2026-08-29', '2026-08-31', '2026-09-01']
```

The newest scoreable session is five days old. The inputs move about once a day
— and `rebuild_dashboard` recomputes this on every intraday slot, up to eighteen
times a day, each time producing the identical dict.

Identical is not a guess. `evaluate` is pure and every draw inside it is seeded
(`_cluster_ci`'s `random.Random(seed)`, the placebo's
`np.random.default_rng(seed)`). Two runs over the live panel before anything was
written:

```
run0 7.5s  138027 bytes  7c437f08f564a981
run1 7.1s  138027 bytes  7c437f08f564a981
deterministic: True
```

## The change

`evaluate_cached(panel)` — memoised on **the panel rows AND the bytes of the code
that scores them**. The second half matters: a memo keyed only on data would
serve pre-edit numbers the first time someone changes `score_signal`.

```
miss 7.72s   hit 0.074s   uncached 7.06s   memo 138118B
hit == uncached: True
```

A missing, torn, or differently-keyed memo costs one recomputation and nothing
else; it is written atomically, so a concurrent reader sees one whole answer or
the other.

The half of the postflight this sits in is the half `config/cron-payloads/*.md`
had to forbid a `timeout` around, because a kill between delivery and commit
leaves a report that was sent and never archived (#765). **Twenty seconds out of
that window is the point** — the speed is the smaller half of it.

`panel_scores`'s promise is untouched: `evaluation.signal_panel.evaluate` is
still the only place a rank IC is computed, and the site still republishes it
unrounded and unrecomputed.

## Gate

`tests/test_signal_panel_memo.py`:

- a hit is proven by **denying** the recomputation — `evaluate` is monkeypatched
  to fail the test. That is also how a draft which recursed into
  `evaluate_cached` instead of `evaluate` was caught;
- a changed panel, a changed source fingerprint, and an unreadable memo are all
  misses, and each is checked against a live recomputation;
- **every first-party import of the module must be either fingerprinted or
  declared `MEMO_NEUTRAL_IMPORTS`.** An import that lands on the evaluation path
  without being part of the key is the one way this memo could ever go stale, so
  adding one forces the classification. (It has already earned its keep: it
  caught `safe_io`, added by this very change.)

Full suite locally: 3403 passed, 5 skipped, 4 xfailed.

## 用户能看到的差别

SURFACE: 无（基础设施）
先例: #765
