### PR TITLE
memory index: 两次夜间重建之间的正常改动不是积压

### DIFF
--- a/ops/system_check.py
+++ b/ops/system_check.py
@@ -1576,6 +1576,35 @@ def _memory_index_backlog():
     return missing, stale, len(indexed)
 
 
+def _written_since_last_reindex(paths, age_hours):
+    """Split `paths` into (backlog, churn) around the last completed reindex.
+
+    A file written AFTER the reindex finished is not a backlog — it is the
+    normal state of a workspace between two nightly passes, and tonight's run
+    will take it. A file written BEFORE it and still missing or stale is the
+    2026-07-27 shape: the reindex ran and did not cover it.
+
+    Measured 2026-09-08: all six files this check was naming (`-pre-open.md`
+    written at 08:12, four `report-prose-*.md`, `intraday-prose-hk.md` rewritten
+    every 30 minutes) post-dated the 05:11 reindex. Genuine backlog: zero. The
+    warning had fired on 36 of 44 runs — 82% — which is why it was worth nothing
+    on the day it would have meant something. `nightly reindex last completed
+    {age}h ago`, already in this check, is the signal that actually catches the
+    incident: on 07-27 the index was five days behind.
+    """
+    if age_hours is None:            # never completed — everything is backlog,
+        return list(paths), []       # and the age problem says so separately.
+    cutoff = time.time() - age_hours * 3600
+    backlog, churn = [], []
+    for path in paths:
+        try:
+            written = (LIVE_WORKSPACE / path).stat().st_mtime
+        except OSError:
+            continue                 # vanished underneath us; not a backlog
+        (churn if written > cutoff else backlog).append(path)
+    return backlog, churn
+
+
 def _memory_index_patch_gaps():
     """Local dist patches openclaw upgrades wipe, both silent at the point of use."""
     if OPENCLAW_INSTALL is None:
@@ -1643,6 +1672,12 @@ def check_memory_index(r):
         r.add('memory index', WARNING, f'cannot read index: {e}')
         return
 
+    age = _memory_reindex_age_hours()
+    # Only what the last reindex ALREADY HAD ITS CHANCE AT counts as backlog.
+    missing, missing_churn = _written_since_last_reindex(missing, age)
+    stale, stale_churn = _written_since_last_reindex(stale, age)
+    churn = len(missing_churn) + len(stale_churn)
+
     problems = []
     if missing:
         problems.append(f'{len(missing)} file(s) never embedded (e.g. {missing[0]})')
@@ -1650,17 +1685,21 @@ def check_memory_index(r):
         problems.append(f'{len(stale)} file(s) changed since indexing (e.g. {stale[0]})')
     problems += _memory_index_patch_gaps()
 
-    age = _memory_reindex_age_hours()
     if age is None:
         problems.append('nightly reindex has never completed')
     elif age > MEMORY_REINDEX_MAX_AGE_HOURS:
         problems.append(f'nightly reindex last completed {age:.0f}h ago')
 
+    # Churn is reported, never as a problem: it is what a live workspace looks
+    # like between two nightly passes, and hiding it entirely would make the OK
+    # line claim more than it checked.
+    churn_note = f' · {churn} written since, due tonight' if churn else ''
     if problems:
-        r.add('memory index', WARNING, '; '.join(problems))
+        r.add('memory index', WARNING, '; '.join(problems) + churn_note)
     else:
         r.add('memory index', OK,
-              f'{indexed} files embedded · patches applied · reindex {age:.0f}h ago')
+              f'{indexed} files embedded · patches applied · '
+              f'reindex {age:.0f}h ago{churn_note}')
 
 
 def _memory_curation_gaps():

--- a/tests/test_memory_index_check.py
+++ b/tests/test_memory_index_check.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import sqlite3
 import sys
+import os
 from datetime import datetime, timedelta
 from pathlib import Path
 
@@ -84,6 +85,23 @@ def box(tmp_path, sc, monkeypatch):
     return {"workspace": workspace, "db": db, "dist": dist, "log": log}
 
 
