### PR TITLE
context: 按证据能证明什么来分档，而不是按某一个字段在不在

### DIFF
--- a/ops/system_check.py
+++ b/ops/system_check.py
@@ -660,17 +660,13 @@ def _cron_jobs_without_prompt_report(sessions):
     if error is not None or listing is None or listing.source != 'cli':
         return []
 
-    reported = {
-        key.split(':cron:', 1)[1].split(':')[0]
-        for key, entry in (sessions or {}).items()
-        if ':cron:' in key and isinstance(entry, dict)
-        and isinstance(entry.get('systemPromptReport'), dict)
-    }
+    evidence = _session_context_evidence(sessions)
     missing = []
     for job in listing.entries or []:
         if not job.get('enabled'):
             continue
-        if str(job.get('id')) in reported:
+        kind, _ = evidence.get(str(job.get('id')), ('none', 0))
+        if kind == 'report':
             continue
         state = job.get('state') if isinstance(job.get('state'), dict) else {}
         if job.get('status') == 'running' or state.get('runningAtMs') is not None:
@@ -683,6 +679,84 @@ def _cron_jobs_without_prompt_report(sessions):
             continue
         missing.append(str(job.get('name') or job.get('id'))[:28])
     return sorted(missing)
+
+
+def _session_context_evidence(sessions):
+    """`{job_id: (kind, skill_count)}` — how much of a run this store can prove.
+
+    Three kinds, and keeping them apart is the point:
+
+      'report'      a `systemPromptReport` — files, tools and skills all checkable
+      'skills_only' no report, but a `skillsSnapshot` the runtime did write
+      'none'        nothing at all
+
+    2026-09-08: of the twelve cron sessions on this host, ELEVEN carried a
+    report and one — `Memory Dreaming Promotion` — carried `skillsSnapshot`,
+    `systemSent` and `contextTokens` but no report. The coverage check read only
+    the report, so it called that job invisible and said so on 31 of 32 runs.
+    Two things were wrong with that, in opposite directions:
+
+      * it is noise. A warning that is always on is not a warning (the same
+        pathology as the 180,000 dashboard threshold, #1399), and it will be
+        scrolled past on the day it means something.
+      * it is ALSO too weak. The store does hold this job's realized skill list,
+        so a run that came out with zero skills is detectable today — and the
+        gate, having declared the job unseeable, does not look.
+
+    `verify_prompt_report` already models the answer one level down: a check it
+    cannot make is reported in `unverified`, never as passed. This is the same
+    idiom one level up — verify the dimension the evidence covers, and NAME the
+    ones it does not, instead of collapsing the job to "unseen".
+    """
+    out = {}
+    for key, entry in (sessions or {}).items():
+        if ':cron:' not in key or not isinstance(entry, dict):
+            continue
+        job_id = key.split(':cron:', 1)[1].split(':')[0]
+        if isinstance(entry.get('systemPromptReport'), dict):
+            out[job_id] = ('report', 0)
+            continue
+        snapshot = entry.get('skillsSnapshot')
+        skills = (snapshot or {}).get('skills') if isinstance(snapshot, dict) else None
+        if isinstance(skills, list):
+            out[job_id] = ('skills_only', len(skills))
+        else:
+            out[job_id] = ('none', 0)
+    return out
+
+
+def cron_jobs_by_context_evidence(sessions, listing):
+    """Split the enabled jobs the coverage check names into what it can prove.
+
+    Returns `(blind, narrowed, skills_only)` — jobs with no evidence at all,
+    jobs whose only evidence says the skill list came out EMPTY, and jobs whose
+    skills check out with the remaining dimensions unverified.
+    """
+    evidence = _session_context_evidence(sessions)
+    blind, narrowed, skills_only = [], [], []
+    for job in (getattr(listing, 'entries', None) or []):
+        if not job.get('enabled'):
+            continue
+        name = str(job.get('name') or job.get('id'))[:28]
+        kind, count = evidence.get(str(job.get('id')), ('none', 0))
+        if kind == 'report':
+            continue
+        state = job.get('state') if isinstance(job.get('state'), dict) else {}
+        if job.get('status') == 'running' or state.get('runningAtMs') is not None:
+            continue
+        last_status = str(
+            state.get('lastStatus') or state.get('lastRunStatus') or '').lower()
+        if last_status in {
+                'error', 'failed', 'failure', 'timeout', 'timed_out',
+                'cancelled', 'canceled', 'skipped'}:
+            continue
+        if kind == 'none':
+            blind.append(name)
+        elif count == 0:
+            narrowed.append(name)
+        else:
+            skills_only.append(f'{name} ({count} skills)')
+    return sorted(blind), sorted(narrowed), sorted(skills_only)
 
 
 def check_context_capability(r):
