### PR TITLE
benchmark: 抓不到和「没有」不能是同一个输出

### DIFF
--- a/src/clawock/market_data/benchmarks.py
+++ b/src/clawock/market_data/benchmarks.py
@@ -28,6 +28,7 @@ Run:
 import argparse
 import json
 import sys
+import time
 from datetime import datetime, timedelta, timezone
 from typing import Dict, List
 
@@ -41,50 +42,131 @@ WS_ROOT = workspace_root()
 OUT_FILE = WS_ROOT / 'assets' / 'data' / 'benchmark.json'
 TIMEOUT = 12
 DEFAULT_DAYS = 60
+# One retry, because the failure this fetcher actually suffers is transient and
+# a whole session of benchmark history costs a day to recover: the series is
+# re-fetched as a 60-day window, so a single success backfills every gap, and a
+# single miss strands one. Polygon's free tier rate-limits (5 req/min) and the
+# link to it drops for minutes at a time (2026-09-07: an https connect to
+# github.com from this host took 133s and failed, then 0.55s six minutes later).
+FETCH_ATTEMPTS = 2
+FETCH_RETRY_SLEEP = 3
 
-def fetch_polygon_daily(ticker: str, days: int, api_key: str) -> List[Dict]:
-    """Polygon aggregates: daily close for the last N calendar days."""
-    if not api_key:
-        return []
+def _polygon_once(ticker: str, days: int, api_key: str) -> List[Dict]:
+    """One Polygon aggregates call. Raises on anything that is not data.
+
+    THE POINT OF RAISING (2026-09-07): this used to read `data.get("results") or
+    []` off an unchecked response, so an HTTP 401 / 403 / 429 — whose body is
+    `{"status": "ERROR", "error": "..."}` with no `results` key at all — returned
+    an empty list indistinguishable from "the market had no sessions in this
+    window". `assign()` then retained the prior series and the only trace was one
+    stderr line. A dead credential or an exhausted rate limit could sit there
+    indefinitely; what surfaced instead was `benchmark freshness` two sessions
+    later, and only then because `expected_lag_sessions: 1` masks the first miss.
+
+    Measured against the live API on 2026-09-07: a bad key answers HTTP 401 with
+    `{"status": "ERROR", "error": "Unknown API Key"}` — no exception, no results.
+    """
     end = datetime.now(timezone.utc).date()
     start = end - timedelta(days=days)
     url = (
         f'https://api.polygon.io/v2/aggs/ticker/{ticker}'
         f'/range/1/day/{start.isoformat()}/{end.isoformat()}'
     )
-    try:
     # Credential goes in a header, never the URL: a query-string secret ends up
     # in proxy logs, crash dumps and Referer, and taints every value derived from
     # the response for any dataflow analysis reading this file.
-        r = requests.get(
-            url,
-            params={'adjusted': 'true', 'sort': 'asc', 'limit': 400},
-            headers={'Authorization': f'Bearer {api_key}'},
-            timeout=TIMEOUT,
-        )
-        data = r.json()
-        results = data.get('results') or []
-        out = []
-        for x in results:
-            ts = x.get('t', 0) / 1000
-            close = x.get('c')
-            if not close:
-                continue
-            out.append({
-                'date':  datetime.fromtimestamp(ts, timezone.utc).strftime('%Y-%m-%d'),
-                'close': round(float(close), 4),
-            })
-        return out
-    except Exception as e:
-        print(f'  warn: polygon {ticker} fetch failed: {e}', file=sys.stderr)
+    r = requests.get(
+        url,
+        params={'adjusted': 'true', 'sort': 'asc', 'limit': 400},
+        headers={'Authorization': f'Bearer {api_key}'},
+        timeout=TIMEOUT,
+    )
+    r.raise_for_status()
+    data = r.json()
+    # Polygon answers 200 with `status: ERROR` too (a malformed range, a ticker
+    # the plan does not cover). Status first, `results` second — the absence of
+    # `results` is only "no sessions" once the call is known to have succeeded.
+    status = str(data.get('status') or '').upper()
+    if status in {'ERROR', 'NOT_AUTHORIZED'}:
+        raise RuntimeError(f"polygon {status}: {data.get('error') or data.get('message')}")
+    out = []
+    for x in data.get('results') or []:
+        ts = x.get('t', 0) / 1000
+        close = x.get('c')
+        if not close:
+            continue
+        out.append({
+            'date':  datetime.fromtimestamp(ts, timezone.utc).strftime('%Y-%m-%d'),
+            'close': round(float(close), 4),
+        })
+    return out
+
+
+def fetch_polygon_daily(ticker: str, days: int, api_key: str) -> List[Dict]:
+    """Polygon aggregates: daily close for the last N calendar days.
+
+    Still returns `[]` on failure — `assign()`'s retain-the-prior-series contract
+    depends on that and must not change. What changes is that the failure is
+    retried first and NAMED second, instead of being spelled the same way as an
+    empty market.
+    """
+    if not api_key:
+        print(f'  warn: polygon {ticker} skipped: no POLYGON_API_KEY',
+              file=sys.stderr)
         return []
