### PR TITLE
hero: the movers card said 今日 on a Sunday

### DIFF
--- a/site/assets/js/dashboard.hero.js
+++ b/site/assets/js/dashboard.hero.js
@@ -96,6 +96,39 @@
   // value+delta 三段式，tone ok/warn/bad），同类一排、放不下折行，不做段落；
   // 能画的数据画微图（接近度计量条、异动零轴迷你柱），文字退为 caption。
   // 判词句本体由 CSS 压成一行 caption —— 成段 prose 在这张卡里没有位置。
+  function moversHeadLabel(DATA) {
+    // The card said 今日异动 whatever the payload's age, and on a weekend those
+    // are Friday's moves — as is Monday morning before the open. About a third
+    // of the hours in a week the word 今日 is wrong.
+    //
+    // The catalyst block in this same card already refuses the browser's idea
+    // of "today" and takes the date from `last_updated`; this is the same
+    // refusal one row up. Both timestamps come out of the payload, so nothing
+    // here depends on the viewer's clock or zone: `last_updated` is HKT
+    // ("2026/09/05 04:03 HKT") and `generated_at` is the build's UTC instant.
+    //
+    // 20 hours, not "a different date": the widest gap inside one trading day
+    // is the US close (04:03 HKT) to the next HK open (09:30 HKT), about five
+    // and a half hours, so 20 cannot fire on a live session — while a weekend
+    // is about fifty.
+    //
+    // The stale label carries no date on purpose. `last_updated` is when the
+    // desk wrote, not which session the numbers are from: the US close lands at
+    // 04:03 HKT, so Friday's US moves are stamped Saturday, and printing that
+    // date would trade one wrong claim for another (#1278: the time on the
+    // artifact follows the cron, the market's own time is a different thing).
+    // The list also mixes both legs, which have different sessions. What the
+    // reader needs is that these are not today's, and that is what it says.
+    var stamp = String(safe(DATA, "last_updated") || "");
+    var match = stamp.match(/^(\d{4})[\/-](\d{2})[\/-](\d{2})\s+(\d{2}):(\d{2})/);
+    var built = Date.parse(String(safe(DATA, "generated_at") || ""));
+    if (!match || !isFinite(built)) return "今日异动";
+    var session = Date.parse(
+      match[1] + "-" + match[2] + "-" + match[3] + "T" + match[4] + ":" + match[5] + ":00+08:00");
+    if (!isFinite(session) || built - session < 20 * 3600 * 1000) return "今日异动";
+    return "异动 · 最近收盘";
+  }
+
   function renderTodayHighlights() {
     const el = document.getElementById("today-highlights");
     const mvEl = document.getElementById("today-movers");
@@ -208,10 +241,11 @@
         + ` style="width:${w.toFixed(1)}%"></i></span>`
         + `<span class="hl-mv-p ${pct >= 0 ? "pos" : "neg"}">${fmtPct(pct, 1)}</span></div>`;
     };
+    const moversHead = moversHeadLabel(DATA);
     const moversRow = movers.length
-      ? `<div class="hl-movers" role="img" aria-label="今日异动前 ${movers.length}：`
+      ? `<div class="hl-movers" role="img" aria-label="${moversHead}前 ${movers.length}：`
         + movers.map(x => `${x.ticker} ${fmtPct(x.today_change_pct, 1)}`).join("、")
-        + `"><div class="hl-mv-head">今日异动</div>${movers.map(mvRow).join("")}</div>`
+        + `"><div class="hl-mv-head">${moversHead}</div>${movers.map(mvRow).join("")}</div>`
       : "";
     // chip 与异动条各自落到自己的挂载点：≥1024 时它们是牌上左右两栏，
     // 窄档回到上下两带（版式全在 CSS，渲染端不判断宽度）。

--- a/site/assets/js/dashboard.render.js
+++ b/site/assets/js/dashboard.render.js
@@ -232,6 +232,39 @@
   // value+delta 三段式，tone ok/warn/bad），同类一排、放不下折行，不做段落；
   // 能画的数据画微图（接近度计量条、异动零轴迷你柱），文字退为 caption。
   // 判词句本体由 CSS 压成一行 caption —— 成段 prose 在这张卡里没有位置。
