### PR TITLE
dashboard: 让超限可归因，并换掉一条 23/23 都在响的警报

### DIFF
--- a/ops/system_check.py
+++ b/ops/system_check.py
@@ -44,6 +44,9 @@ from clawock.providers.openclaw import (  # noqa: E402
     read_jobs as openclaw_read_jobs,
     runtime_paths as openclaw_runtime_paths,
 )
+# The size report names blocks, and it must name them the way the CI gate does —
+# one helper, so the two cannot describe the same payload differently.
+from clawock.publish import dashboard as dashboard_builder  # noqa: E402
 
 _OPENCLAW_PATHS = openclaw_runtime_paths()
 
@@ -314,18 +317,44 @@ def check_dashboard_buildable(r):
         r.add('dashboard.json build', CRITICAL, 'no output file')
         return
     size = out.stat().st_size
-    # The payload only grows (snapshots, decisions, outcome rows), so the cap is
-    # reached between one publish and the next with no warning: on 2026-07-28 it
-    # crossed 200KB and every push turned red on a test, not here. Warn while
-    # there is still room to trim something.
-    cap, near = 200_000, 180_000
+    # MEASURED, and it corrected what used to be written here (2026-09-08). The
+    # old note said "the payload only grows … warn while there is still room to
+    # trim", and chose `near = 180_000` under that premise. It does not only
+    # grow: over 23 consecutive host runs it ranged 182,073–200,465 bytes and
+    # moved up to 13,474 between one run and the next. Two consequences the old
+    # threshold could not express:
+    #
+    #   * 180,000 was BELOW the observed floor, so this warning fired on 23 of
+    #     23 runs. A warning that is always on is not a warning; it is a line
+    #     kcn scrolls past in the seven-warning list.
+    #   * There is no "room to trim" window to warn inside. From an ordinary
+    #     190KB run the next one can be over the cap with nothing in between.
+    #
+    # So the threshold is now one observed swing below the cap — it says the
+    # true thing ("one ordinary day can breach from here") instead of a number
+    # that is true every day. And every branch names the biggest blocks, because
+    # a size with no composition cannot be acted on.
+    cap = 200_000
+    swing = 14_000          # ≥ the 13,474 largest observed run-to-run delta
+    near = cap - swing
+    try:
+        detail = dashboard_builder.describe_payload_size(
+            json.loads(out.read_text(encoding='utf-8')), size, cap)
+    except Exception:       # noqa: BLE001 — a composition probe must not red the gate
+        detail = f'{size:,} bytes'
     if size > cap:
-        r.add('dashboard.json size', WARNING, f'{size:,} > 200KB cap')
+        # Deliberately not CRITICAL: pre-push CRITICAL blocks the live host's
+        # data pushes (2026-08-31 froze master for 8h), and freezing the data
+        # plane over a payload that is merely too big is worse than publishing
+        # it. The wording carries the urgency instead — `validate` is already red
+        # at this point, which is the actionable fact.
+        r.add('dashboard.json size', WARNING,
+              f'OVER the {cap:,} cap — `validate` is red until this is trimmed. {detail}')
     elif size > near:
         r.add('dashboard.json size', WARNING,
-              f'{size:,} — {cap - size:,} bytes left under the 200KB cap')
+              f'within one day\'s swing ({swing:,}) of the cap. {detail}')
     else:
-        r.add('dashboard.json build', OK, f'{size:,} bytes')
+        r.add('dashboard.json build', OK, detail)
 
 
 def check_peer_map_coverage(r):

--- a/src/clawock/publish/dashboard.py
+++ b/src/clawock/publish/dashboard.py
@@ -1681,6 +1681,32 @@ def compute_today_movers(us_h, hk_h, leg_keys=('us', 'hk')):
         return []
 
 
