### PR TITLE
harness: 把「休市哨兵被读成缺失」这一族剩下的三处补齐

### DIFF
--- a/src/clawock/automation/brief_fallback.py
+++ b/src/clawock/automation/brief_fallback.py
@@ -279,7 +279,22 @@ def main():
     if not ctx_path.exists():
         print(f'FATAL: no preflight context at {ctx_path}', file=sys.stderr)
         sys.exit(1)
-    prepared = prepare_context(ctx_path.read_text())
+    # A closed-market sentinel is not an incomplete context — it is a context
+    # that says nothing was due. Falling through would hand `fail_closed_artifacts`
+    # an empty payload and write a zero-action pre-open.md + plan.json for a day
+    # neither market opens, which then reads downstream as "the brief ran and had
+    # nothing to say". Exit before writing anything. (brief_watchdog gates the
+    # same day and should never dispatch us here; this is the second layer, and
+    # a manual `gh workflow run` is exactly how the first one gets bypassed.)
+    raw_ctx = ctx_path.read_text()
+    try:
+        if json.loads(raw_ctx).get('status') == 'market_closed':
+            print(f'  skip: {ctx_path} is a market_closed sentinel — no brief was due')
+            return
+    except (ValueError, AttributeError):
+        pass  # malformed context is prepare_context's problem, not this gate's
+
+    prepared = prepare_context(raw_ctx)
     if not prepared['complete']:
         md, plan = fail_closed_artifacts(today, prepared)
         Path(f'memory/{today}-pre-open.md').write_text(md)

--- a/src/clawock/harness/brief_watchdog.py
+++ b/src/clawock/harness/brief_watchdog.py
@@ -54,6 +54,8 @@ import sys
 from datetime import datetime
 from pathlib import Path
 