@@ -739,7 +813,6 @@ def check_context_capability(r):
     # otherwise average away a tenth enabled job that produces none — the gate
     # reads OK while one live job is unverifiable (#473). Names, not a count, so
     # the finding says which job to go look at.
-    unreported_jobs = _cron_jobs_without_prompt_report(sessions)
     coverage_blind = _cron_coverage_blind()
     if coverage_blind:
         # Not a finding about the jobs — a finding about this gate. A run that
@@ -749,11 +822,31 @@ def check_context_capability(r):
               f'per-job prompt-report coverage was not checked: '
               f'{coverage_blind}, so a job producing no report would not be '
               f'named by this run')
-    if unreported_jobs:
+    listing, _listing_error = _cron_listing()
+    blind, narrowed, skills_only = cron_jobs_by_context_evidence(sessions, listing)
+    # Three answers, because they call for three different actions — and because
+    # collapsing them into one is what made this line fire on 31 of 32 runs
+    # while checking nothing (2026-09-08).
+    if narrowed:
+        # The one that is a real finding about a RUN: the store holds this job's
+        # realized skill list and the list is empty. Under the old shape the job
+        # was declared unseeable and this went unnoticed.
         r.add('context capability', WARNING,
-              f'{len(unreported_jobs)} enabled cron job(s) produce no prompt '
-              f'report, so this gate cannot see them: '
-              f'{", ".join(unreported_jobs)}')
+              f'{", ".join(narrowed)}: the run recorded an EMPTY skill list — '
+              f'context came out narrowed')
+    if blind:
+        r.add('context capability', WARNING,
+              f'{len(blind)} enabled cron job(s) record nothing this gate can '
+              f'read — no prompt report and no skills snapshot: '
+              f'{", ".join(blind)}')
+    if skills_only:
+        # Named, never silent (#473: nine healthy jobs must not average away a
+        # tenth). But named with what IS proven, and OK rather than WARNING:
+        # the skills dimension checks out; files and tools are unverified, which
+        # is the same distinction `verify_prompt_report` draws with `unverified`.
+        r.add('context capability', OK,
+              f'skills verified, files/tools unverified (no prompt report): '
+              f'{", ".join(skills_only)}')
 
     silent = sorted(profiles_seen - set(newest))
     if silent:

--- a/tests/test_context_capability_not_vacuous.py
+++ b/tests/test_context_capability_not_vacuous.py
@@ -248,3 +248,118 @@ def test_an_unreadable_schedule_does_not_invent_findings(monkeypatch):
 
     monkeypatch.setattr('clawock.providers.openclaw.cron_cli_json', boom)
     assert sc._cron_jobs_without_prompt_report({}) == []
