### PR TITLE
tests: 冻住跨午夜会翻面的那次时钟读数，并把闸扩到它看不见的兄弟机制

### DIFF
--- a/tests/test_system_check_delivered_but_unarchived.py
+++ b/tests/test_system_check_delivered_but_unarchived.py
@@ -17,14 +17,36 @@ red.
 import importlib.util
 import subprocess
 import sys
-from datetime import date
+from datetime import date, timedelta
 from pathlib import Path
 
 import pytest
 
 
 ROOT = Path(__file__).resolve().parents[1]
-TODAY = date.today().strftime("%Y-%m-%d")
+
+# FROZEN, not read from the clock (2026-09-08). This used to be
+# `TODAY = date.today().strftime(...)` at module scope: read ONCE at import,
+# while `check_delivered_but_unarchived` calls `date.today()` again when the
+# test body runs. A full-suite run that starts before 00:00 and reaches this
+# module after it writes `brief-sent-<yesterday>.json` and then asks a check
+# looking for `<today>` — four of these went red that way on 2026-09-07→08, with
+# nobody having touched any code. CI runs in UTC, so the crossing is 16:00 UTC.
+#
+# The existing `test_time_dependent_assertions` gate states the rule this
+# violates ("要么冻住时钟，要么从同一个时钟推出期望值") but could not see it: no
+# date literal appears in any assertion here, so its regex had nothing to match.
+# It now also rejects module-level clock reads.
+TODAY = "2026-09-01"          # the day the gate was written for
+
+
+class _FrozenDate(date):
+    """`date` with a `today()` that cannot move. Subclassed rather than stubbed
+    so any other `date` use inside the check keeps working."""
+
+    @classmethod
+    def today(cls):
+        return cls.fromisoformat(TODAY)
 
 
 @pytest.fixture(scope="module")
@@ -48,6 +70,9 @@ def workspace(system_check, monkeypatch, tmp_path):
     subprocess.run(["git", "config", "user.email", "t@e.st"], cwd=ws, check=True)
     subprocess.run(["git", "config", "user.name", "t"], cwd=ws, check=True)
     monkeypatch.setattr(system_check, "WS", ws)
+    # Freeze the check's clock to the same day the fixtures write. Both halves
+    # now come from one value that cannot advance mid-run.
+    monkeypatch.setattr(system_check, "date", _FrozenDate)
     return ws
 
 
@@ -129,3 +154,39 @@ def test_an_unreadable_marker_does_not_crash_the_gate(system_check, workspace):
     (workspace / "memory" / ".tmp" / f"brief-sent-{TODAY}.json").write_text("{oops")
     _write_brief(workspace)
     assert _run(system_check, workspace) == []
+
+
+def test_the_outcome_does_not_depend_on_what_day_it_is(system_check, workspace,
+                                                       monkeypatch):
+    """The 2026-09-07→08 red, encoded.
+
+    That night a full-suite run started before 00:00 HKT and reached this module
+    after it. `TODAY` had been read from the clock at import; the check read it
+    again at run time; the fixtures wrote one day and the check looked for the
+    next. Four tests here went red with nobody having touched any code.
+
+    So: move the real clock across midnight between two runs and require the
+    same answer. The fixture freezes the check's clock, which is what makes that
+    true — revert the freeze and this test reproduces the failure directly
+    rather than waiting for a midnight.
+    """
+    _mark_delivered(workspace)
+    _write_brief(workspace)
+    before = _run(system_check, workspace)
+
+    class _NextDay(_FrozenDate):
+        @classmethod
+        def today(cls):
+            return date.fromisoformat(TODAY) + timedelta(days=1)
+
+    monkeypatch.setattr(system_check, "date", _NextDay)
+    # The check is asked on "the next day"; the workspace is untouched. A gate
+    # whose subject is "today's brief" must still answer about the day it is
+    # given, not silently about the day the fixtures happened to write.
+    after = _run(system_check, workspace)
+
+    assert [s for _, s, _ in before] == [system_check.WARNING]
+    # Crossing midnight makes today's brief ABSENT, not archived — a different
+    # true answer, reached deliberately. What must never happen is the two
+    # halves disagreeing about which day they mean inside ONE run.
+    assert [s for _, s, _ in after] == []

--- a/tests/test_time_dependent_assertions.py
+++ b/tests/test_time_dependent_assertions.py
@@ -39,6 +39,66 @@ def _offenders():
     return found
 
 