+def _predating_reindex(path: Path, text: str) -> Path:
+    """Write a file the last reindex already had its chance at.
+
+    Backlog is now defined against the reindex, not against now (2026-09-08):
+    a file written AFTER the pass is normal churn tonight will take, and calling
+    that a backlog is what made this warning fire on 36 of 44 host runs. The
+    incident these tests encode is the other one — 2026-07-27, five days of
+    dreaming notes that the reindex RAN PAST and still did not embed — so the
+    fixture has to place them where they actually were: before the pass.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text)
+    old = (datetime.now() - timedelta(hours=6)).timestamp()
+    os.utime(path, (old, old))
+    return path
+
+
 def _run(sc):
     r = sc.Result()
     sc.check_memory_index(r)
@@ -101,7 +119,8 @@ def test_healthy_box_reports_ok(sc, box):
 
 def test_unembedded_file_is_reported(sc, box):
     """The July failure: dreaming notes written but never embedded."""
-    (box["workspace"] / "memory" / "dreaming" / "2026-07-27.md").write_text("new\n")
+    _predating_reindex(
+        box["workspace"] / "memory" / "dreaming" / "2026-07-27.md", "new\n")
     severity, message = _run(sc)
     assert severity == sc.WARNING
     assert "never embedded" in message
@@ -110,7 +129,8 @@ def test_unembedded_file_is_reported(sc, box):
 
 def test_file_changed_since_indexing_is_reported(sc, box):
     """A source indexed once and edited since is stale, and the ratio hides it."""
-    (box["workspace"] / "memory" / "2026-07-27.md").write_text("today, plus an edit\n")
+    _predating_reindex(
+        box["workspace"] / "memory" / "2026-07-27.md", "today, plus an edit\n")
     severity, message = _run(sc)
     assert severity == sc.WARNING
     assert "changed since indexing" in message
@@ -122,7 +142,7 @@ def test_gitignored_trees_count_as_index_scope(sc, box):
     472/472 index. Excluding them would under-report the backlog."""
     tmp_dir = box["workspace"] / "memory" / ".tmp"
     tmp_dir.mkdir()
-    (tmp_dir / "report-prose-hk-open.md").write_text("prose\n")
+    _predating_reindex(tmp_dir / "report-prose-hk-open.md", "prose\n")
     severity, message = _run(sc)
     assert severity == sc.WARNING
     assert "memory/.tmp/report-prose-hk-open.md" in message
@@ -207,3 +227,70 @@ def test_check_is_registered_in_main(sc):
     body = source.split("\n    checks = [", 1)[1].split("]", 1)[0]
     registered = {line.strip().rstrip(",") for line in body.splitlines() if line.strip()}
     assert "check_memory_index" in registered
+
+
+# ── churn is not backlog (2026-09-08) ────────────────────────────────────────
+# This warning had fired on 36 of 44 host runs — 82% — and on 2026-09-08 all six
+# files it was naming (`-pre-open.md` at 08:12, four `report-prose-*.md`, and
+# `intraday-prose-hk.md`, which is rewritten every 30 minutes) post-dated the
+# 05:11 reindex. Genuine backlog: zero. It was measuring the gap between two
+# nightly passes, which is not a state anyone can act on, and it was worth
+# nothing on the day it would have meant something.
+
+
+def test_a_file_written_after_the_reindex_is_not_a_backlog(sc, box):
+    """Tonight's pass will take it. That is the system working."""
+    (box["workspace"] / "memory" / ".tmp").mkdir()
+    (box["workspace"] / "memory" / ".tmp" / "intraday-prose-hk.md").write_text("now\n")
+
+    severity, message = _run(sc)
+
+    assert severity == sc.OK, message
+    assert "1 written since, due tonight" in message
+
+
+def test_the_churn_count_is_still_stated_not_hidden(sc, box):
+    """Silently dropping it would make the OK line claim more than it checked."""
+    (box["workspace"] / "memory" / "fresh-a.md").write_text("a\n")
+    (box["workspace"] / "memory" / "fresh-b.md").write_text("b\n")
+
+    _, message = _run(sc)
+
+    assert "2 written since, due tonight" in message
+
+
+def test_churn_rides_along_on_a_real_finding_too(sc, box):
+    """A genuine backlog must not hide the churn, nor churn the backlog."""
+    _predating_reindex(box["workspace"] / "memory" / "old-miss.md", "old\n")
+    (box["workspace"] / "memory" / "fresh.md").write_text("new\n")
+
+    severity, message = _run(sc)
+
+    assert severity == sc.WARNING
+    assert "1 file(s) never embedded" in message
+    assert "memory/old-miss.md" in message
+    assert "1 written since, due tonight" in message
+
+
+def test_a_reindex_that_never_completed_makes_everything_backlog(sc, box):
+    """With no pass to measure against, nothing has had its chance yet — and the
+    age problem says so separately, so the two findings agree."""
+    box["log"].write_text("reaped 0 rows\n")
+    (box["workspace"] / "memory" / "fresh.md").write_text("new\n")
+
+    severity, message = _run(sc)
+
+    assert severity == sc.WARNING
+    assert "1 file(s) never embedded" in message
+    assert "nightly reindex has never completed" in message
+    assert "written since" not in message
+
+
+def test_a_file_removed_underneath_the_check_is_not_a_backlog(sc, box):
+    """Between listing and stat, the intraday harness rewrites its scratch files."""
+    ghost = box["workspace"] / "memory" / "ghost.md"
+    ghost.write_text("x\n")
+    backlog, churn = sc._written_since_last_reindex(["memory/ghost.md", "memory/gone.md"],
+                                                    age_hours=3)
+
+    assert backlog == [] and churn == ["memory/ghost.md"]


