### PR TITLE
debate citations: the hard stop had no name, so no debate could cite it

### DIFF
--- a/skills/daily-deep-brief/SKILL.md
+++ b/skills/daily-deep-brief/SKILL.md
@@ -714,7 +714,7 @@ postflight 严格 schema 校验：
         "attacked_consensus": "攻击的是「AI 板块整体还有一波」这条最强共识",
         "frames": ["technical_breakdown", "relative_strength"],
         "judge": "纪律优先：政策型减仓不等预测兑现",
-        "evidence_ids": ["risk:leveraged_exposure:07226", "quant:07226:dist_ma200_pct"]
+        "evidence_ids": ["risk:leveraged_exposure:US", "quant:ROBN:dist_ma200_pct"]
       }
     },
     {
@@ -761,8 +761,11 @@ postflight 严格 schema 校验：
   - `judge`：Judge 的合成判词一句话（不是 Bull/Bear 的复述）。
   - `evidence_ids`（≤6 条，选填）：这场辩论**站在**哪几条 context 证据上（#1141）。只认三个能被解析的命名空间，postflight 逐条对着本次 context 核，**核不上的直接丢掉并记一条 degradation**（不会让流水线变红，但会被数出来）：
     - `news:<event_id>` —— `context.news_evidence_graph.events[].event_id`
-    - `risk:<type>` 或 `risk:<type>:<ticker>` —— `context.risk_guardrail` 的 breach / hard_stop / concentration_review
-    - `quant:<ticker>:<field>` —— `context.quant_signals.rows[<ticker>]` 上一个非空字段（如 `quant:SPCH:dist_ma200_pct`）
+    - `risk:<type>`、`risk:<type>:<ticker>` 或 `risk:<type>:<leg>` —— `context.risk_guardrail` 的 breach / hard_stop_watch / concentration_review：
+      - 可引的 `<type>` 全集（**逐字照抄那一行自己的 `type` 字段**）：`single_name`、`single_name_review`、`leveraged_exposure`、`leveraged_hard_stop`、`regime_delever`、`factor_concentration`、`beta`
+      - 带票的行用 `:<ticker>`；`ticker` 为 null 的**整条腿**的闸用 `:<leg>`（`HK` / `US` / `BOOK`）或者干脆不带后缀
+      - 别自己起名（`concentration`、`hard_stop` 这种核不上），也**不要从那行的 `action` 文案里捞一个 ticker 拼上去**——那样引用的是一个不存在的行
+    - `quant:<ticker>:<field>` —— `context.quant_signals.rows[<ticker>]` 上一个非空字段（如 `quant:SPCH:dist_ma200_pct`）。**只有 `rows` 里真有的 ticker 能引**：杠杆 ETF 通常没有自己的行（07226 没有，它的底层 HSTECH 有），要引就引你真正读的那一行
     **没有可引的证据就不填**，别为了填而造 id：造出来的引用比不引更糟，它看起来像证据。portable workflow lane 早就要求每个 case 带 `evidence_ids`（`workflows/validators.py`），这里是把同一条纪律接到日报这条 lane 上。
   - **不会因为格式错误让 08:00 流水线变红**：postflight 的 normalizer 会裁剪超长文本、丢弃未知键与不在枚举内的 frame，整块为空则记为「没写」。但缺席是被数出来的——dashboard 的 `debate_coverage.bear_case_pct` 就是这条纪律的实测曲线，别用空块凑覆盖率。
 - `expected_move_pct`（number，选填，带符号，单位 %）：**这条 decision 预期这只票走多远**（#1159）。`confidence` 说的是「多有把握」，`invalidation_price` 说的是「论点在哪死」，**没有一个字段说「走多远」**——所以「方向对、幅度错了四倍」这句话这本账本目前对自己讲不出来。填了之后按 t1 对 `underlying_return_t1_pct` 打分（这只票自己的收益，不是 `benefit_t1_pct` 那个相对不动的反事实）。

--- a/src/clawock/decision/packet.py
+++ b/src/clawock/decision/packet.py
@@ -755,7 +755,11 @@ def _risk_map(context: dict, active: set[str]) -> dict[str, list[dict]]:
             "kind": "hard_stop",
             "scope": "ticker",
             "breach_id": row.get("breach_id"),
-            "type": "leveraged_hard_stop",
+            # The row's own name. This was the only surface that knew the type
+            # was `leveraged_hard_stop` while the row it describes carried no
+            # `type` at all — one name here, another in the rendered table, and
+            # nothing citable in between.
+            "type": row.get("type") or "leveraged_hard_stop",
             "severity": "critical",
             "detail": row.get("detail"),
             "action_text": row.get("action"),

--- a/src/clawock/harness/brief_postflight.py
+++ b/src/clawock/harness/brief_postflight.py
@@ -244,6 +244,14 @@ def _citable_refs(context) -> set[str]:
             ticker = str((row or {}).get('ticker') or '').strip()
             if ticker:
                 refs.add(f'risk:{kind}:{ticker}')
+            # A leg-level breach (`leveraged_exposure`, `beta`) carries no
+            # ticker: the cap is on the book, not on a name. Without a scoped
+            # form for those rows the only way to point at "the HK one" is to
+            # borrow a ticker out of the row's prose, which resolves to
+            # nothing — measured, 8 of 28 dropped refs did exactly that.
+            leg = str((row or {}).get('leg') or '').strip()
+            if leg:
+                refs.add(f'risk:{kind}:{leg}')
 
     rows = ((context.get('quant_signals') or {}).get('rows')) or {}
     if isinstance(rows, dict):

--- a/src/clawock/harness/brief_render.py
+++ b/src/clawock/harness/brief_render.py
@@ -342,7 +342,12 @@ def risk_section(context):
     discipline = context.get("risk_discipline") or {}
     rows = []
     for item in (guard.get("hard_stop_watch") or []):
-        rows.append(["hard_stop", text(item.get("ticker")), text(item.get("severity")),
+        # The row's own `type`, not a label invented here: this column is where
+        # the plan author reads the name it must cite as `risk:<type>[:…]`, and
+        # printing `hard_stop` over a `leveraged_hard_stop` row taught it a name
+        # that resolves to nothing (11 of 28 dropped refs, 09-01…09-07).
+        rows.append([text(item.get("type") or "hard_stop"),
+                     text(item.get("ticker")), text(item.get("severity")),
                      text(item.get("detail")), text(item.get("breach_id"))])
     for item in (guard.get("breaches") or []):
         rows.append([text(item.get("type")), text(item.get("ticker") or item.get("leg")),

--- a/src/clawock/portfolio/guardrail.py
+++ b/src/clawock/portfolio/guardrail.py
@@ -218,6 +218,11 @@ def compute_risk_guardrail(hk_holdings, us_holdings, hk_conc, us_conc, risk,
             pnl = _holding_pnl_pct(h)
             if pnl is not None and pnl <= caps['lev_etf_stop_pct']:
                 hard_stops.append({
+                    # Every other guardrail row names its own kind; this one
+                    # did not, and a row without a `type` is a row a debate
+                    # cannot cite (#1141 resolves `risk:<type>[:<ticker>]`
+                    # against exactly this field).
+                    'type': 'leveraged_hard_stop',
                     'ticker': h['ticker'], 'leg': leg, 'pnl_pct': pnl,
                     'severity': 'critical',
                     'detail': f"{h['ticker']} 浮亏 {pnl}% ≤ 硬止损线 {caps['lev_etf_stop_pct']}%",

--- a/src/clawock/publish/dashboard.py
+++ b/src/clawock/publish/dashboard.py
@@ -664,11 +664,19 @@ def load_guardrail_history(ws=None, limit=None):
     return rows[-limit:] if limit else rows
 
 
-def _breach_identity(row):
-    """What makes two breaches, recorded on different days, the same breach."""
+def _breach_identity(row, key='breaches'):
+    """What makes two breaches, recorded on different days, the same breach.
+
+    The list a row came from carries the type half for `hard_stop_watch`: the
+    history projection stores those rows as ticker/leg/pnl only, so a stop's own
+    `type` cannot enter the key without every stop reading as new on the day the
+    producer started naming them — an age that resets is worse than no age.
+    """
     if not isinstance(row, dict):
         return None
-    return (row.get('type') or 'hard_stop', row.get('leg'), row.get('ticker'))
+    kind = ('hard_stop' if key == 'hard_stop_watch'
+            else (row.get('type') or 'hard_stop'))
+    return (kind, row.get('leg'), row.get('ticker'))
 
 
 def _consecutive_age(identity, history, key):
@@ -681,7 +689,8 @@ def _consecutive_age(identity, history, key):
     """
     days = 0
     for row in reversed(history):
-        present = any(_breach_identity(r) == identity for r in (row.get(key) or []))
+        present = any(_breach_identity(r, key) == identity
+                      for r in (row.get(key) or []))
         if not present:
             break
         days += 1
@@ -716,7 +725,7 @@ def annotate_guardrail_history(guardrail, history):
                 if not isinstance(entry, dict):
                     continue
                 days, capped = _consecutive_age(
-                    _breach_identity(entry), history, key)
+                    _breach_identity(entry, key), history, key)
                 entry['age_days'] = days
                 if capped:
                     entry['age_capped'] = True

--- a/tests/test_brief_render.py
+++ b/tests/test_brief_render.py
@@ -28,7 +28,8 @@ CONTEXT = {
     },
     "risk_discipline": {"open_count": 7, "unacknowledged_count": 7, "oldest_open_days": 47},
     "risk_guardrail": {
-        "hard_stop_watch": [{"ticker": "07226", "severity": "critical",
+        "hard_stop_watch": [{"type": "leveraged_hard_stop", "ticker": "07226",
+                             "severity": "critical",
                              "detail": "07226 浮亏 -25.7% ≤ 硬止损线 -18%",
                              "breach_id": "risk-4ab"}],
         "breaches": [], "directive": "四条硬闸必须各出一个动作。",

--- a/tests/test_debate_evidence_citations.py
+++ b/tests/test_debate_evidence_citations.py
@@ -23,8 +23,15 @@ def _context():
             {'event_id': 'evt_real', 'ticker': 'SPCH'},
         ]},
         'risk_guardrail': {
-            'breaches': [{'type': 'single_name', 'ticker': 'SPCH'}],
-            'hard_stop_watch': [{'type': 'leveraged_hard_stop', 'ticker': '07226'}],
+            'breaches': [
+                {'type': 'single_name', 'leg': 'US', 'ticker': 'SPCH'},
+                # A leg-level cap: the breach is on the book, not on a name,
+                # so the row carries no ticker (real shape, `guardrail.py`).
+                {'type': 'leveraged_exposure', 'leg': 'HK', 'ticker': None},
+            ],
+            'hard_stop_watch': [
+                {'type': 'leveraged_hard_stop', 'leg': 'HK', 'ticker': '07226'},
+            ],
         },
         'quant_signals': {'rows': {
             'SPCH': {'dist_ma200_pct': -12.4, 'rsi14': None},
@@ -81,6 +88,9 @@ def test_the_context_is_what_decides_whether_a_citation_stands():
             'news:evt_invented',                # not in the graph
             'risk:single_name:SPCH',            # a real breach, with its ticker
             'risk:leveraged_hard_stop',         # a real hard stop, unscoped
+            'risk:leveraged_hard_stop:07226',   # the same stop, scoped to its name
+            'risk:leveraged_exposure:HK',       # a leg-level cap, scoped to its leg
+            'risk:leveraged_exposure:07226',    # that cap has no ticker to borrow
             'risk:margin_call',                 # no such breach today
             'quant:SPCH:dist_ma200_pct',        # a present signal field
             'quant:SPCH:rsi14',                 # present but null → not citable
@@ -91,10 +101,12 @@ def test_the_context_is_what_decides_whether_a_citation_stands():
 
     assert pruned['decisions'][0]['debate']['evidence_ids'] == [
         'news:evt_real', 'risk:single_name:SPCH',
-        'risk:leveraged_hard_stop', 'quant:SPCH:dist_ma200_pct',
+        'risk:leveraged_hard_stop', 'risk:leveraged_hard_stop:07226',
+        'risk:leveraged_exposure:HK', 'quant:SPCH:dist_ma200_pct',
     ]
     assert dropped == [
-        'd1:news:evt_invented', 'd1:risk:margin_call', 'd1:quant:SPCH:rsi14',
+        'd1:news:evt_invented', 'd1:risk:leveraged_exposure:07226',
+        'd1:risk:margin_call', 'd1:quant:SPCH:rsi14',
     ]
 
 
@@ -150,3 +162,115 @@ def test_the_page_shows_what_a_debate_stood_on():
 
     assert 'evidence_ids' in js and 'dbt-cite' in js, (
         'a citation nobody can see is the same unverifiable claim, one layer in')
+
+
+def _guardrail_from_the_real_producer():
+    """A guardrail built by the module that builds the morning's, not by hand.
+
+    Every hand-written fixture in this file agreed with the resolver about the
+    shape of a `risk_guardrail` row. Production did not: `hard_stop_watch` rows
+    carried no `type` at all, so the resolver skipped all of them and every
+    hard-stop citation the model wrote was dropped as "unresolvable" — 14 of
+    the 28 dropped refs sampled between 09-01 and 09-07. A fixture cannot catch
+    that. Only the producer's own output can.
+    """
+    from clawock.portfolio import guardrail as guardrail_mod
+
+    def holding(ticker, value, *, leveraged=False, pnl_pct=0.0, shares=100):
+        cost_value = value / (1 + pnl_pct / 100)
+        return {
+            'ticker': ticker, 'name': ticker, 'shares': shares,
+            'cost_basis': cost_value / shares, 'current_value': value,
+            'is_leveraged_etf': leveraged,
+        }
+
+    # One 2x name deep enough under water to trip the hard stop, sized so the
+    # leg also breaches its single-name and leveraged-exposure caps; a second
+    # leg holding a name inside the review band.
+    hk = [holding('07226', 700.0, leveraged=True, pnl_pct=-27.1),
+          holding('00700', 300.0)]
+    us = [holding('SPCH', 500.0, leveraged=True, pnl_pct=-18.2),
+          holding('AAPL', 450.0), holding('MSFT', 50.0)]
+    return guardrail_mod.compute_risk_guardrail(
+        hk, us,
+        guardrail_mod.compute_concentration(hk),
+        guardrail_mod.compute_concentration(us),
+        {'us': {'beta_spx': 5.5}},
+    )
+
+
+def test_every_guardrail_row_the_producer_emits_can_be_cited():
+    from clawock.harness import brief_postflight
+
+    guardrail = _guardrail_from_the_real_producer()
+    citable = brief_postflight._citable_refs({'risk_guardrail': guardrail})
+
+    rows = [(key, row)
+            for key in ('breaches', 'hard_stop_watch', 'concentration_reviews')
+            for row in guardrail.get(key) or []]
+    assert rows, 'the fixture stopped tripping any cap — it proves nothing now'
+    assert any(key == 'hard_stop_watch' for key, _ in rows), (
+        'the family that was uncitable for a week must stay in this fixture')
+
+    for key, row in rows:
+        kind = row.get('type')
+        assert kind, f'{key} row has no type, so no citation can name it: {row}'
+        assert f'risk:{kind}' in citable
+        if row.get('ticker'):
+            assert f"risk:{kind}:{row['ticker']}" in citable
+        else:
+            # No ticker to point at: the leg is the only scope the row has,
+            # and without it the model borrows a ticker out of the prose.
+            assert f"risk:{kind}:{row['leg']}" in citable
+
+
+def test_the_skill_names_exactly_the_row_types_the_producer_can_emit():
+    """The model cites by copying `type` verbatim; an undocumented one is a guess.
+
+    Both directions matter. A type the producer emits but the skill never names
+    is a row the model can only cite by inventing a name for it (`hard_stop`,
+    `concentration` — both observed, both dropped). A type the skill names but
+    nothing emits teaches a citation that can never resolve.
+    """
+    import re
+
+    root = Path(__file__).resolve().parents[1]
+    produced = set(re.findall(
+        r"'type':\s*'([a-z_]+)'",
+        (root / 'src' / 'clawock' / 'portfolio' / 'guardrail.py').read_text(
+            encoding='utf-8')))
+    skill = (root / 'skills' / 'daily-deep-brief' / 'SKILL.md').read_text(
+        encoding='utf-8')
+    vocabulary = [line for line in skill.split('\n') if '可引的 `<type>` 全集' in line]
+    assert len(vocabulary) == 1, 'the skill must state the vocabulary exactly once'
+    documented = set(re.findall(r'`([a-z_]+)`', vocabulary[0])) - {'type'}
+
+    assert documented == produced, (
+        f'skill-only: {sorted(documented - produced)}; '
+        f'producer-only: {sorted(produced - documented)}')
+
+
+def test_one_hard_stop_has_one_name_across_every_surface_that_shows_it():
+    """Three surfaces described the same row, and none of them agreed.
+
+    The rendered brief table printed `hard_stop`, the decision packet's
+    constraint said `leveraged_hard_stop`, and the guardrail row the resolver
+    reads carried no `type` at all — so whichever name the model copied, its
+    citation was dropped. `risk:hard_stop:*` was the single most common dropped
+    form (11 of 28 sampled).
+    """
+    from clawock.decision import packet as packet_mod
+    from clawock.harness import brief_postflight, brief_render
+
+    guardrail = _guardrail_from_the_real_producer()
+    stop = (guardrail.get('hard_stop_watch') or [])[0]
+    name, ticker = stop['type'], stop['ticker']
+
+    rendered = brief_render.risk_section({'risk_guardrail': guardrail})
+    assert f'| {name} |' in rendered, rendered
+
+    risks = packet_mod._risk_map({'risk_guardrail': guardrail}, {ticker})
+    assert [r['type'] for r in risks[ticker] if r['kind'] == 'hard_stop'] == [name]
+
+    citable = brief_postflight._citable_refs({'risk_guardrail': guardrail})
+    assert f'risk:{name}:{ticker}' in citable

--- a/tests/test_guardrail_history_projection.py
+++ b/tests/test_guardrail_history_projection.py
@@ -190,3 +190,26 @@ def test_unusable_lines_are_skipped_rather_than_raising(tmp_path, bad):
         bad + '\n' + json.dumps(_row('2026-08-28')) + '\n', encoding='utf-8')
     assert [r['date'] for r in dashboard.load_guardrail_history(tmp_path)] \
         == ['2026-08-28']
+
+
+def test_naming_a_hard_stop_does_not_reset_the_age_it_already_had(tmp_path):
+    """The stop is the same stop the day its row starts carrying a `type`.
+
+    `hard_stop_watch` rows had no `type` until the citation fix gave them one,
+    and the history file projects them to ticker/leg/pnl — so it will never
+    carry that name for the days already on record. If the type entered the
+    identity key, every open stop would read `age_days: 1` on the deploy day
+    and the card would quietly under-report an eight-day-old breach.
+    """
+    ws = _write(tmp_path, [
+        _row('2026-09-03', stops=[STOP_HK]),
+        _row('2026-09-04', stops=[STOP_HK]),
+        _row('2026-09-07', stops=[STOP_HK]),
+    ])
+    history = dashboard.load_guardrail_history(ws)
+    named = dict(STOP_HK, type='leveraged_hard_stop', severity='critical')
+
+    guardrail = dashboard.annotate_guardrail_history(
+        {'hard_stop_watch': [named], 'breaches': []}, history)
+
+    assert guardrail['hard_stop_watch'][0]['age_days'] == 3


### PR DESCRIPTION
Every weekday brief since 09-01 has filed a `debate_citation_unresolved` degradation — **66 dropped references across six briefs**, the only degradations in the ledger. It reads as the model inventing evidence. Half of it was not.

## What the sweep found

`prune_debate_citations` resolves `risk:<type>[:<ticker>]` against the `type` field of each `risk_guardrail` row. `hard_stop_watch` rows are the only family the producer never gave a `type` to, so `_citable_refs` skipped every one of them:

**No hard stop was citable at all** — 14 of the 28 sampled dropped refs were hard stops, dropped by construction, while `risk_guardrail.directive` was simultaneously ordering the Judge section to produce an action for each of them.

And three surfaces named the same row three different ways:

| surface | name |
|---|---|
| rendered brief table (`brief_render.risk_section`) | `hard_stop` |
| decision packet constraint (`packet._risk_map`) | `leveraged_hard_stop` |
| the guardrail row the resolver reads | *(nothing)* |

`risk:hard_stop:*` — the label the model could actually see, in its own brief — was the single most common dropped form, 11 of 28.

The rest breaks down as: 8 refs pointing at a leg-level cap (`leveraged_exposure`, `beta`) with a ticker borrowed out of the row's prose, because those rows have `ticker: null` and no other scope to name; and a genuine remainder the model invented, which still drops.

## The changes

- **`portfolio/guardrail.py`** — hard-stop rows carry `type: leveraged_hard_stop`, like every other guardrail row already did.
- **`harness/brief_render.py`, `decision/packet.py`** — both read that field instead of hardcoding a name of their own.
- **`harness/brief_postflight.py`** — `risk:<type>:<leg>` resolves, so a leg-level cap has a scope that exists.
- **`publish/dashboard.py`** — `_breach_identity` keyed hard stops on `type or 'hard_stop'`, and the history file projects those rows *without* a type. Naming them would have reset `age_days` to 1 for every open stop on the deploy day — an eight-day-old breach quietly re-reading as new. The list a row came from now carries that half of the key.
- **`skills/daily-deep-brief/SKILL.md`** — the worked example cited `risk:leveraged_exposure:07226` (that breach has no ticker) and `quant:07226:dist_ma200_pct` (a 2x ETF has no quant row; its underlying does), on a decision about a third ticker. **Both unresolvable — the model was copying our own example.** Replaced, plus the full `<type>` vocabulary and the leg form are now written down where the plan is authored.

## Verification

Against today's real context bundle (`memory/.tmp/brief-context-2026-09-07.json`), citable refs 301 → 307: all three live hard stops become citable (bare, by ticker, by leg), `risk:leveraged_exposure:HK` resolves, and the two refs that were genuinely invented (`risk:leveraged_exposure:risk-da9861ae6562`, `quant:07226:dist_ma200_pct`) still drop.

Full suite: **3414 passed, 5 skipped, 4 xfailed**.

## Why this was green for a week

Every fixture in `test_debate_evidence_citations.py` agreed with the resolver about the shape of a guardrail row — including `hard_stop_watch: [{'type': 'leveraged_hard_stop', ...}]`, a shape production has never produced. A hand-written fixture cannot catch a producer that disagrees with it. New gates:

- build the guardrail with the **real producer** and assert every row it emits is citable (and that `hard_stop_watch` stays in the fixture);
- the skill's documented `<type>` vocabulary is exactly the set the producer emits, both directions;
- the three surfaces agree on one stop's name;
- a stop keeps its `age_days` on the day it gains a `type`.