+def _module_level_clock_reads():
+    """Module constants whose value is a live clock read.
+
+    A SIBLING of the rule above, and invisible to it: no date literal appears
+    anywhere, so the regex has nothing to match. The trap is the two reads. The
+    constant is evaluated ONCE at import — during collection — while the code
+    under test calls the clock again when the test body runs. In a suite that
+    takes minutes, those two reads can land on opposite sides of midnight.
+
+    Measured, not hypothesised: on 2026-09-07→08 a full-suite run straddled
+    00:00 HKT and four tests in
+    `test_system_check_delivered_but_unarchived.py` went red — its fixtures
+    wrote `brief-sent-<yesterday>.json` and the check looked for `<today>`.
+    Re-run in isolation, and re-run after midnight, all green. Nobody had
+    touched any code. CI runs in UTC, where the crossing is 16:00.
+
+    Freezing is the fix, and it is always available: a fixture date is a value
+    the test chooses, never something it has to ask the clock for.
+    """
+    found = []
+    for path in sorted(TESTS.glob("*.py")):
+        if path.name == Path(__file__).name:
+            continue
+        source = path.read_text(encoding="utf-8")
+        for node in ast.parse(source).body:      # module level only
+            if not isinstance(node, (ast.Assign, ast.AnnAssign)):
+                continue
+            value = node.value
+            if value is None:
+                continue
+            if any(call in ast.unparse(value) for call in LIVE_CLOCK):
+                targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+                names = [t.id for t in targets if isinstance(t, ast.Name)]
+                found.append(f"{path.name}::{names[0] if names else '<expr>'}")
+    return found
+
+
+def test_no_module_level_constant_is_read_from_the_clock():
+    assert _module_level_clock_reads() == [], (
+        "这些模块级常量在 import 时读了一次时钟，被测代码在 test 跑的时候还会再读一次；"
+        f"一次长跑跨过午夜，两次读数就在两天：{_module_level_clock_reads()}。"
+        "修法：冻住（写死夹具日期 + monkeypatch 被测代码的时钟）。")
+
+
+def test_the_module_level_scanner_can_actually_see_an_offender():
+    """反空转：这条闸也必须真的能抓到东西。"""
+    sample = "TODAY = date.today().strftime('%Y-%m-%d')\n"
+    node = ast.parse(sample).body[0]
+
+    assert any(call in ast.unparse(node.value) for call in LIVE_CLOCK)
+
+
+def test_the_module_level_scanner_leaves_frozen_constants_alone():
+    """写死的夹具日期正是修法本身，不能被这条闸判成违例。"""
+    sample = "TODAY = '2026-09-01'\n"
+    node = ast.parse(sample).body[0]
+
+    assert not any(call in ast.unparse(node.value) for call in LIVE_CLOCK)
+
+
 def test_no_test_compares_a_live_clock_against_a_date_literal():
     assert _offenders() == [], (
         "这些测试同时读了真实时钟并对日期字面量断言，它们会在某个午夜自己变红："


### PR DESCRIPTION
## 证据

2026-09-07→08，一次全量套件跑跨了 00:00 HKT：

```
3442 passed, 4 failed          ← 跨午夜那次
  test_delivered_and_committed_is_green
  test_staged_but_uncommitted_still_counts_as_archived
  test_an_absent_brief_is_the_miss_detectors_business
  …
7 passed                       ← 单独重跑
3446 passed                    ← 午夜之后整套重跑
```

**没有人改任何代码。**

## 机制

```python
TODAY = date.today().strftime("%Y-%m-%d")   # 模块级：collection 时读一次
...
check_delivered_but_unarchived()            # 被测代码：test 跑的时候再读一次
    today = date.today().strftime('%Y-%m-%d')
```

夹具写 `brief-sent-<昨天>.json`，闸去找 `<今天>`。一次跑几分钟的套件，两次读数可以落在午夜两边。**CI 跑在 UTC，这个跨点是 16:00。**

## 闸看不见它，而且它的文档写对了规则

`test_time_dependent_assertions` 的 docstring 说得很准：

> 要么冻住时钟（把 now 传进去 / monkeypatch），要么从同一个时钟推出期望值。

模块级 `TODAY = date.today()` **两条都不是** —— 它是对同一个时钟的**另一次**读取。但那道闸的判据是「读了实时时钟 **且** 对日期字面量断言」，而这里任何断言里都没有日期字面量，正则没有东西可匹配。

**又一次守卫覆盖 N-1。** 已知的「master 自己红」机制现在是四种（前三种在 memory `clawock-date-literal-test-timebomb-2026-08-26`）。

## 改动

- `TODAY` 写死成 `2026-09-01`（这道闸当初就是为那天写的），fixture 里 monkeypatch `system_check.date` 成一个 `today()` 不会动的 `date` **子类**（子类而非桩，让检查里其它 `date` 用法照常工作）。两边现在出自同一个不会中途前进的值。
- 闸加第二条规则：**测试文件里不许有模块级的时钟读数**。陷阱是「读了两次」，跟有没有日期字面量无关，所以必须是单独一条 AST 规则。配两条反空转：它必须抓得到真实违例，也必须放过写死的夹具日期。
- 加一条行为测试直接复现那一夜：两次运行之间把被测代码的时钟推过午夜，要求同一份工作区给出各自正确的答案 —— 而不是两边对「今天是哪天」各执一词。

## 验证

**RED-CHECK**：把本 PR 对 `test_system_check_delivered_but_unarchived.py` 的修复 revert 掉，新闸 `test_no_module_level_constant_is_read_from_the_clock` **当场变红**并点名那个常量。全量 **3441 passed**。

全仓扫下来这类模块级时钟读数**只有这一处**，所以闸落地即绿。

https://claude.ai/code/session_01TF24SJwjnJARZaEFjNiSMz