### PR TITLE
system_check: the same cron listing, fetched twice, 6.4s of a 10.3s run

### DIFF
--- a/ops/system_check.py
+++ b/ops/system_check.py
@@ -11,6 +11,7 @@ Used by:
   • CI weekly-health.yml      (full check)
   • Manual: `python3 ops/system_check.py`
 """
+import functools
 import glob
 import json
 import os
@@ -552,6 +553,30 @@ def check_decision_ledger(r):
         r.add('decisions.jsonl', OK, f'{len(rows)} decisions · {len({x.get("episode_id") for x in rows})} episodes')
 
 
+@functools.lru_cache(maxsize=1)
+def _cron_listing():
+    """The cron schedule, read once for the whole run.
+
+    Two checks need it — `check_cron_paths_exist` for the payload contract and
+    `check_context_capability` for per-job prompt-report coverage — and each was
+    reading it for itself: two identical `openclaw cron list --json` spawns,
+    3.28s and 3.11s measured inside a 10.3s run, inside `.githooks/pre-push`,
+    once per push attempt.
+
+    One read is also the more correct read. Two checks in the same report
+    disagreeing about which jobs exist would be a defect, and a schedule cannot
+    meaningfully change inside the ten seconds this process lives.
+
+    Returns `(read, error)` so each caller keeps the wording it already had for
+    a schedule it could not read. `main()` clears it, so a long-lived caller
+    (the tests) never inherits another run's snapshot.
+    """
+    try:
+        return openclaw_read_jobs(), None
+    except Exception as error:  # noqa: BLE001 — each caller reports its own way
+        return None, error
+
+
 def _cron_jobs_without_prompt_report(sessions):
     """Enabled cron jobs whose newest session carries no `systemPromptReport`.
 
@@ -571,11 +596,13 @@ def _cron_jobs_without_prompt_report(sessions):
     cannot be read — an unreadable schedule is not evidence that every job is
     covered, but it is also not this check's failure to report.
     """
-    try:
-        from clawock.providers.openclaw import cron_cli_json
-
-        listing = cron_cli_json(['list', '--json']) or {}
-    except Exception:
+    listing, error = _cron_listing()
+    # Unchanged semantics: this needs the CLI's flattened `status`, which the
+    # SQLite view does not carry (it has the nested state only), and before the
+    # shared read a CLI that could not answer left this with an empty listing
+    # and therefore no findings. An unreadable schedule is still not evidence
+    # that every job is covered.
+    if error is not None or listing is None or listing.source != 'cli':
         return []
 
     reported = {
@@ -585,7 +612,7 @@ def _cron_jobs_without_prompt_report(sessions):
         and isinstance(entry.get('systemPromptReport'), dict)
     }
     missing = []
-    for job in listing.get('jobs', []) or []:
+    for job in listing.entries or []:
         if not job.get('enabled'):
             continue
         if str(job.get('id')) in reported:
@@ -704,12 +731,11 @@ def check_cron_paths_exist(r):
     files kept only as an explicitly rejected last-resort fossil.
     """
     import re
-    try:
-        cron_read = openclaw_read_jobs()
-        jobs = cron_read.entries
-    except Exception as e:
-        r.add('cron paths', WARNING, f'cron jobs unreadable: {e}')
+    cron_read, error = _cron_listing()
+    if error is not None or cron_read is None:
+        r.add('cron paths', WARNING, f'cron jobs unreadable: {error}')
         return
+    jobs = cron_read.entries
     if not jobs:
         if not openclaw_is_installed():
             # CI runner / dev clone without the openclaw install — nothing to check.
@@ -1670,6 +1696,10 @@ def main():
     # GitHub Secret Scanning + Push Protection own repository-wide credential
     # detection. The pre-commit hook still scans staged additions locally; do
     # not put the old full-tree git-grep back into this latency-sensitive hook.