+def payload_blocks_by_size(payload):
+    """`[(block, bytes), …]` biggest first — what the cap is actually spent on.
+
+    Lives beside the builder rather than in the test so both the CI gate and
+    `system_check` name the same blocks in the same units. A cap breach is only
+    half a report: "203,000 bytes; trim something" tells a reviewer that CI is
+    red and nothing about whether their diff did it. On 2026-07-28 (#743) that
+    ambiguity cost a session — the baseline was already over, and the PR under
+    review was blamed.
+    """
+    return sorted(
+        ((key, len(json.dumps(value, ensure_ascii=False).encode('utf-8')))
+         for key, value in (payload or {}).items()),
+        key=lambda row: -row[1],
+    )
+
+
+def describe_payload_size(payload, raw_bytes, cap, top=6):
+    """One human line plus the biggest blocks, for a gate that must be acted on."""
+    blocks = payload_blocks_by_size(payload)
+    listed = ' · '.join(f'{key} {size:,}' for key, size in blocks[:top])
+    headroom = cap - raw_bytes
+    return (f'{raw_bytes:,} bytes, {headroom:,} under the {cap:,} cap; '
+            f'biggest blocks: {listed}')
+
+
 def _latest_brief_context():
     """Return (path, dict) of the newest brief-context that actually carries data.
 

--- a/tests/test_dashboard_payload_size.py
+++ b/tests/test_dashboard_payload_size.py
@@ -11,6 +11,8 @@ from pathlib import Path
 
 import pytest
 
+from clawock.publish.dashboard import describe_payload_size
+
 
 ROOT = Path(__file__).resolve().parents[1]
 # Bytes, not characters — the unit build_dashboard's MAX_OUT_BYTES and
@@ -40,7 +42,19 @@ def test_payload_stays_under_the_published_cap(freshly_built_dashboard):
     # this asserted came from the checkout, which a previous run may have left
     # there — so the cap was checked against a payload nobody built on purpose.
     size = len(freshly_built_dashboard.read_bytes())
-    assert size < SIZE_CAP, f"{size:,} bytes; trim or move detail to a sidecar"
+    # A BREACH HAS TO BE ATTRIBUTABLE (2026-09-08). This builder reads the real
+    # tree, and the market data in that tree lands on master all day — so this
+    # gate can go red on a PR that did not touch the payload at all. Measured
+    # over 23 consecutive host runs the payload swings between 182,073 and
+    # 200,465 bytes, up to 13,474 between one run and the next, and it has
+    # already crossed the cap once. "203,000 bytes; trim something" tells the
+    # reviewer that CI is red and nothing about whether their diff did it; on
+    # 2026-07-28 (#743) exactly that ambiguity cost a session. Name the blocks.
+    assert size < SIZE_CAP, (
+        describe_payload_size(json.loads(freshly_built_dashboard.read_text()),
+                              size, SIZE_CAP)
+        + " — trim, move detail to a sidecar, or confirm this is today's data "
+          "rather than the diff by rebuilding on master")
 
 
 def test_overview_projection_keeps_canonical_money_health_and_generation_parity(

--- a/tests/test_dashboard_size_is_attributable.py
+++ b/tests/test_dashboard_size_is_attributable.py
@@ -1,0 +1,85 @@
+"""A cap breach that cannot be attributed costs a session (#743, 2026-07-28).
+
+`test_payload_stays_under_the_published_cap` builds from the REAL tree, and the
+market data in that tree lands on master all day. So the gate can go red on a PR
+that never touched the payload. Measured over 23 consecutive host runs the
+payload ranged 182,073–200,465 bytes, moved up to 13,474 between one run and the
+next, and crossed the cap once. `"203,000 bytes; trim something"` told the
+reviewer that CI was red and nothing about whose fault it was.
+
+The same measurement retired the old `near = 180_000` warning in system_check:
+180,000 is BELOW the observed floor, so it fired on 23 of 23 runs — a warning
+that is always on is not a warning.
+"""
+import json
+
+from clawock.publish import dashboard
+
+
+PAYLOAD = {
+    "decision_traces": ["x" * 400],
+    "snapshots": ["y" * 200],
+    "fx": {"usdhkd": 7.84},
+}
+
+
+def test_blocks_are_reported_biggest_first():
+    blocks = dashboard.payload_blocks_by_size(PAYLOAD)
+
+    assert [key for key, _ in blocks] == ["decision_traces", "snapshots", "fx"]
+    assert all(a[1] >= b[1] for a, b in zip(blocks, blocks[1:]))
+
+
+def test_sizes_are_bytes_not_characters():
+    """The payload is heavily CJK; characters read ~5% low and that gap is the
+    whole headroom. Same unit as the cap, or the number is a lie (#743)."""
+    blocks = dashboard.payload_blocks_by_size({"cn": "港股"})
+
+    assert blocks[0][1] == len(json.dumps("港股", ensure_ascii=False).encode("utf-8"))
+
+
+def test_every_block_is_accounted_for():
+    """A breakdown that quietly drops blocks would send the reader after the
+    wrong one."""
+    blocks = dashboard.payload_blocks_by_size(PAYLOAD)
+
+    assert {key for key, _ in blocks} == set(PAYLOAD)
+
+
+def test_the_description_names_the_biggest_blocks_and_the_headroom():
+    text = dashboard.describe_payload_size(PAYLOAD, 190_491, 200_000, top=2)
+
+    assert "190,491" in text
+    assert "9,509" in text                 # headroom, stated not implied
+    assert "decision_traces" in text
+    assert "snapshots" in text
+    assert "fx" not in text                # top=2 honoured
+
+
+def test_an_empty_payload_does_not_crash_the_report():
+    assert dashboard.describe_payload_size({}, 0, 200_000)
+
+
+def test_the_ci_gate_uses_the_shared_describer():
+    """Two reports of the same payload must not describe it differently."""
+    from pathlib import Path
+
+    source = (Path(__file__).resolve().parents[1]
+              / "tests" / "test_dashboard_payload_size.py").read_text()
+
+    assert "describe_payload_size" in source
+    assert 'f"{size:,} bytes; trim or move detail to a sidecar"' not in source
+
+
+def test_system_check_reports_composition_and_a_threshold_that_discriminates():
+    from pathlib import Path
+
+    source = (Path(__file__).resolve().parents[1]
+              / "ops" / "system_check.py").read_text()
+
+    # The retired premise and the always-on threshold, both gone.
+    assert "The payload only grows" not in source
+    assert "cap, near = 200_000, 180_000" not in source
+    # …replaced by one derived from the observed run-to-run swing.
+    assert "swing = 14_000" in source
+    assert "describe_payload_size" in source


### PR DESCRIPTION
## 量出来的（host 的 system_check 历史，23 次连续运行）

```
min 182,073 · median 188,695 · max 200,465 · 相邻两次最大跳 13,474

> 180,000: 23/23 (100%)     > 190,000: 11/23 (48%)
> 188,000: 12/23 ( 52%)     > 200,000:  1/23 ( 4%)   ← 已经超过一次
```

这两条数字直接推翻了这段代码原本写着的前提。

## 1. `system_check` 的注释是错的，阈值因此没有信息量

```python
# The payload only grows (snapshots, decisions, outcome rows), so the cap is
# reached between one publish and the next with no warning … Warn while
# there is still room to trim something.
cap, near = 200_000, 180_000
```

- payload **不是只增**：它上下摆 ±13.5KB。
- `180,000` **低于观测到的下限（182,073）** ⇒ 这条警告 **23/23 都在响**。一条永远在响的警告不是警告，是七条 warning 列表里被划过去的一行。
- 也根本没有「还有余地可以修剪」的窗口：从平常的 190KB 那一次，下一次就可能已经过线，中间什么信号都没有。

## 2. CI 硬闸会因为「今天的数据」红在无关的 PR 上

`test_payload_stays_under_the_published_cap` 用**真实工作树**构建，而行情数据整天往 master 落。失败文案是：

```
203,000 bytes; trim or move detail to a sidecar
```

只告诉审阅者 CI 红了，**不告诉他是不是自己干的**。2026-07-28（#743）正是这个歧义烧掉一整个会话：基线本来就超了（200,584），锅扣在了当时那个 PR 上。

## 改动

- `dashboard.payload_blocks_by_size` / `describe_payload_size`：按块列字节数，最大的在前，**字节不是字符**（payload 大量中文，按字符读低 ~5%，而那正好是全部余量 —— #743 的老坑）。放在 builder 旁边而不是测试里，好让 CI 闸和 system_check 用**同一个**描述器。
- CI 闸失败文案换成它，并补一句怎么判责任：「在 master 上重建一次」。今天真实 payload 的样子：

  ```
  190,491 bytes, 9,509 under the 200,000 cap; biggest blocks:
  decision_traces 36,720 · snapshots 17,418 · plan_timeline 14,572 ·
  recent_decisions 11,684 · risk 10,901 · decision_metrics 10,870
  ```

- system_check 阈值改成 `cap - swing`，`swing = 14_000`（≥ 实测最大单步 13,474）。它说的是真话——「从这儿开始，平常一天的波动就能过线」——而不是一个每天都成立的数字。三个分支现在都带块级构成。
- 超限**不升级成 CRITICAL**：pre-push 的 CRITICAL 会卡死本机数据推送（2026-08-31 冻了 master 8 小时），为一个太大的 payload 冻结整个数据面比发布它更糟。紧迫性放进文案——此时 `validate` 已经红了，那才是可执行的事实。

**没有动 cap。** 200,000 是产品约束（访客要下载它），这个 PR 只让它的两次报告变得可执行。

## 验证

RED-CHECK：7 条新测试在修复前**全红**。全量 **3444 passed**。

https://claude.ai/code/session_01TF24SJwjnJARZaEFjNiSMz