### PR TITLE
context capability: an empty coverage list meant both "all covered" and "nothing looked at"

### DIFF
--- a/ops/system_check.py
+++ b/ops/system_check.py
@@ -577,6 +577,30 @@ def _cron_listing():
         return None, error
 
 
+def _cron_coverage_blind():
+    """Why per-job coverage could not be counted this run, or None.
+
+    `_cron_jobs_without_prompt_report` returns an empty list both when every
+    job is covered and when the schedule could not be read at all — and those
+    are not the same answer. The check's own header states that rule for
+    sessions ("nothing to check" and "the thing I check stopped being produced"
+    are not the same answer); the schedule it counts coverage against was the
+    half still merging them, so a run that checked no job at all looked exactly
+    like a run in which every job was fine.
+
+    Silent where there is genuinely nothing to be blind about: a machine with no
+    openclaw (a CI runner, an agent worktree) has no schedule to fail to read.
+    """
+    listing, error = _cron_listing()
+    if error is None and listing is not None and listing.source == 'cli':
+        return None
+    if not openclaw_is_installed():
+        return None
+    source = 'unreadable' if listing is None else listing.source
+    return (f'the cron schedule came back {source}'
+            + (f' ({error})' if error is not None else ''))
+
+
 def _cron_jobs_without_prompt_report(sessions):
     """Enabled cron jobs whose newest session carries no `systemPromptReport`.
 
@@ -597,11 +621,13 @@ def _cron_jobs_without_prompt_report(sessions):
     covered, but it is also not this check's failure to report.
     """
     listing, error = _cron_listing()
-    # Unchanged semantics: this needs the CLI's flattened `status`, which the
-    # SQLite view does not carry (it has the nested state only), and before the
-    # shared read a CLI that could not answer left this with an empty listing
-    # and therefore no findings. An unreadable schedule is still not evidence
-    # that every job is covered.
+    # This needs the CLI's flattened `status` to skip a job that is running;
+    # the SQLite view carries the nested state only. When the CLI cannot
+    # answer, coverage is not empty — it is unknown, and the caller has to be
+    # able to tell those apart. This function's own header states the rule for
+    # sessions ("nothing to check" and "the thing I check stopped being
+    # produced" are not the same answer); the schedule it counts coverage
+    # against was the half still merging them.
     if error is not None or listing is None or listing.source != 'cli':
         return []
 
@@ -685,6 +711,15 @@ def check_context_capability(r):
     # reads OK while one live job is unverifiable (#473). Names, not a count, so
     # the finding says which job to go look at.
     unreported_jobs = _cron_jobs_without_prompt_report(sessions)