+    # A fresh snapshot per run: the memo is for the seconds this process lives,
+    # not for a test session that calls main() twice against different stores.
+    _cron_listing.cache_clear()
+
     checks = [
         check_baseline_files,
         check_root_allowlist,

--- a/tests/test_context_capability_not_vacuous.py
+++ b/tests/test_context_capability_not_vacuous.py
@@ -16,6 +16,18 @@ import json
 import pytest
 
 
+@pytest.fixture(autouse=True)
+def _fresh_cron_listing():
+    """The cron schedule is read once per system_check run and memoised, so a
+    test that stubs a different listing has to start from an empty memo — the
+    same clear `main()` does before its checks."""
+    import ops.system_check as sc
+
+    sc._cron_listing.cache_clear()
+    yield
+    sc._cron_listing.cache_clear()
+
+
 class _Report:
     def __init__(self):
         self.rows = []

--- a/tests/test_system_check_reads_without_spawning.py
+++ b/tests/test_system_check_reads_without_spawning.py
@@ -122,6 +122,96 @@ def test_a_healthy_chain_is_read_from_the_store_too(
                                                       system_check.OK)]
 
 
+# ── the schedule, once ──────────────────────────────────────────────────────
+
+def _listing(source, jobs):
+    from clawock.providers.openclaw import CronRead
+    return CronRead(jobs, source)
+
+
+def _counting_reader(system_check, monkeypatch, result):
+    reads = []
+    monkeypatch.setattr(system_check, "openclaw_read_jobs",
+                        lambda *a, **k: reads.append(1) or result)
+    system_check._cron_listing.cache_clear()
+    return reads
+
+
+def test_the_schedule_is_read_once_for_the_whole_run(system_check, monkeypatch):
+    """Two checks need the cron listing. Each used to fetch its own, and the
+    fetch is an `openclaw cron list --json` subprocess: two 3.1-3.3s spawns
+    inside a 10.3s run, inside the pre-push hook, once per push attempt.
+
+    Counted at the provider, not at the memo, so this says the same thing about
+    the code that has no memo.
+    """
+    from clawock.providers import openclaw
+
+    spawns = []
+    monkeypatch.setattr(openclaw, "cron_cli_json", lambda *a, **k: spawns.append(1) or {
+        "jobs": [{"id": "job-a", "name": "cron a", "enabled": True,
+                  "status": "ok", "state": {"lastRunStatus": "ok"},
+                  "schedule": {"kind": "cron", "expr": "0 8 * * 1-5"}}]})
+    if hasattr(system_check, "_cron_listing"):
+        system_check._cron_listing.cache_clear()
+
+    for call in (lambda: system_check.check_cron_paths_exist(system_check.Result()),
+                 lambda: system_check._cron_jobs_without_prompt_report({})):
+        try:
+            call()
+        except Exception:  # noqa: BLE001 — the spawn count is the assertion
+            pass
+
+    assert len(spawns) == 1, (
+        f"the schedule was fetched {len(spawns)} times in one run; each fetch "
+        f"is a subprocess")
+
+
+def test_a_new_run_does_not_inherit_the_last_snapshot(system_check, monkeypatch):
+    """The memo is for the seconds one process lives. `main()` clears it, and so
+    must anything that drives these checks twice against different stores."""
+    first = _listing("cli", [{"id": "one", "name": "one", "enabled": True}])
+    second = _listing("cli", [{"id": "two", "name": "two", "enabled": True}])
+    monkeypatch.setattr(system_check, "openclaw_read_jobs", lambda *a, **k: first)
+    system_check._cron_listing.cache_clear()
+
+    assert system_check._cron_listing()[0].entries[0]["id"] == "one"
+    monkeypatch.setattr(system_check, "openclaw_read_jobs", lambda *a, **k: second)
+    assert system_check._cron_listing()[0].entries[0]["id"] == "one", (
+        "the memo did not hold, so both checks pay for their own read")
+    system_check._cron_listing.cache_clear()
+    assert system_check._cron_listing()[0].entries[0]["id"] == "two"
+
+
+def test_prompt_report_coverage_still_declines_a_non_cli_listing(
+        system_check, monkeypatch):
+    """It reads the CLI's flattened `status` to skip a job that is running, and
+    the SQLite view carries the nested state only. Before the shared read, a CLI
+    that could not answer left this with no findings; that has to stay true, or
+    a running job gets named as uncovered."""
+    jobs = [{"id": "job-a", "name": "cron a", "enabled": True,
+             "state": {"lastRunStatus": "ok"}}]
+    _counting_reader(system_check, monkeypatch, _listing("sqlite", jobs))
+
+    assert system_check._cron_jobs_without_prompt_report({}) == []
+
+
+def test_an_unreadable_schedule_is_reported_not_swallowed(
+        system_check, monkeypatch):
+    def explode(*_args, **_kwargs):
+        raise RuntimeError("no runtime here")
+
+    monkeypatch.setattr(system_check, "openclaw_read_jobs", explode)
+    system_check._cron_listing.cache_clear()
+
+    result = system_check.Result()
+    system_check.check_cron_paths_exist(result)
+
+    assert [s for _, s, _ in result.checks] == [system_check.WARNING]
+    assert "no runtime here" in result.checks[0][2]
+    assert system_check._cron_jobs_without_prompt_report({}) == []
+
+
 # ── compiling the sources ───────────────────────────────────────────────────
 
 def _workspace(tmp_path, files):


