### PR TITLE
watchdog: 休市不再发空的确定性兜底

### DIFF
--- a/src/clawock/harness/intraday_watchdog.py
+++ b/src/clawock/harness/intraday_watchdog.py
@@ -36,6 +36,14 @@ but duplicates, so it's gone. Telegram is the sole backstop channel.
 Healthy runs use their generated report; stalled/looped runs fall back to the
 deterministic preflight block on Telegram. Dedupe remains per slot.
 
+CLOSED MARKETS ARE NOT FAILURES (2026-09-07): the gate order is closed → loop →
+marker → generation → mirror. preflight's holiday sentinel carries no
+`raw_wechat_block`, and every gate below reads a missing block as "the model
+never produced the report", so on US Labor Day this watchdog mailed kcn a 🧯
+deterministic-fallback banner with an empty body. A closed session has no report
+to back up; the blockless guard at the generation gate catches the same shape
+for any other blockless context.
+
 MARKER FIRST (2026-07-29): the gates are ordered loop → marker → generation →
 mirror,
 and that order is the fix, not an accident. The generation gate used to run
@@ -281,6 +289,33 @@ def main():
              'expected_job': expected_job, 'expected_slot': expected_slot,
              'run_at': run_at})
         return 0
+    # --- Closed-market gate: a closed session has no report to back up -------
+    # preflight writes a BLOCKLESS `market_closed` sentinel and exits before it
+    # fetches anything, so the slot's context carries no `raw_wechat_block` by
+    # construction. Everything below reads a missing block as "the model never
+    # produced the report" and mirrors the deterministic fallback — which on a
+    # holiday is a 🧯 banner with an empty body: a message that says the LLM
+    # failed, on a day nothing was supposed to run. That is what reached kcn on
+    # 2026-09-07 (US Labor Day, 22:03 slot), and it would have repeated once per
+    # slot until 02:33 HKT. report_watchdog never had the bug because its
+    # blockless guard sits above its generation gate; this watchdog had no such
+    # guard at all.
+    #
+    # This gate stays ABOVE the loop gate: a loop detected on a closed day is a
+    # cron that should not have engaged the model at all, and its evidence is
+    # already in the run record and the heartbeat — not something to page kcn
+    # about with a body that would be empty anyway. No heartbeat is recorded
+    # here either: preflight already recorded `market_closed` for this slot, and
+    # that is the terminal state cron_health_check expects to see.
+    if context.get('status') == 'market_closed':
+        log({'tag': tag, 'action': 'skip',
+             'reason': 'market closed this slot — preflight wrote a blockless '
+                       'sentinel, so there is no report to back up',
+             'closed_reason': context.get('reason'),
+             'expected_job': expected_job, 'expected_slot': expected_slot,
+             'run_at': run_at})
+        return 0
+
     # --- In-flight gate: never judge a slot that has not finished -----------
     if attempt_still_running(context, last):
         log({'tag': tag, 'action': 'defer',
@@ -371,6 +406,19 @@ def main():
     # canonical path can set it truthfully. A permanently-false term in an `or`
     # is not redundancy — if it ever did fire it would mark a contract-violating
     # run as delivered and mirror a truncated summary as if it were the report.
+    # A blockless context that is NOT the holiday sentinel (a future status, a
+    # truncated write) still has nothing to put in the fallback body. Sending
+    # the banner alone would report an LLM failure and then prove nothing about
+    # it, so skip and leave the trace in the log — the same call report_watchdog
+    # makes for its own blockless contexts.
+    if not raw_block_first:
+        log({'tag': tag, 'action': 'skip',
+             'reason': 'no preflight raw_wechat_block — nothing to back up',
+             'status': context.get('status'),
+             'expected_job': expected_job, 'expected_slot': expected_slot,
+             'run_at': run_at})
+        return 0
+
     block_present = bool(raw_block_first and raw_block_first in summary)
     delivered_clean = block_present
     if not delivered_clean:

--- a/tests/test_intraday_watchdog_slots.py
+++ b/tests/test_intraday_watchdog_slots.py
@@ -175,16 +175,22 @@ SLOT = '2026-07-29T10:30:00+08:00'
 HEADING = '🇭🇰 港股盯盘 | 07/29 10:32 HKT'
 
 
-def _wire_watchdog(monkeypatch, tmp_path, *, run, now, marker, loop_score=1):
-    """Set up main() against a tmp workspace; returns (sends, heartbeats, events)."""
+def _wire_watchdog(monkeypatch, tmp_path, *, run, now, marker, loop_score=1,
+                   context=None):
+    """Set up main() against a tmp workspace; returns (sends, heartbeats, events).
+
+    `context` overrides the preflight context written to disk, so a test can hand
+    main() a blockless sentinel instead of a healthy block.
+    """
     from clawock.harness import intraday_watchdog as watchdog
 
     context_dir = tmp_path / 'memory' / '.tmp'
     context_dir.mkdir(parents=True, exist_ok=True)
-    (context_dir / 'intraday-context-hk-latest.json').write_text(json.dumps({
-        'heartbeat': {'job': '盘中盯盘', 'slot': SLOT},
-        'raw_wechat_block': f'{HEADING}\n恒指 25,713 ▲1.59%',
-    }))
+    (context_dir / 'intraday-context-hk-latest.json').write_text(json.dumps(
+        context if context is not None else {
+            'heartbeat': {'job': '盘中盯盘', 'slot': SLOT},
+            'raw_wechat_block': f'{HEADING}\n恒指 25,713 ▲1.59%',
+        }))
     if marker is not None:
         (context_dir / 'intraday-sent-hk.json').write_text(json.dumps(marker))
 
@@ -368,3 +374,75 @@ def test_a_marker_that_failed_telegram_still_gets_mirrored(
     assert HEADING in sends[0]              # the report reaches kcn, not just a banner
     assert events[-1]['action'] == 'mirror-telegram'
     assert events[-1]['reason'] == 'postflight cosend failed'
+
+
+def test_market_closed_sentinel_gets_no_deterministic_fallback(
+        tmp_path, monkeypatch):
+    """2026-09-07 US Labor Day: an empty 🧯 banner reached kcn on a closed market.
+
+    preflight gates the holiday and writes a BLOCKLESS `market_closed` sentinel,
+    but this watchdog read the missing block as "the LLM never produced the
+    report" and mirrored the deterministic fallback — header only, no body, once
+    per slot for the rest of the session.
+    """
+    now = datetime(2026, 7, 29, 10, 40, tzinfo=HKT)
+    run = _run(datetime(2026, 7, 29, 10, 30, tzinfo=HKT),
+               summary='=== MARKET CLOSED ===', delivery={})
+
+    watchdog, sends, heartbeats, events = _wire_watchdog(
+        monkeypatch, tmp_path, run=run, now=now, marker=None,
+        context={'status': 'market_closed', 'market': 'hk',
+                 'reason': '节假日休市', 'skip': True,
+                 'heartbeat': {'job': '盘中盯盘', 'slot': SLOT}})
+
+    assert watchdog.main() == 0
+    assert sends == []
+    # preflight already recorded market_closed for this slot; the watchdog must
+    # not overwrite that terminal state with a backstop verdict.
+    assert heartbeats == []
+    assert events[-1]['action'] == 'skip'
+    assert events[-1]['closed_reason'] == '节假日休市'
+
+
+def test_a_detected_loop_on_a_closed_market_still_sends_nothing(
+        tmp_path, monkeypatch):
+    """The closed gate sits above the loop gate deliberately.
+
+    A loop on a day the market never opened has an empty block to report, so the
+    fallback would be a banner claiming an LLM failure with nothing behind it.
+    """
+    now = datetime(2026, 7, 29, 10, 40, tzinfo=HKT)
+    run = _run(datetime(2026, 7, 29, 10, 30, tzinfo=HKT), summary='', delivery={})
+
+    watchdog, sends, _, events = _wire_watchdog(
+        monkeypatch, tmp_path, run=run, now=now, marker=None,
+        loop_score=watchdog_loop_threshold(),
+        context={'status': 'market_closed', 'market': 'hk',
+                 'reason': '周末休市', 'skip': True,
+                 'heartbeat': {'job': '盘中盯盘', 'slot': SLOT}})
+
+    assert watchdog.main() == 0
+    assert sends == []
+    assert events[-1]['action'] == 'skip'
+
+
+def test_blockless_context_never_sends_a_bodyless_fallback(
+        tmp_path, monkeypatch):
+    """Not the holiday sentinel, still nothing to put in the body."""
+    now = datetime(2026, 7, 29, 10, 40, tzinfo=HKT)
+    run = _run(datetime(2026, 7, 29, 10, 30, tzinfo=HKT), summary='', delivery={})
+
+    watchdog, sends, _, events = _wire_watchdog(
+        monkeypatch, tmp_path, run=run, now=now, marker=None,
+        context={'status': 'something_new',
+                 'heartbeat': {'job': '盘中盯盘', 'slot': SLOT}})
+
+    assert watchdog.main() == 0
+    assert sends == []
+    assert events[-1]['action'] == 'skip'
+    assert events[-1]['reason'].startswith('no preflight raw_wechat_block')
+
+
+def watchdog_loop_threshold():
+    from clawock.harness import intraday_watchdog as watchdog
+    return watchdog.LOOP_THRESHOLD


### PR DESCRIPTION
## 现象

2026-09-07（美股劳工节，美股全天休市）22:13 HKT，kcn 的 Telegram 收到：

```
🧯 intraday-us 确定性兜底（LLM 未完成）
以下内容由 preflight 数据直接生成，未经过模型改写：
```

标题下面是空的。

## 机制

节假日闸本身没坏。`intraday_preflight` 在抓价之前就判出 `节假日休市`，写了一份
**没有 `raw_wechat_block`** 的 `market_closed` sentinel 然后 exit 0 —— 22:03 和
22:33 两个槽的 `intraday-context-us-latest.json` 都是这份 216 字节的哨兵。

漏的是 `intraday_watchdog`：它是四个 watchdog 里**唯一没有 blockless 守卫**的一个。
`raw_block` 为空 ⇒ `raw_block_first = None` ⇒ generation gate 的
`block_present` 恒 False ⇒ 判「LLM 未完成」⇒ 发兜底，正文是空字符串。
`report_watchdog` 没这个 bug，因为它的 blockless 守卫（`no preflight
raw_wechat_block (cron likely never ran)`）就在 generation gate 上面 —— 同一晚
21:48 的 `us-open` watchdog 正是走这条路正确 skip 的。

而且这不是一条：watchdog 每槽跑一次（:13/:43，22-23 点 + 0-2 点），本来会一路发到
02:33 HKT 共 10 条。

## 修法

- **闭市闸**（放在 loop gate 之上）：`context.status == 'market_closed'` ⇒ skip，
  **不写 heartbeat** —— preflight 已经记过 `market_closed`，那才是
  `cron_health_check` 认的终态。放在 loop gate 之上是有意的：休市日的循环是不该
  启动的一轮，正文无论如何是空的。
- **blockless 闸**（generation gate 上）：任何拿不出正文的 context 一律不发兜底，
  只留 log —— 与 `report_watchdog` 的判断口径对齐。

## 验证

三条新回归测试，**RED-CHECK 真跑出红**：在修复前的 `intraday_watchdog.py` 上
3 failed（兜底确实发了出去），修复后 18 passed。相关面 `-k "watchdog or heartbeat
or cron"` 295 passed。

线上今晚剩余 9 个槽已用 per-slot dedupe flag 先行抑制，合并后 `refresh_live.sh`
让 editable 安装直接生效。

https://claude.ai/code/session_01TF24SJwjnJARZaEFjNiSMz