+  function moversHeadLabel(DATA) {
+    // The card said 今日异动 whatever the payload's age, and on a weekend those
+    // are Friday's moves — as is Monday morning before the open. About a third
+    // of the hours in a week the word 今日 is wrong.
+    //
+    // The catalyst block in this same card already refuses the browser's idea
+    // of "today" and takes the date from `last_updated`; this is the same
+    // refusal one row up. Both timestamps come out of the payload, so nothing
+    // here depends on the viewer's clock or zone: `last_updated` is HKT
+    // ("2026/09/05 04:03 HKT") and `generated_at` is the build's UTC instant.
+    //
+    // 20 hours, not "a different date": the widest gap inside one trading day
+    // is the US close (04:03 HKT) to the next HK open (09:30 HKT), about five
+    // and a half hours, so 20 cannot fire on a live session — while a weekend
+    // is about fifty.
+    //
+    // The stale label carries no date on purpose. `last_updated` is when the
+    // desk wrote, not which session the numbers are from: the US close lands at
+    // 04:03 HKT, so Friday's US moves are stamped Saturday, and printing that
+    // date would trade one wrong claim for another (#1278: the time on the
+    // artifact follows the cron, the market's own time is a different thing).
+    // The list also mixes both legs, which have different sessions. What the
+    // reader needs is that these are not today's, and that is what it says.
+    var stamp = String(safe(DATA, "last_updated") || "");
+    var match = stamp.match(/^(\d{4})[\/-](\d{2})[\/-](\d{2})\s+(\d{2}):(\d{2})/);
+    var built = Date.parse(String(safe(DATA, "generated_at") || ""));
+    if (!match || !isFinite(built)) return "今日异动";
+    var session = Date.parse(
+      match[1] + "-" + match[2] + "-" + match[3] + "T" + match[4] + ":" + match[5] + ":00+08:00");
+    if (!isFinite(session) || built - session < 20 * 3600 * 1000) return "今日异动";
+    return "异动 · 最近收盘";
+  }
+
   function renderTodayHighlights() {
     const el = document.getElementById("today-highlights");
     const mvEl = document.getElementById("today-movers");
@@ -344,10 +377,11 @@
         + ` style="width:${w.toFixed(1)}%"></i></span>`
         + `<span class="hl-mv-p ${pct >= 0 ? "pos" : "neg"}">${fmtPct(pct, 1)}</span></div>`;
     };
+    const moversHead = moversHeadLabel(DATA);
     const moversRow = movers.length
-      ? `<div class="hl-movers" role="img" aria-label="今日异动前 ${movers.length}：`
+      ? `<div class="hl-movers" role="img" aria-label="${moversHead}前 ${movers.length}：`
         + movers.map(x => `${x.ticker} ${fmtPct(x.today_change_pct, 1)}`).join("、")
-        + `"><div class="hl-mv-head">今日异动</div>${movers.map(mvRow).join("")}</div>`
+        + `"><div class="hl-mv-head">${moversHead}</div>${movers.map(mvRow).join("")}</div>`
       : "";
     // chip 与异动条各自落到自己的挂载点：≥1024 时它们是牌上左右两栏，
     // 窄档回到上下两带（版式全在 CSS，渲染端不判断宽度）。

--- a/tests/dashboard_tab_runtime.spec.js
+++ b/tests/dashboard_tab_runtime.spec.js
@@ -1491,6 +1491,48 @@ async function testDataHealthNamesTheDegradedSlotAndWeChatDrops(browser, base) {
   await context.close();
 }
 