+from clawock import sessions as trading_calendar
+
 from ._watchdog_common import (
     WS, HKT, log, build_brief_card, send_telegram, KCN_TELEGRAM,
     dispatch_brief_fallback, await_brief_fallback_outcome,
@@ -467,6 +469,26 @@ def main():
 
     today = datetime.now(HKT).strftime('%Y-%m-%d')
     tag = 'brief'
+
+    # --- Closed-market gate: no brief was due, so nothing is missing ----------
+    # Same rule as brief_preflight, and it has to be the same rule: the brief
+    # covers both markets, so it is skipped ONLY when HK and US are both closed
+    # (either one trading still earns a brief). On such a day preflight writes a
+    # blockless `market_closed` sentinel and never produces pre-open.md or
+    # plan.json — and `inspect_brief_artifacts` only asks whether those files
+    # exist. Without this gate the 09:05 pass reads their absence as a miss,
+    # pages kcn, and dispatches brief-fallback.yml to have a vendor LLM write a
+    # pre-market brief for a day neither market opens. Next occurrence of the
+    # shape: 2026-12-25 (聖誕 + Christmas). Sibling of the intraday_watchdog
+    # holiday bug of 2026-09-07.
+    hk_closed = trading_calendar.closed_reason('hk')
+    us_closed = trading_calendar.closed_reason('us')
+    if hk_closed and us_closed:
+        log({'tag': tag, 'action': 'skip',
+             'reason': 'both markets closed — no brief was due today',
+             'closed_reason': f'港股{hk_closed}+美股{us_closed}',
+             'check_missing': bool(args.check_missing)})
+        return 0
 
     if args.check_missing:
         issues = inspect_brief_artifacts(today)

--- a/src/clawock/harness/report_watchdog.py
+++ b/src/clawock/harness/report_watchdog.py
@@ -198,7 +198,16 @@ def main():
     raw_block = (ctx.get('raw_wechat_block') or '').strip()
     raw_block_first = raw_block.splitlines()[0] if raw_block else None
     if not raw_block_first:
-        log({'tag': tag, 'action': 'skip', 'reason': 'no preflight raw_wechat_block (cron likely never ran)'})
+        # Right call either way, but say WHICH state it is: a holiday sentinel
+        # and a cron that never fired are the same shape on disk, and logging
+        # both as "cron likely never ran" sends the next diagnosis after a
+        # phantom missing run. (2026-09-07 spent its first minutes there.)
+        closed = ctx.get('reason') if ctx.get('status') == 'market_closed' else None
+        log({'tag': tag, 'action': 'skip',
+             'reason': ('market closed — preflight wrote a blockless sentinel'
+                        if closed else
+                        'no preflight raw_wechat_block (cron likely never ran)'),
+             'closed_reason': closed})
         return 0
 
     # --- In-flight gate: never judge a slot that has not finished -------------

--- a/src/clawock/publish/dashboard.py
+++ b/src/clawock/publish/dashboard.py
@@ -1682,13 +1682,26 @@ def compute_today_movers(us_h, hk_h, leg_keys=('us', 'hk')):
 
 
 def _latest_brief_context():
-    """Return (path, dict) of newest memory/.tmp/brief-context-*.json by mtime, or (None, None)."""
+    """Return (path, dict) of the newest brief-context that actually carries data.
+
+    Newest-by-mtime is the wrong pick on a day both markets are closed:
+    brief_preflight writes a blockless `market_closed` sentinel under exactly
+    this name, so the newest file is a five-key stub with no `concentration`, no
+    `opportunity`, no `add_alpha_activation`. Returning it would satisfy the
+    caller's `bool(brief_ctx)` presence test, and the merge-not-overwrite guard
+    would therefore NOT restore the last good values — publishing the risk and
+    add-side cards empty on a holiday, as if the brief had run and found
+    nothing. Skipping the sentinel returns the last real context, or (None, None)
+    when there is none, which is the state the restore path is built for.
+    """
     try:
         paths = glob.glob(str(WS_ROOT / 'memory' / '.tmp' / 'brief-context-*.json'))
-        if not paths:
-            return None, None
-        latest = max(paths, key=os.path.getmtime)
-        return latest, load_json(latest)
+        for path in sorted(paths, key=os.path.getmtime, reverse=True):
+            context = load_json(path)
+            if isinstance(context, dict) and context.get('status') == 'market_closed':
+                continue
+            return path, context
+        return None, None
     except Exception as e:
         print(f'  warn: _latest_brief_context failed: {e}', file=sys.stderr)
         return None, None

--- a/tests/test_brief_fallback_market_closed.py
+++ b/tests/test_brief_fallback_market_closed.py
@@ -1,0 +1,54 @@
+"""The off-host brief fallback must not manufacture a brief for a closed day.
+
+`prepare_context` reports a `market_closed` sentinel as "incomplete", and
+incomplete means fail-closed artifacts — a zero-action pre-open.md + plan.json.
+Written on a day neither market opens, those read downstream as "the brief ran
+and had nothing to say". brief_watchdog gates that day and should never dispatch
+this workflow, but a manual `gh workflow run brief-fallback.yml` bypasses it,
+which is the whole reason this second layer exists.
+"""
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from clawock.automation import brief_fallback
+
+
+TODAY = '2026-12-25'
+SENTINEL = {'status': 'market_closed', 'date': TODAY,
+            'reason': '港股节假日休市+美股节假日休市', 'skip': True}
+
+
+@pytest.fixture
+def workspace(tmp_path, monkeypatch):
+    (tmp_path / 'memory' / '.tmp').mkdir(parents=True)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv('TODAY', TODAY)
+    return tmp_path
+
+
+def test_a_market_closed_sentinel_writes_no_artifacts(workspace, monkeypatch):
+    (workspace / 'memory' / '.tmp' / f'brief-context-{TODAY}.json').write_text(
+        json.dumps(SENTINEL, ensure_ascii=False))
+    monkeypatch.setattr(brief_fallback, 'chat',
+                        lambda *a, **kw: pytest.fail('vendor call on a closed day'))
+
+    brief_fallback.main()
+
+    assert not (workspace / 'memory' / f'{TODAY}-pre-open.md').exists()
+    assert not (workspace / 'memory' / f'{TODAY}-plan.json').exists()
+
+
+def test_an_ordinary_incomplete_context_still_fails_closed(workspace, monkeypatch):
+    """The gate is about `market_closed` only — a real broken context still fails closed."""
+    (workspace / 'memory' / '.tmp' / f'brief-context-{TODAY}.json').write_text(
+        json.dumps({'date': TODAY}))
+    monkeypatch.setattr(brief_fallback, 'chat',
+                        lambda *a, **kw: pytest.fail('vendor call on a broken context'))
+
+    brief_fallback.main()
+
+    assert (workspace / 'memory' / f'{TODAY}-pre-open.md').exists()
+    assert (workspace / 'memory' / f'{TODAY}-plan.json').exists()

--- a/tests/test_brief_watchdog.py
+++ b/tests/test_brief_watchdog.py
@@ -305,3 +305,53 @@ def test_outcome_is_persisted_so_a_later_pass_can_see_what_happened(
     state = json.loads(watchdog.missing_state_path(TODAY).read_text())
     assert state["fallback_outcome"] == "failure"
     assert "https://gh/run/4" in state["fallback_outcome_detail"]
+
+
+def _wire_main(monkeypatch, tmp_path, argv, hk_closed, us_closed):
+    """Run main() against a tmp workspace with a stubbed calendar and no I/O."""
+    events, calls = [], {"dispatch": 0, "send": 0}
+    monkeypatch.setattr(watchdog, "WS", tmp_path)
+    monkeypatch.setattr(watchdog.trading_calendar, "closed_reason",
+                        lambda market, *a, **kw: {"hk": hk_closed,
+                                                  "us": us_closed}[market])
+    monkeypatch.setattr(watchdog, "log", events.append)
+    monkeypatch.setattr(watchdog, "dispatch_brief_fallback",
+                        lambda _dry: (calls.__setitem__("dispatch",
+                                                        calls["dispatch"] + 1),
+                                      (True, "ok"))[1])
+    monkeypatch.setattr(watchdog, "send_telegram",
+                        lambda _t, _m, _d: (calls.__setitem__("send",
+                                                              calls["send"] + 1),
+                                            (True, "ok"))[1])
+    _stub_outcome(monkeypatch)
+    monkeypatch.setattr(sys, "argv", ["brief_watchdog.py", *argv])
+    return events, calls
+
+
+@pytest.mark.parametrize("argv", [[], ["--check-missing"]])
+def test_both_markets_closed_is_not_a_missing_brief(tmp_path, monkeypatch, argv):
+    """2026-12-25 shape: no brief was due, so nothing is missing.
+
+    brief_preflight skips only when HK and US are BOTH closed, and then writes a
+    blockless sentinel — no pre-open.md, no plan.json. `inspect_brief_artifacts`
+    only asks whether those files exist, so without this gate the 09:05 pass
+    pages kcn and dispatches brief-fallback.yml to have a vendor LLM write a
+    pre-market brief for a day neither market opens.
+    """
+    events, calls = _wire_main(monkeypatch, tmp_path, argv,
+                               hk_closed="节假日休市", us_closed="节假日休市")
+
+    assert watchdog.main() == 0
+    assert calls == {"dispatch": 0, "send": 0}
+    assert events[-1]["action"] == "skip"
+    assert events[-1]["closed_reason"] == "港股节假日休市+美股节假日休市"
+
+
+def test_one_market_open_still_earns_a_brief(tmp_path, monkeypatch):
+    """The gate is narrow on purpose — either market trading still earns a brief."""
+    events, calls = _wire_main(monkeypatch, tmp_path, ["--check-missing"],
+                               hk_closed="节假日休市", us_closed=None)
+
+    assert watchdog.main() == 0
+    assert calls["dispatch"] == 1          # the miss detector did its job
+    assert not any(e.get("closed_reason") for e in events)

--- a/tests/test_dashboard_brief_context_sentinel.py
+++ b/tests/test_dashboard_brief_context_sentinel.py
@@ -1,0 +1,70 @@
+"""A closed-market sentinel must not be mistaken for today's brief context.
+
+Sibling of the 2026-09-07 intraday_watchdog holiday bug. `brief_preflight`
+writes a blockless `market_closed` sentinel under the same
+`brief-context-{date}.json` name it uses for a real context, so on a day both
+markets are closed the newest file by mtime is a five-key stub. That stub still
+passes the caller's `bool(brief_ctx)` presence test, which is what tells the
+merge-not-overwrite guard NOT to restore the last good card — so the risk and
+add-side cards would publish empty, as if the brief had run and found nothing.
+"""
+import json
+import os
+import time
+
+from clawock.publish import dashboard
+
+
+REAL = {
+    'date': '2026-12-24',
+    'concentration': {'hk': {'weights': [{'ticker': '0700.HK', 'weight_pct': 30}]}},
+    'opportunity': {'candidates': []},
+}
+SENTINEL = {
+    'status': 'market_closed',
+    'date': '2026-12-25',
+    'reason': '港股节假日休市+美股节假日休市',
+    'skip': True,
+}
+
+
+def _write(tmp_path, name, payload, mtime):
+    path = tmp_path / 'memory' / '.tmp' / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=False))
+    os.utime(path, (mtime, mtime))
+    return path
+
+
+def test_the_newest_context_is_skipped_when_it_is_a_holiday_sentinel(
+        tmp_path, monkeypatch):
+    monkeypatch.setattr(dashboard, 'WS_ROOT', tmp_path)
+    now = time.time()
+    real = _write(tmp_path, 'brief-context-2026-12-24.json', REAL, now - 86400)
+    _write(tmp_path, 'brief-context-2026-12-25.json', SENTINEL, now)
+
+    path, context = dashboard._latest_brief_context()
+
+    assert path == str(real)
+    assert context['concentration']          # the card keeps yesterday's real data
+
+
+def test_only_sentinels_reads_as_no_context_so_the_restore_path_runs(
+        tmp_path, monkeypatch):
+    """(None, None) is the state the merge-not-overwrite guard is built for."""
+    monkeypatch.setattr(dashboard, 'WS_ROOT', tmp_path)
+    _write(tmp_path, 'brief-context-2026-12-25.json', SENTINEL, time.time())
+
+    assert dashboard._latest_brief_context() == (None, None)
+
+
+def test_a_normal_day_still_picks_the_newest_context(tmp_path, monkeypatch):
+    monkeypatch.setattr(dashboard, 'WS_ROOT', tmp_path)
+    now = time.time()
+    _write(tmp_path, 'brief-context-2026-12-23.json', {'date': '2026-12-23'}, now - 86400)
+    newest = _write(tmp_path, 'brief-context-2026-12-24.json', REAL, now)
+
+    path, context = dashboard._latest_brief_context()
+
+    assert path == str(newest)
+    assert context['date'] == '2026-12-24'