+    return _fetch_with_retry(f'polygon {ticker}',
+                             lambda: _polygon_once(ticker, days, api_key))
 
 
-def fetch_tencent_hk_daily(sym: str, days: int) -> List[Dict]:
-    """Tencent kline: HK index daily close for the last N calendar days.
+# Retrying a 401 is not resilience, it is two failures. Only the classes that
+# can differ on the next call are retried: a dropped or slow link, a rate limit,
+# a server-side error. A bad credential, a ticker the plan does not cover, or a
+# malformed range answers the same way forever and should be reported at once so
+# the reason reaches the log while it is still true.
+RETRYABLE_STATUS = frozenset({429, 500, 502, 503, 504})
 
-    sym is the Tencent symbol form, e.g. 'hkHSI' / 'hkHSTECH'.
-    Response shape: data[sym].day = [[date, open, close, high, low, volume], ...]
+
+def _is_retryable(exc: Exception) -> bool:
+    if isinstance(exc, (requests.exceptions.Timeout,
+                        requests.exceptions.ConnectionError)):
+        return True
+    response = getattr(exc, 'response', None)
+    return getattr(response, 'status_code', None) in RETRYABLE_STATUS
+
+
+def _fetch_with_retry(label: str, call) -> List[Dict]:
+    """Run `call`, retrying only what a retry could fix; name the failure either way.
+
+    Returns `[]` on failure, deliberately: `assign()`'s retain-the-prior-series
+    contract is built on that and is the reason a bad fetch has never destroyed a
+    good series. The change is that `[]` now always comes with a printed reason,
+    so "the fetch broke" and "the market had no sessions" stop being the same
+    output.
+    """
+    for attempt in range(1, FETCH_ATTEMPTS + 1):
+        try:
+            return call()
+        except Exception as e:                    # noqa: BLE001 — reported, not raised
+            if attempt < FETCH_ATTEMPTS and _is_retryable(e):
+                print(f'  warn: {label} attempt {attempt} failed ({e}) — retrying',
+                      file=sys.stderr)
+                time.sleep(FETCH_RETRY_SLEEP)
+                continue
+            print(f'  warn: {label} fetch failed after {attempt} attempt(s): {e}',
+                  file=sys.stderr)
+            return []
+    return []
+
+
+def _tencent_hk_once(sym: str, days: int) -> List[Dict]:
+    """One Tencent kline call. Raises on anything that is not data.
+
+    Same rule as `_polygon_once`: an HTTP error must not be spelled the same way
+    as an index with no sessions in the window. This leg has not been the one
+    failing (HSI/HSTECH were current through 09-04 while SPY sat at 09-02), but
+    it had the identical unchecked-response shape, and a guard that only exists
+    on the leg that already broke is the coverage bug this codebase keeps
+    re-learning.
     """
     end = datetime.now(timezone.utc).date()
     start = end - timedelta(days=days)
@@ -92,25 +174,31 @@ def fetch_tencent_hk_daily(sym: str, days: int) -> List[Dict]:
         'https://web.ifzq.gtimg.cn/appstock/app/kline/kline'
         f'?param={sym},day,{start.isoformat()},{end.isoformat()},400'
     )
-    try:
-        r = requests.get(url, timeout=TIMEOUT)
-        d = r.json()
-        rows = (d.get('data') or {}).get(sym, {})
-        # Tencent sometimes returns "day", sometimes "qfqday" (adjusted); take whichever exists
-        series = rows.get('day') or rows.get('qfqday') or []
-        out = []
-        for row in series:
-            if len(row) < 3:
-                continue
-            try:
-                close = float(row[2])
-            except (TypeError, ValueError):
-                continue
-            out.append({'date': row[0], 'close': round(close, 4)})
-        return out
-    except Exception as e:
-        print(f'  warn: tencent {sym} fetch failed: {e}', file=sys.stderr)
-        return []
+    r = requests.get(url, timeout=TIMEOUT)
+    r.raise_for_status()
+    d = r.json()
+    rows = (d.get('data') or {}).get(sym, {})
+    # Tencent sometimes returns "day", sometimes "qfqday" (adjusted); take whichever exists
+    series = rows.get('day') or rows.get('qfqday') or []
+    out = []
+    for row in series:
+        if len(row) < 3:
+            continue
+        try:
+            close = float(row[2])
+        except (TypeError, ValueError):
+            continue
+        out.append({'date': row[0], 'close': round(close, 4)})
+    return out
+
+
+def fetch_tencent_hk_daily(sym: str, days: int) -> List[Dict]:
+    """Tencent kline: HK index daily close for the last N calendar days.
+
+    sym is the Tencent symbol form, e.g. 'hkHSI' / 'hkHSTECH'.
+    """
+    return _fetch_with_retry(f'tencent {sym}',
+                             lambda: _tencent_hk_once(sym, days))
 
 
 SERIES_MARKET = {'SPY': 'us', 'HSI': 'hk', 'HSTECH': 'hk'}

--- a/tests/test_benchmark_fetch_errors.py
+++ b/tests/test_benchmark_fetch_errors.py
@@ -1,0 +1,162 @@
+"""A fetch that could not run must not be spelled like a market with no sessions.
+
+2026-09-07: `assets/data/benchmark.json` held SPY through 2026-09-02 while HSI
+and HSTECH were current through 09-04. Polygon, queried directly that evening,
+returned 09-03 and 09-04 — the data existed, the stored series just never
+advanced. `fetch_polygon_daily` read `data.get("results") or []` off an
+UNCHECKED response, so an HTTP 401 / 403 / 429 — whose body is
+`{"status": "ERROR", "error": "..."}` with no `results` key — came back as an
+empty list. `assign()` correctly retained the prior series (that contract is not
+being changed), and the whole event's only trace was one stderr line.
+
+Verified against the live API that evening: a bad key answers HTTP 401 with
+`{"status": "ERROR", "error": "Unknown API Key"}`. No exception. No results.
+
+The series is re-fetched as a 60-day window, so ONE success backfills every gap
+— which is why a single unretried miss is worth this much machinery.
+"""
+import types
+
+import pytest
+import requests
+
+from clawock.market_data import benchmarks
+
+
+class _Response:
+    def __init__(self, status_code=200, payload=None):
+        self.status_code = status_code
+        self._payload = payload if payload is not None else {}
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise requests.exceptions.HTTPError(
+                f'{self.status_code} Client Error', response=self)
+
+    def json(self):
+        return self._payload
+
+
+@pytest.fixture(autouse=True)
+def _no_sleeping(monkeypatch):
+    # `raising=False` so these tests still RUN against a build that has no retry
+    # at all — the point of the suite is that the old shape fails on behaviour
+    # (an HTTP error returning `[]` in silence), not on an AttributeError.
+    monkeypatch.setattr(benchmarks, 'time',
+                        types.SimpleNamespace(sleep=lambda _s: None),
+                        raising=False)
+
+
+def _polygon_bar(date_ms, close):
+    return {'t': date_ms, 'c': close}
+
+
+def test_an_http_error_is_reported_not_returned_as_emptiness(monkeypatch, capsys):
+    monkeypatch.setattr(benchmarks.requests, 'get',
+                        lambda *a, **kw: _Response(
+                            401, {'status': 'ERROR', 'error': 'Unknown API Key'}))
+
+    assert benchmarks.fetch_polygon_daily('SPY', 60, 'key') == []
+
+    err = capsys.readouterr().err
+    assert 'polygon SPY' in err and '401' in err
+
+
+def test_a_200_with_status_error_is_also_a_failure(monkeypatch, capsys):
+    """Polygon answers 200 with `status: ERROR` too. `results` being absent is
+    only "no sessions" once the call is known to have succeeded."""
+    monkeypatch.setattr(benchmarks.requests, 'get',
+                        lambda *a, **kw: _Response(
+                            200, {'status': 'ERROR', 'error': 'unknown ticker'}))
+
+    assert benchmarks.fetch_polygon_daily('SPY', 60, 'key') == []
+    assert 'unknown ticker' in capsys.readouterr().err
+
+
+def test_a_genuinely_empty_window_is_not_reported_as_a_failure(monkeypatch, capsys):
+    """The one case that really is "no data": a successful call, no bars."""
+    monkeypatch.setattr(benchmarks.requests, 'get',
+                        lambda *a, **kw: _Response(200, {'status': 'OK', 'results': []}))
+
+    assert benchmarks.fetch_polygon_daily('SPY', 60, 'key') == []
+    assert 'failed' not in capsys.readouterr().err
+
+
+def test_a_transient_failure_is_retried_and_heals(monkeypatch):
+    """One success backfills the whole 60-day window, so the retry is the
+    difference between a healed series and a session stranded for a day."""
+    calls = {'n': 0}
+
+    def flaky(*a, **kw):
+        calls['n'] += 1
+        if calls['n'] == 1:
+            raise requests.exceptions.ConnectionError('link dropped')
+        return _Response(200, {'status': 'OK',
+                               'results': [_polygon_bar(1_788_000_000_000, 700.5)]})
+
+    monkeypatch.setattr(benchmarks.requests, 'get', flaky)
+
+    rows = benchmarks.fetch_polygon_daily('SPY', 60, 'key')
+
+    assert calls['n'] == 2
+    assert [r['close'] for r in rows] == [700.5]
+
+
+def test_a_rate_limit_is_retried(monkeypatch):
+    calls = {'n': 0}
+
+    def limited(*a, **kw):
+        calls['n'] += 1
+        if calls['n'] == 1:
+            return _Response(429, {'status': 'ERROR', 'error': 'too many requests'})
+        return _Response(200, {'status': 'OK', 'results': []})
+
+    monkeypatch.setattr(benchmarks.requests, 'get', limited)
+
+    benchmarks.fetch_polygon_daily('SPY', 60, 'key')
+
+    assert calls['n'] == 2
+
+
+def test_a_dead_credential_is_not_retried(monkeypatch):
+    """Retrying a 401 is not resilience, it is two failures. It answers the same
+    way forever; report it at once, while the reason is still in the log."""
+    calls = {'n': 0}
+
+    def unauthorized(*a, **kw):
+        calls['n'] += 1
+        return _Response(401, {'status': 'ERROR', 'error': 'Unknown API Key'})
+
+    monkeypatch.setattr(benchmarks.requests, 'get', unauthorized)
+
+    benchmarks.fetch_polygon_daily('SPY', 60, 'key')
+
+    assert calls['n'] == 1
+
+
+def test_a_missing_key_says_so(monkeypatch, capsys):
+    """Silence here would be indistinguishable from a market with no sessions."""
+    assert benchmarks.fetch_polygon_daily('SPY', 60, '') == []
+    assert 'POLYGON_API_KEY' in capsys.readouterr().err
+
+
+def test_the_hk_leg_has_the_same_guard(monkeypatch, capsys):
+    """It was not the leg that broke — which is exactly why it needs the guard.
+    A check that only exists where the failure already happened is the coverage
+    bug this codebase keeps re-learning."""
+    monkeypatch.setattr(benchmarks.requests, 'get',
+                        lambda *a, **kw: _Response(503, {}))
+
+    assert benchmarks.fetch_tencent_hk_daily('hkHSI', 60) == []
+    assert 'tencent hkHSI' in capsys.readouterr().err
+
+
+def test_a_failed_fetch_still_returns_a_list_so_the_prior_series_survives(monkeypatch):
+    """`assign()` retains the prior series on an empty fetch (#fetcher-merge-not-
+    overwrite). Raising out of here instead would turn a stale benchmark into a
+    missing one — strictly worse."""
+    monkeypatch.setattr(benchmarks.requests, 'get',
+                        lambda *a, **kw: _Response(500, {}))
+
+    assert benchmarks.fetch_polygon_daily('SPY', 60, 'key') == []
+    assert benchmarks.fetch_tencent_hk_daily('hkHSI', 60) == []

--- a/tests/test_market_leaf_modules.py
+++ b/tests/test_market_leaf_modules.py
@@ -8,6 +8,7 @@ import sys
 from pathlib import Path
 
 import pytest
+import requests
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "src"))
@@ -54,8 +55,17 @@ def test_load_api_keys_round_trips(tmp_path):
 # ---------------------------------------------------------------------------
 
 class _Resp:
-    def __init__(self, payload):
+    def __init__(self, payload, status_code=200):
         self._payload = payload
+        self.status_code = status_code
+
+    def raise_for_status(self):
+        # The fetchers check the status before reading the body (2026-09-07): an
+        # HTTP error must not be spelled the same way as a market with no
+        # sessions. A stub without this method is not a response.
+        if self.status_code >= 400:
+            raise requests.exceptions.HTTPError(
+                f"{self.status_code} Error", response=self)
 
     def json(self):
         return self._payload


### PR DESCRIPTION
## 证据

`assets/data/benchmark.json`：

```
SPY:    43 点，最后 = 2026-09-02        ← 差 2 个美股交易日
HSI:    42 点，最后 = 2026-09-04
HSTECH: 42 点，最后 = 2026-09-04
```

09-07 晚上直接问 Polygon：**09-03 和 09-04 都在**（42 bars，最后三天 09-02/09-03/09-04）。数据一直有，是存下来的序列没往前走。

`system_check` 到第 2 个交易日才报 WARN —— `expected_lag_sessions: 1` 把第一次漏掉的那天遮住了。日志里能看到它是怎么慢慢烂的：

```
HSI @ 09-02 · SPY @ 09-01   ✓ OK
HSI @ 09-03 · SPY @ 09-02   ✓ OK
HSI @ 09-03 · SPY @ 09-02   ✓ OK
SPY 2 session(s) behind      ⚠ WARN
```

## 根因

```python
r = requests.get(url, headers={'Authorization': f'Bearer {api_key}'}, timeout=TIMEOUT)
data = r.json()                      # ← 没有 raise_for_status，没有 status 检查
results = data.get('results') or []  # ← 401 的 body 里根本没有 results
```

当天对着线上 API 实测：

```
HTTP 401
{"status": "ERROR", "request_id": "...", "error": "Unknown API Key"}
```

**不抛异常。** 于是 401 / 403 / 429 / 5xx 全部变成一个空 list，跟「这个窗口内该市场没有交易日」一模一样。`assign()` 按约定保留旧序列（这条契约不改——它正是脏数据没有毁掉好序列的原因），整件事唯一的痕迹是一行 stderr。**一个死掉的 credential 可以这样躺很久。**

跟今晚 #1393 / #1394 / #1396 是同一族：**「查不了」被渲染成「没有」。**

## 改动

- `raise_for_status()`，再检查 Polygon 自己的 `status` 字段（它也会 200 带 `status: ERROR`）。**`results` 缺席只有在确认调用成功之后，才等于「没有交易日」。**
- 一次重试，且**只重试重试能修的那些**：`Timeout` / `ConnectionError` / 429 / 5xx。
  401 重试不是韧性，是两次失败 —— 它永远是同一个答案，应该趁理由还在日志里立刻报出来。
  序列是按 60 天窗口**整体重取**的，所以**一次成功就把所有缺口补回来**，一次没重试的失败才值得这么多机制。
- 港股那条腿（腾讯 kline）同样处理。**它不是坏掉的那条——正因如此才要加**：只长在已经出过事的那条腿上的守卫，就是这个仓库反复重学的覆盖率 bug。
- 失败仍然返回 `[]`（`assign()` 的保留契约不动），变的是**每个 `[]` 现在都带一条印出来的理由**。
- `tests/test_market_leaf_modules.py` 的 `_Resp` 桩补上 `raise_for_status`：没有它的桩不是一个 response。

## 验证

**RED-CHECK**：9 条新测试里 **6 条在修复前行为红**（401 静默返回空、200+ERROR、不重试、限流不重试、缺 key 不吭声、港股腿无守卫）。另外 3 条前后都绿 —— 那三条钉的正是本来就对的行为（真空窗口不报错、失败仍返回 list 让旧序列存活），是防回归不是证 bug。

全量套件 **3446 passed, 5 skipped, 4 xfailed**。

https://claude.ai/code/session_01TF24SJwjnJARZaEFjNiSMz