### PR DESCRIPTION
## 证据

先量了一遍**每条 check 的 WARN 率**（host 的 system_check 历史）：

```
check                   WARN  总次数   占比
memory index              36     44    82%   ← 本 PR
context capability        31     63    49%   ← #1400 已修
dashboard.json size       23     23   100%   ← #1399 已修
fallback chain             7      7   100%   ← kcn 的决定（钱包）
delivery channels          2      2   100%   ← 已否三次
```

然后逐个查 `memory index` 当天点名的六个文件：

```
上次 reindex 完成于 09-07 05:11

新于 reindex  09-07 08:12  memory/2026-09-07-pre-open.md
新于 reindex  09-07 15:33  memory/.tmp/intraday-prose-hk.md      ← 每 30 分钟重写一次
新于 reindex  09-07 16:11  memory/.tmp/report-prose-hk-close.md
新于 reindex  09-07 12:03  memory/.tmp/report-prose-hk-mid.md
新于 reindex  09-07 09:33  memory/.tmp/report-prose-hk-open.md
新于 reindex  09-07 13:33  memory/.tmp/report-prose-hk-pm.md
```

**6/6 全部写于那次 reindex 之后。真积压：0。**

它量的是「两次夜间重建之间的间隔」——那不是任何人能处置的状态。而正因为天天在响，它在真正有意义的那天也不会被看见。

## 这道闸本来就有抓真事故的信号

`nightly reindex last completed {age}h ago`。2026-07-27 那次（索引落后五天，07-23 起的 dreaming 笔记全部不可召回）正是它该抓的形状 —— **reindex 跑过了，仍然没覆盖到**。

## 改动

- `_written_since_last_reindex`：以上次**完成**的 reindex 为界，把 missing/stale 拆成
  - **backlog** —— 那趟跑过了还没覆盖 = 07-27 的形状，照旧 WARNING
  - **churn** —— 那趟之后才写的，今晚会被带走
- churn **仍然报出来**，只是不算 problem：`· 6 written since, due tonight`。完全藏掉会让 OK 那行声称的比它实际检查的多。
- `age is None`（从未完成过重建）⇒ 全部算 backlog —— 没有那一趟，就没有「已经有过机会」这回事；而 age 那条 problem 会同时说出原因，两条结论一致。

三条老测试**改的是夹具不是断言**：它们编码的是 07-27，而 07-27 的文件本来就写在那趟 reindex **之前**。新增 `_predating_reindex()` 把它们放回真实位置 —— 这不是放宽，是让它们终于编码了那个事故。

本机效果：

```diff
- ⚠ WARN  1 file(s) never embedded (e.g. memory/2026-09-07-pre-open.md); 5 file(s) changed since indexing
+ ✓ OK    231 files embedded · patches applied · reindex 20h ago · 6 written since, due tonight
```

## 验证

RED-CHECK：4 条新测试在修复前红，含行为红（reindex 之后写的文件旧代码判 WARNING）。全量 **3468 passed**。

https://claude.ai/code/session_01TF24SJwjnJARZaEFjNiSMz