+    coverage_blind = _cron_coverage_blind()
+    if coverage_blind:
+        # Not a finding about the jobs — a finding about this gate. A run that
+        # could not read the schedule has checked no job at all, and saying
+        # nothing there is the same silence the paragraph above refuses.
+        r.add('context capability', WARNING,
+              f'per-job prompt-report coverage was not checked: '
+              f'{coverage_blind}, so a job producing no report would not be '
+              f'named by this run')
     if unreported_jobs:
         r.add('context capability', WARNING,
               f'{len(unreported_jobs)} enabled cron job(s) produce no prompt '

--- a/tests/test_system_check_reads_without_spawning.py
+++ b/tests/test_system_check_reads_without_spawning.py
@@ -196,6 +196,39 @@ def test_prompt_report_coverage_still_declines_a_non_cli_listing(
     assert system_check._cron_jobs_without_prompt_report({}) == []
 
 
+def test_coverage_that_could_not_be_counted_says_so(system_check, monkeypatch):
+    """An empty list of uncovered jobs means "every job is covered" OR "no job
+    was looked at", and the report showed the same green line either way. The
+    check's own header refuses that merge for sessions; this is the other half.
+    """
+    jobs = [{"id": "job-a", "name": "cron a", "enabled": True,
+             "state": {"lastRunStatus": "ok"}}]
+    _counting_reader(system_check, monkeypatch, _listing("sqlite", jobs))
+    monkeypatch.setattr(system_check, "openclaw_is_installed", lambda: True)
+
+    reason = system_check._cron_coverage_blind()
+
+    assert reason and "sqlite" in reason, reason
+    assert system_check._cron_jobs_without_prompt_report({}) == [], (
+        "the list is empty either way — which is the whole point")
+
+
+def test_a_machine_with_no_runtime_is_not_called_blind(system_check, monkeypatch):
+    """A CI runner and an agent worktree have no schedule to fail to read.
+    Warning there would be the false alarm this gate exists to avoid."""
+    _counting_reader(system_check, monkeypatch, _listing("sqlite", []))
+    monkeypatch.setattr(system_check, "openclaw_is_installed", lambda: False)
+
+    assert system_check._cron_coverage_blind() is None
+
+
+def test_a_cli_listing_is_not_blind(system_check, monkeypatch):
+    _counting_reader(system_check, monkeypatch, _listing("cli", []))
+    monkeypatch.setattr(system_check, "openclaw_is_installed", lambda: True)
+
+    assert system_check._cron_coverage_blind() is None
+
+
 def test_an_unreadable_schedule_is_reported_not_swallowed(
         system_check, monkeypatch):
     def explode(*_args, **_kwargs):


### PR DESCRIPTION
维度 I（闸的盲区）· 这一条是**这个 check 自己的注释**指出来的，只是它只把规则用在了一半上。

## The finding

`check_context_capability` says, in its own header:

> "Nothing to check" and "the thing I check stopped being produced" are not the
> same answer, and merging them is how this gate would go quiet without going
> red.

It enforces that for sessions. The **schedule** it counts per-job coverage
against is the half still merging them:

```python
unreported_jobs = _cron_jobs_without_prompt_report(sessions)
if unreported_jobs:
    r.add('context capability', WARNING, ...)
```

`_cron_jobs_without_prompt_report` returns `[]` in two very different worlds:

- every enabled cron job is covered, and
- **the cron listing could not be read at all, so no job was looked at.**

Both printed the same line: `✓ OK  context capability  interactive 7f/35s/31t ·
isolated-cron 5f/35s/34t`.

## Not hypothetical plumbing

The listing comes from `openclaw cron list --json`, and its own provider
documents the failure:

```python
# `cron list --json` round-trips through the gateway and has been observed
# at ~42s on a loaded host. A tight timeout trips TimeoutExpired, which
# callers read as "no data" and quietly fall back to a stale source.
CRON_TIMEOUT_SECONDS = 120
```

That fallback is the whole reason the SQLite path exists. When it happens, the
coverage half of this gate checks nothing — and, until this PR, said nothing
about it. #473 added per-job coverage precisely because a profile-level average
hid one unverifiable job; a run that checks zero jobs hides all of them.

## The change

`_cron_coverage_blind()` names the reason, and the check adds a WARN row **about
itself**, not about the jobs:

```
per-job prompt-report coverage was not checked: the cron schedule came back
sqlite, so a job producing no report would not be named by this run
```

Silent where there is genuinely nothing to be blind about: a machine with no
openclaw — a CI runner, an agent worktree — has no schedule to fail to read, and
warning there would be the false alarm this gate exists to avoid. Verified on
the live host: no new row, `_cron_coverage_blind()` returns None.

`_cron_jobs_without_prompt_report` keeps its list-returning shape on purpose —
eight existing assertions read it, and widening the return type to carry one
string would have been churn for no signal.

## Gate

Three cases in `tests/test_system_check_reads_without_spawning.py`:

- a non-CLI listing on a host that HAS openclaw is blind, and the uncovered-job
  list is empty in exactly that case — "which is the whole point";
- a host with no openclaw is not called blind;
- a CLI listing is not called blind.

Full suite locally: 3410 passed, 5 skipped, 4 xfailed.

## 用户能看到的差别

SURFACE: 无（基础设施）
先例: #473