+
+
+# ── what the evidence proves, not whether one field exists (2026-09-08) ──────
+# Of the twelve cron sessions on the host that day, ELEVEN carried a
+# `systemPromptReport` and one — `Memory Dreaming Promotion` — carried
+# `skillsSnapshot`, `systemSent` and `contextTokens` but no report. Reading only
+# the report made the gate call that job invisible, and say so on 31 of 32 runs.
+#
+# Wrong in both directions at once: noise (a warning that is always on is not a
+# warning — same pathology as #1399's 180,000 threshold), AND too weak (the
+# store holds that job's realized skill list, so a run that came out with zero
+# skills was detectable and the gate, having declared the job unseeable, did not
+# look).
+#
+# `verify_prompt_report` already models the answer one level down: a check it
+# cannot make goes in `unverified`, never counted as passed.
+
+
+def _listing(monkeypatch, jobs):
+    monkeypatch.setattr('clawock.providers.openclaw.cron_cli_json',
+                        lambda argv: {'jobs': jobs})
+    import ops.system_check as sc
+    listing, _ = sc._cron_listing()
+    return listing
+
+
+JOB = {'id': 'a', 'name': 'Dreaming', 'enabled': True, 'state': {'lastStatus': 'ok'}}
+
+
+def test_a_job_with_only_a_skills_snapshot_is_verified_on_skills(monkeypatch):
+    import ops.system_check as sc
+
+    listing = _listing(monkeypatch, [JOB])
+    blind, narrowed, skills_only = sc.cron_jobs_by_context_evidence(
+        {'agent:main:cron:a': {'skillsSnapshot': {'skills': [{'name': 'x'},
+                                                             {'name': 'y'}]}}},
+        listing)
+
+    assert blind == [] and narrowed == []
+    assert skills_only == ['Dreaming (2 skills)']
+
+
+def test_an_empty_skill_list_is_a_finding_the_old_shape_could_not_make(monkeypatch):
+    """THE point of the split. Under "no report ⇒ unseeable" this run looked
+    exactly like a healthy one; the store said the context came out empty."""
+    import ops.system_check as sc
+
+    listing = _listing(monkeypatch, [JOB])
+    blind, narrowed, skills_only = sc.cron_jobs_by_context_evidence(
+        {'agent:main:cron:a': {'skillsSnapshot': {'skills': []}}}, listing)
+
+    assert narrowed == ['Dreaming']
+    assert skills_only == [] and blind == []
+
+
+def test_a_job_with_no_evidence_at_all_is_still_blind(monkeypatch):
+    """#473 is not being softened: a job the store says nothing about stays a
+    loud warning. Only the jobs it DOES say something about move."""
+    import ops.system_check as sc
+
+    listing = _listing(monkeypatch, [JOB])
+    blind, narrowed, skills_only = sc.cron_jobs_by_context_evidence(
+        {'agent:main:cron:a': {'updatedAt': 20}}, listing)
+
+    assert blind == ['Dreaming']
+    assert narrowed == [] and skills_only == []
+
+
+def test_a_job_with_a_full_report_is_in_none_of_the_three(monkeypatch):
+    import ops.system_check as sc
+
+    listing = _listing(monkeypatch, [JOB])
+
+    assert sc.cron_jobs_by_context_evidence(
+        {'agent:main:cron:a': {'systemPromptReport': {}}}, listing) == ([], [], [])
+
+
+def test_the_split_covers_exactly_the_jobs_the_old_view_names(monkeypatch):
+    """Two views of one question must not drift apart: every job the report-only
+    view calls uncovered has to land in exactly one of the three buckets."""
+    import ops.system_check as sc
+
+    jobs = [
+        {'id': 'a', 'name': 'Full', 'enabled': True, 'state': {'lastStatus': 'ok'}},
+        {'id': 'b', 'name': 'SkillsOnly', 'enabled': True, 'state': {'lastStatus': 'ok'}},
+        {'id': 'c', 'name': 'Empty', 'enabled': True, 'state': {'lastStatus': 'ok'}},
+        {'id': 'd', 'name': 'Nothing', 'enabled': True, 'state': {'lastStatus': 'ok'}},
+    ]
+    sessions = {
+        'agent:main:cron:a': {'systemPromptReport': {}},
+        'agent:main:cron:b': {'skillsSnapshot': {'skills': [{'name': 'x'}]}},
+        'agent:main:cron:c': {'skillsSnapshot': {'skills': []}},
+        'agent:main:cron:d': {'updatedAt': 1},
+    }
+    listing = _listing(monkeypatch, jobs)
+
+    blind, narrowed, skills_only = sc.cron_jobs_by_context_evidence(sessions, listing)
+    named = set(blind) | set(narrowed) | {s.split(' (')[0] for s in skills_only}
+
+    assert named == set(sc._cron_jobs_without_prompt_report(sessions))
+    assert named == {'SkillsOnly', 'Empty', 'Nothing'}
+
+
+def test_a_failed_run_stays_out_of_every_bucket(monkeypatch):
+    """#490 unchanged: the scheduler already says the run failed; blaming
+    context assembly as well makes the warning cry wolf."""
+    import ops.system_check as sc
+
+    listing = _listing(monkeypatch, [
+        {'id': 'a', 'name': 'Timed out', 'enabled': True,
+         'state': {'lastStatus': 'error'}}])
+
+    assert sc.cron_jobs_by_context_evidence(
+        {'agent:main:cron:a': {'skillsSnapshot': {'skills': []}}},
+        listing) == ([], [], [])