### PR DESCRIPTION
性能/稳定性 · #1385 的直接续集：那条 PR 之后钩子降到 ~9s，**数一数它还起几个进程**，答案是同一条命令起了两次。

## The finding

Counting `openclaw` CLI spawns across one `system_check` run:

```
total 10.3s, CLI spawns: 2
   (('list', '--json'), 3.28)
   (('list', '--json'), 3.11)
```

Two checks need the cron listing, and each fetched its own:

| check | how it read the schedule |
|---|---|
| `check_cron_paths_exist` | `openclaw_read_jobs()` |
| `check_context_capability` | `cron_cli_json(['list', '--json'])` |

6.4 seconds of a 10.3-second script, for the same listing — inside
`.githooks/pre-push`, once per push attempt.

**One read is also the more correct read.** Two checks in the same report
disagreeing about which jobs exist would be a defect, and a schedule cannot
meaningfully change inside the ten seconds this process lives.

## The change

`_cron_listing()` — the schedule, read once per run, returning `(read, error)`
so each caller keeps the wording it already had for a schedule it could not
read.

Semantics are unchanged where it matters. Prompt-report coverage still declines
a listing that did not come from the CLI: it reads the CLI's flattened `status`
to skip a job that is currently running, and the SQLite view carries the nested
state only —

```
CLIstatus= 'ok'   SQstatus= None
CLI top-only: ['lastDeliveryStatus', 'lastRunAtMs', 'lastRunStatus',
               'nextRunAtMs', 'status', 'updatedAtMs']
```

— so before the shared read, a CLI that could not answer left that check with an
empty listing and therefore no findings. That stays true, or a running job gets
named as uncovered.

## After

```
total 6.7s  rc=2  CLI spawns=1
  ⚠ WARN   context capability   1 enabled cron job(s) produce no prompt report … Memory Dreaming Promotion
  ✓ OK     cron paths           11 jobs · 0 referenced scripts present
```

Same 25 checks, same verdicts. **61.1s → 8.7-9.5s (#1385) → 6.7s**, against a
retry ladder that pays it up to three times per publish.

## The hazard this introduced, and what caught it

A memo is per-process state, which is exactly the thing that surprises a caller.
Two existing tests in `test_context_capability_not_vacuous.py` stub their own
listing and were served the previous test's snapshot. `main()` clears the memo
before its checks; that file now clears it around each test. The contract is
stated in both places rather than assumed in one.

## Gate

Appended to `tests/test_system_check_reads_without_spawning.py`:

- **the spawn count is asserted at the provider, not at the memo**, so it says
  the same thing about code that has no memo — red on `origin/master` with
  "the schedule was fetched 2 times in one run";
- a second run does not inherit the first's snapshot (`cache_clear` is part of
  the contract, not an implementation detail);
- a non-CLI listing still yields no prompt-report findings;
- an unreadable schedule is still reported as a WARN naming the error, not
  swallowed.

Full suite locally: 3407 passed, 5 skipped, 4 xfailed.

## 用户能看到的差别

SURFACE: 无（基础设施）
先例: #1382