--- a/tests/test_report_watchdog_market_closed.py
+++ b/tests/test_report_watchdog_market_closed.py
@@ -1,0 +1,57 @@
+"""A holiday sentinel and a cron that never fired are the same shape on disk.
+
+report_watchdog already makes the right CALL for both (skip, no backstop — a
+blockless context has no report to mirror). What it used to get wrong is the
+name: logging a holiday as "cron likely never ran" points the next diagnosis at
+a phantom missing run. The 2026-09-07 Labor Day incident spent its first minutes
+there before the log turned out to be describing a gate working correctly.
+"""
+import json
+import sys
+from datetime import datetime, timedelta, timezone
+
+HKT = timezone(timedelta(hours=8))
+
+
+def _wire(monkeypatch, tmp_path, context):
+    from clawock.harness import report_watchdog as watchdog
+
+    today = datetime.now(HKT).strftime('%Y-%m-%d')
+    ctx_dir = tmp_path / 'memory' / '.tmp'
+    ctx_dir.mkdir(parents=True)
+    (ctx_dir / f'report-context-hk-open-{today}.json').write_text(
+        json.dumps(context, ensure_ascii=False))
+
+    events = []
+    monkeypatch.setattr(watchdog, 'WS', tmp_path)
+    monkeypatch.setattr(watchdog, 'find_job_id', lambda name: 'job-hk')
+    monkeypatch.setattr(watchdog, 'today_runs',
+                        lambda job_id: [{'runAtMs': 1, 'sessionId': 's', 'summary': ''}])
+    monkeypatch.setattr(watchdog, 'log', events.append)
+    monkeypatch.setattr(watchdog, 'send_telegram',
+                        lambda *a: (_ for _ in ()).throw(
+                            AssertionError('a blockless context must not send')))
+    monkeypatch.setattr(sys, 'argv',
+                        ['report_watchdog.py', '--market', 'hk', '--phase', 'open',
+                         '--job-name', '港股开盘报告'])
+    return watchdog, events
+
+
+def test_a_holiday_sentinel_is_logged_as_a_holiday(tmp_path, monkeypatch):
+    watchdog, events = _wire(monkeypatch, tmp_path, {
+        'status': 'market_closed', 'market': 'hk', 'phase': 'open',
+        'reason': '节假日休市', 'skip': True})
+
+    assert watchdog.main() == 0
+    assert events[-1]['action'] == 'skip'
+    assert events[-1]['closed_reason'] == '节假日休市'
+    assert 'never ran' not in events[-1]['reason']
+
+
+def test_a_genuinely_absent_run_still_says_so(tmp_path, monkeypatch):
+    watchdog, events = _wire(monkeypatch, tmp_path, {})
+
+    assert watchdog.main() == 0
+    assert events[-1]['action'] == 'skip'
+    assert events[-1]['closed_reason'] is None
+    assert 'cron likely never ran' in events[-1]['reason']