+async function testMoversSayWhichSessionTheyAreFrom(browser, base) {
+  // 「今日异动」印的是 portfolio.json 里的 today_change_pct，也就是最近一次
+  // 报价的涨跌。周末打开面板，那是周五的数字，却顶着「今日」；周一开盘前同样。
+  // 一周里大约三分之一的时间这两个字是错的。同一张牌下面十行的 catalyst 块
+  // 早就拒绝用浏览器的「今天」（它从 last_updated 取日期），这里是同一条拒绝。
+  for (const [label, lastUpdated, generatedAt, expected] of [
+    ["weekend", "2026/09/05 04:03 HKT", "2026-09-06T16:40:05Z", "异动 · 最近收盘"],
+    ["live session", "2026/09/04 16:10 HKT", "2026-09-04T08:15:00Z", "今日异动"],
+  ]) {
+    const context = await browser.newContext({ viewport: { width: 1280, height: 900 } });
+    const page = await context.newPage();
+    await stubLiveOrigin(page, {
+      patch: (name, json) => {
+        if (name !== "overview.json" && name !== "dashboard.json") return null;
+        json.last_updated = lastUpdated;
+        json.generated_at = generatedAt;
+        json.today_movers = [
+          { ticker: "SKHY", name: "SK", region: "us", today_change_pct: 8.14, current_price: 177 },
+          { ticker: "07226", name: "XL", region: "hk", today_change_pct: 4.4, current_price: 3.18 },
+        ];
+        return json;
+      },
+    });
+    const state = observe(page);
+    await page.goto(base, { waitUntil: "networkidle" });
+    await waitForData(page);
+
+    const head = page.locator(".hl-mv-head");
+    await head.waitFor({ state: "visible" });
+    assert.equal((await head.innerText()).trim(), expected,
+      `${label}: the movers card claims the wrong session`);
+
+    const aria = await page.locator(".hl-movers").getAttribute("aria-label");
+    assert(aria && aria.startsWith(expected),
+      `${label}: the screen-reader label still says something else: ${aria}`);
+
+    assert.deepEqual(state.failures, []);
+    assert.deepEqual(state.errors, []);
+    await context.close();
+  }
+}
+
 async function main() {
   const server = serveWorkspace();
   await new Promise(resolve => server.listen(0, "127.0.0.1", resolve));
@@ -1515,6 +1557,7 @@ async function main() {
     await testAPanelSaysWhenItsDataDidNotLoad(browser, base);
     await testCronRailAccountsForEverySlotWithoutASecondVerdict(browser, base);
     await testCronNeedsActionMergesIntoTheOneTodoListButWatchDoesNot(browser, base);
+    await testMoversSayWhichSessionTheyAreFrom(browser, base);
   } finally {
     await browser.close();
     await new Promise(resolve => server.close(resolve));


### PR DESCRIPTION
维度 L · 类 3（交互与状态完整）—— 这次是**一个断言，没有依据**。

## The finding

The hero's movers card prints a hardcoded head:

```js
+ `"><div class="hl-mv-head">今日异动</div>${movers.map(mvRow).join("")}</div>`
```

`today_movers` is built from `today_change_pct` in portfolio.json — the change on
the last quote the desk saw. Nothing anywhere checks when that was.

Live payload, read at 2026-09-06 16:40 UTC (a Sunday):

```
generated_at  2026-09-06T16:40:05Z
last_updated  2026/09/05 04:03 HKT
today_movers  SKHY +8.14% · 07226 +4.40%      ← Friday's session
```

So the card told a Sunday reader that SKHY moved 8% **today**. Same every weekday
morning before the open. Roughly a third of the hours in a week the word 今日 is
false.

**Ten lines below, in the same card, the catalyst block already refuses this**:

```js
// last_updated is HKT-local with slashes …
const today = (String(safe(DATA, "last_updated") || "").slice(0,10)…)
```

— it takes "today" from the payload rather than from the browser, on purpose.
The row above it never got the same treatment.

## The change

`moversHeadLabel(DATA)` compares two timestamps that **both come out of the
payload**, so nothing depends on the viewer's clock or time zone:

| payload | head |
|---|---|
| `last_updated 2026/09/04 16:10 HKT` + `generated_at 2026-09-04T08:15Z` (live) | `今日异动` |
| `last_updated 2026/09/05 04:03 HKT` + `generated_at 2026-09-06T16:40Z` (Sunday) | `异动 · 最近收盘` |
| Monday 00:05 UTC, data still Saturday 04:03 HKT | `异动 · 最近收盘` |
| either field missing or unparseable | `今日异动` (never invents a claim) |

**20 hours, not "a different calendar date"**: the widest gap inside one trading
day is the US close (04:03 HKT) to the next HK open (09:30 HKT) — about five and
a half hours — so the threshold cannot fire on a live session, while a weekend
is about fifty.

**The stale label carries no date on purpose.** `last_updated` is when the desk
wrote, not which session the numbers are from: the US close lands at 04:03 HKT,
so Friday's US moves are stamped *Saturday*, and printing that date would trade
one wrong claim for another (#1278 — the time on the artifact follows the cron;
the market's own time is a different thing). The list also mixes both legs, whose
sessions differ. What the reader needs to know is that these are not today's.

Both bundles carry this card by hand; the helper is byte-identical in both and
`test_dashboard_bundle_parity` keeps it that way.

## Gate

`testMoversSayWhichSessionTheyAreFrom` drives the real page twice through
`stubLiveOrigin` — a weekend payload must read `异动 · 最近收盘` in the head **and
in the aria-label** (the screen-reader copy was a second hardcoded 今日异动), a
live-session payload must still read `今日异动`.

Red on `origin/master`:

```
code: 'ERR_ASSERTION',
actual: '今日异动',
expected: '异动 · 最近收盘',
```

Whole browser contract green locally (16 specs, exit 0) after
`ops/pages/fetch_data_plane.py`; `pytest -k "dashboard or bundle or hero"` 236 passed.

## 用户能看到的差别

SURFACE: 面板
现在: 周末（或任何一个开盘前的早上）打开面板，首屏那张牌说「今日异动 SKHY +8.14%」——那是上周五的行情
修完: 同一时刻它说「异动 · 最近收盘」，交易时段内照旧说「今日异动」