### PR DESCRIPTION
上一轮我把这条留给 kcn 了，理由是「让它产报告 = 改 live cron job 的行为；记成已知豁免 = 削弱一道故意造得很吵的闸」。查下来**有第三条路**，而且它既不改 job 也不削弱闸。

## 事实

本机 12 个 cron session：

```
11 个带 systemPromptReport                     ← 全部 OK
 1 个没有：Memory Dreaming Promotion
     但它带 skillsSnapshot(36 skills) / systemSent / contextTokens
     lastStatus = ok，每天 03:00 正常跑
```

所以**不是「这类 job 天生不产」**，也不是它没留下上下文证据 —— 它留了，只是留的不是覆盖率检查读的那个字段。于是那条 warning 在 **32 次运行里响了 31 次**。

## 这个形状同时错在两个相反的方向

- **是噪音。** 一条永远在响的警告不是警告（和 #1399 那条 `near = 180_000` 同一种病 —— 23/23 都在响），它会在真正有意义的那天被划过去。
- **同时又太弱。** session store 里就有这个 job **实际拿到的 skill 列表**。「这一轮跑出来 0 个 skill」今天是可检测的 —— 而闸因为已经宣布这个 job 看不见，**根本不去看**。

`verify_prompt_report` 在下一层早就写对了：

> *Backend dialect decides what is checkable: a runtime-plugin backend legitimately reports an empty catalog, so that check is reported as **unverified** rather than passed.*

这个 PR 就是把同一个写法搬到上一层。

## 改动

| | |
|---|---|
| `_session_context_evidence` | session 分三档：`report` / `skills_only` / `none` |
| `cron_jobs_by_context_evidence` | 把「没 report」的 job 拆成 **blind**（什么都没有，仍是大声 WARNING —— **#473 一点没削弱**）、**narrowed**（唯一证据说 skill 列表是空的 ⇒ 关于某一轮的真发现，旧形状做不出）、**skills_only**（skills 验过，files/tools 未验，OK 并把两者都点名） |
| 报告端 | 一条覆盖警告 → 三条各自对应不同动作的结论 |

本机跑出来：

```
- ⚠ WARN  1 enabled cron job(s) produce no prompt report, so this gate cannot see them: Memory Dreaming Promotion
+ ✓ OK    skills verified, files/tools unverified (no prompt report): Memory Dreaming Promotion (36 skills)
```

信息更多，噪音更少，**而且从今天起 0 skill 会红**。

## 验证

RED-CHECK：6 条新测试在修复前**全红**，包括「空 skill 列表是旧形状做不出的发现」和「两个视图必须覆盖同一批 job」（防两套判据漂移）。全量 **3463 passed**。

https://claude.ai/code/session_01TF24SJwjnJARZaEFjNiSMz