### PR DESCRIPTION
#1393 修的是 `intraday_watchdog` **一个点**。这个 PR 是顺着「还有谁把 blockless /
`market_closed` 哨兵读成『该有的东西没拿到』」把消费者扫了一遍的结果——又找到三处，
外加一处日志口径。

判据还是那条：**「本来就不该有」和「应该有但没拿到」在磁盘上是同一个形状，闸只认后一种。**

## 1. `brief_watchdog` —— 完全没有休市概念（真会 page kcn + 烧 vendor call）

brief 覆盖两市，**只在 HK+US 同日休市才跳**。那天 `brief_preflight` 写哨兵、
不产 `pre-open.md` / `plan.json`，而 `inspect_brief_artifacts` 只问这两个文件在不在：

```
09:05 --check-missing → issues=['brief_missing','plan_missing']
                      → alert_brief_missing → page kcn + dispatch brief-fallback.yml
```

也就是让 vendor LLM 给一个**两市都不开**的日子写盘前简报。静态表里这种日子：
`2026-12-25`、`2027-01-01`（更早的 06-19 / 05-25 那几天 `--check-missing` 还没上线，
所以这个组合从没真跑过）。

修法：在 `main()` 顶上加与 `brief_preflight` **同一条**规则的闸，覆盖 08:30 和 09:05 两个 pass。
闸故意很窄——任一市开市照常判 miss。

## 2. `brief_fallback` —— 会给休市日写出零动作简报

`prepare_context` 把哨兵报成 `incomplete` ⇒ `fail_closed_artifacts` 写出零动作的
`pre-open.md` + `plan.json`，下游读起来就是「简报跑了但没话说」。加显式哨兵检查，
什么都不写就退出。

watchdog 那道闸挡住的是**自动** dispatch，手工 `gh workflow run brief-fallback.yml`
正是绕过它的那条路，所以这里要第二层。

## 3. `dashboard._latest_brief_context` —— 假期把卡片刷空

按 mtime 取最新 ⇒ 双休日取到的就是哨兵。它**非空**，于是调用方的
`_presence['anomalies'] = bool(brief_ctx)` 判 True，
merge-not-overwrite 恢复路径**不会**触发：

```
风险信号卡 / 加仓侧卡 → 发空，看起来像「简报跑过、什么都没发现」
```

改成跳过哨兵取最近一份真上下文；全是哨兵就回 `(None, None)`——那才是恢复路径
设计出来要处理的状态。

## 4. `report_watchdog` —— 判断对，名字错

blockless 就不补投，这是对的。但休市和「cron 没跑」记成同一句
`cron likely never ran`，会把下一次诊断指向一个并不存在的漏跑——09-07 当晚
开头几分钟就花在这上面。分开记。

## 验证

**RED-CHECK**：8 条新测试在修复前的代码上**全红**，修复后全绿。其中行为红是
双休 brief（2）、dashboard 哨兵（2）、brief_fallback（1）；另 3 条是结构红
（旧代码没有那个属性 / 日志字段），也一并留着当守卫。

`-k "watchdog or brief or dashboard or fallback or calendar"` → **669 passed, 2 xfailed**。

https://claude.ai/code/session_01TF24SJwjnJARZaEFjNiSMz