### PR TITLE
backlog: `oldest` 读的是最新那条，而且会被 rebase 抹掉

### DIFF
--- a/ops/system_check.py
+++ b/ops/system_check.py
@@ -1119,12 +1119,30 @@ def check_publish_backlog(r):
     if not count:
         r.add('publish backlog', OK, 'nothing unpushed')
         return
+    # TWO BUGS IN ONE LINE, both making `hours` read ~0 forever (2026-09-08):
+    #
+    #   * `git log -1` returns the NEWEST commit — the log is newest-first — so
+    #     a variable named `oldest` held the most recent one. Measured on this
+    #     repo over five commits: `-1` answered 00:42:36 while the true oldest
+    #     was 23:52:35, a 50-minute error on a 50-minute backlog.
+    #   * `%ct` is the COMMITTER date, and `push_with_rebase_retry` rebases —
+    #     every retry rewrites it to now. `%at` (author date) survives a rebase,
+    #     and "how long has this been stranded" is a question about when the
+    #     work was made, not about when git last touched it.
+    #
+    # Consequence: `hours >= BACKLOG_WARN_HOURS` never fired. Every one of the
+    # eight backlog warnings in the host's history reads `oldest 0.0h`, and the
+    # check escalated on `count` alone. The incident this half exists for is the
+    # opposite shape — 2026-08-31, a SMALL number of commits stranded for EIGHT
+    # hours behind a pre-push refusal — and it would have been reported at 0.0h.
     oldest = subprocess.run(
-        ['git', 'log', '-1', '--format=%ct', 'origin/master..HEAD'],
+        ['git', 'log', '--format=%at', 'origin/master..HEAD'],
         capture_output=True, text=True, timeout=10)
     hours = None
     try:
-        hours = (time.time() - int(oldest.stdout.strip())) / 3600
+        # Last line, because the log is newest-first.
+        stamps = [int(line) for line in oldest.stdout.split() if line.strip()]
+        hours = (time.time() - min(stamps)) / 3600
     except Exception:
         pass
     age = f'{hours:.1f}h' if hours is not None else 'unknown age'

--- a/tests/test_backlog_age_is_the_oldest.py
+++ b/tests/test_backlog_age_is_the_oldest.py
@@ -1,0 +1,160 @@
+"""`oldest` has to mean oldest, and has to survive a rebase.
+
+`check_publish_backlog` escalates on either half of
+
+    count >= BACKLOG_WARN_COMMITS or hours >= BACKLOG_WARN_HOURS
+
+and the second half never fired. Two bugs in one line:
+
+  * `git log -1` returns the NEWEST commit — the log is newest-first — so a
+    variable named `oldest` held the most recent one. Measured on the live repo
+    over five commits: `-1` answered 00:42:36 while the true oldest was
+    23:52:35.
+  * `%ct` is the committer date, and `push_with_rebase_retry` rebases; every
+    retry rewrites it to now.
+
+Both push the reading toward zero, which is what the host's history shows:
+all eight backlog warnings ever recorded read `oldest 0.0h`, so the check only
+ever escalated on `count`. The incident the age half exists for is the opposite
+shape — 2026-08-31, a SMALL number of commits stranded for EIGHT hours behind a
+pre-push refusal (see this suite's sibling) — and it would have read 0.0h.
+
+Driven through a REAL git repo on purpose. The sibling suite's fake answers any
+`git log` with one stamp regardless of argv, so it proves the branch runs and
+can say nothing about whether the arguments ask the right question — which is
+exactly how this survived.
+"""
+import importlib.util
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+@pytest.fixture(scope="module")
+def system_check():
+    for path in (ROOT, ROOT / "src"):
+        if str(path) not in sys.path:
+            sys.path.insert(0, str(path))
+    spec = importlib.util.spec_from_file_location(
+        "kcnyu_system_check_backlog_age", ROOT / "ops" / "system_check.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _run(repo, *args, **kw):
+    return subprocess.run(["git", "-C", str(repo), *args],
+                          check=True, capture_output=True, text=True, **kw).stdout
+
+
+@pytest.fixture
+def repo(tmp_path):
+    """master, an `origin/master` behind it, and commits of known ages."""
+    origin = tmp_path / "origin.git"
+    subprocess.run(["git", "init", "-q", "--bare", str(origin)], check=True)
+    work = tmp_path / "work"
+    subprocess.run(["git", "init", "-q", "-b", "master", str(work)], check=True)
+    _run(work, "config", "user.email", "t@e.st")
+    _run(work, "config", "user.name", "t")
+    _run(work, "remote", "add", "origin", str(origin))
+    (work / "seed.txt").write_text("seed\n")
+    _run(work, "add", "seed.txt")
+    _run(work, "commit", "-qm", "seed")
+    _run(work, "push", "-q", "origin", "master")
+    return work
+
+
+def _commit_aged(repo, name, hours_ago):
+    stamp = time.strftime("%Y-%m-%dT%H:%M:%S",
+                          time.localtime(time.time() - hours_ago * 3600))
+    (repo / name).write_text(name)
+    _run(repo, "add", name)
+    _run(repo, "commit", "-qm", name,
+         env={"GIT_AUTHOR_DATE": stamp, "GIT_COMMITTER_DATE": stamp,
+              "PATH": "/usr/bin:/bin", "HOME": str(repo)})
+
+
+def _backlog(system_check, monkeypatch, repo):
+    monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
+    monkeypatch.chdir(repo)
+    result = system_check.Result()
+    system_check.check_publish_backlog(result)
+    assert len(result.checks) == 1
+    _, severity, message = result.checks[0]
+    return severity, message
+
+
+def test_the_age_is_the_oldest_commit_not_the_newest(
+        system_check, monkeypatch, repo):
+    """The reported number must describe the commit that has waited longest."""
+    _commit_aged(repo, "old.txt", hours_ago=5)
+    _commit_aged(repo, "new.txt", hours_ago=0)
+
+    severity, message = _backlog(system_check, monkeypatch, repo)
+
+    assert severity == system_check.WARNING
+    assert "oldest 5." in message, message      # not 0.0h
+
+
+def test_a_small_backlog_stranded_for_hours_escalates(
+        system_check, monkeypatch, repo):
+    """The 2026-08-31 shape: below the count threshold, far past the age one.
+    Under the old reading this was `1 commit(s) unpushed, oldest 0.0h` — OK."""
+    _commit_aged(repo, "stuck.txt", hours_ago=8)
+
+    severity, message = _backlog(system_check, monkeypatch, repo)
+
+    assert severity == system_check.WARNING
+    assert "1 commit(s) unpushed" in message
+    assert "oldest 8." in message
+
+
+def test_a_fresh_single_commit_is_still_a_normal_publish_cycle(
+        system_check, monkeypatch, repo):
+    """The fix must not turn every ordinary tick into a warning."""
+    _commit_aged(repo, "fresh.txt", hours_ago=0)
+
+    severity, _ = _backlog(system_check, monkeypatch, repo)
+
+    assert severity == system_check.OK
+
+
+def test_a_rebase_does_not_reset_the_age(system_check, monkeypatch, repo, tmp_path):
+    """`push_with_rebase_retry` rebases on every retry, and a rebase that
+    actually replays commits REWRITES `%ct` to now. `%at` survives it — and the
+    question is how long the work has waited, not when git last touched it.
+
+    The remote has to move for the rebase to replay anything; a rebase onto the
+    commit you are already on is a no-op and proves nothing.
+    """
+    _commit_aged(repo, "stuck.txt", hours_ago=6)
+    before = _backlog(system_check, monkeypatch, repo)[1]
+
+    # Someone else pushes: now our pending commit has to be replayed.
+    other = tmp_path / "other"
+    subprocess.run(["git", "clone", "-q", str(repo / ".." / "origin.git"),
+                    str(other)], check=True)
+    _run(other, "config", "user.email", "o@e.st")
+    _run(other, "config", "user.name", "o")
+    (other / "theirs.txt").write_text("theirs\n")
+    _run(other, "add", "theirs.txt")
+    _run(other, "commit", "-qm", "theirs")
+    _run(other, "push", "-q", "origin", "master")
+
+    _run(repo, "fetch", "-q", "origin")
+    _run(repo, "rebase", "origin/master")
+    # The rebase really did rewrite the committer date…
+    committer_age_h = (time.time() - int(
+        _run(repo, "log", "-1", "--format=%ct").strip())) / 3600
+    assert committer_age_h < 0.1, committer_age_h
+
+    after = _backlog(system_check, monkeypatch, repo)[1]
+
+    assert "oldest 6." in before, before
+    assert "oldest 6." in after, after      # …and the age survived it


### PR DESCRIPTION
## 怎么找到的

先按 job × stage 量了一遍 workflow-outcomes 的降级率，`committed_local` 是最大成因（23 条 warning 里 16 条）：

```
09-04/09-05  committed_local ×16   unpushed 累到 6
09-07        committed_local ×0    ← 09-06 的 PUSH_TIMEOUT_SECONDS 修复生效了
```

那部分**已经修好了**，不需要新 PR。但 09-05 那晚 `unpushed_commits` 一路累到 6，我去查当时有没有人喊——`publish backlog` 确实喊了 8 次，可是：

```
7 × publish backlog  1 commit(s) unpushed, oldest 0.0h
1 × publish backlog  2 commit(s) unpushed, oldest 0.0h
```

**八次全是 `oldest 0.0h`。** 一个永远读作 0 的年龄读数不是读数。

## 一行里两个 bug

```python
oldest = subprocess.run(['git', 'log', '-1', '--format=%ct', 'origin/master..HEAD'], …)
```

1. **`git log -1` 拿的是最新那条** —— log 是新到旧。一个叫 `oldest` 的变量里装着最近的那条。本仓实测五条 commit：

   ```
   git log -1 --format=%ct     → 09-08 00:42:36
   真正最旧 (tail -1)           → 09-07 23:52:35
   ```

2. **`%ct` 是 committer date，而 `push_with_rebase_retry` 会 rebase** —— 每次重试都把它改写成现在。`%at`（author date）不受 rebase 影响，而「这东西搁置了多久」问的是**活是什么时候干的**，不是 git 最后一次碰它是什么时候。

两个都把读数推向 0，所以

```python
count >= BACKLOG_WARN_COMMITS(3) or hours >= BACKLOG_WARN_HOURS(2.0)
```

的**第二半从来没有生效过**，这道闸只靠 count 升级。

而这半个条件存在的理由正是相反的形状 —— **2026-08-31，少量 commit 因为 pre-push 拒绝被搁置八小时**（这个 suite 的姐妹文件开头就写着这个事故）。按旧读法那天会报成 `1 commit(s) unpushed, oldest 0.0h`，也就是 **OK**。

## 为什么现有 18 条测试没抓到

它们的假 git 对任何 `git log` 都返回同一个时间戳，**不看 argv**：

```python
if argv[:2] == ["git", "log"]:
    return subprocess.CompletedProcess(argv, 0, stamp + "\n", "")
```

所以它们证明的是「这条分支跑到了」，对「参数问的是不是正确的问题」一个字都说不了。**这个 bug 正是这么活下来的。**

新测试走**真 git 仓库**。那条 rebase 测试里远端必须真的往前走过 —— 对着自己所在的 commit 做 rebase 是空操作，什么都证明不了（我第一版就是这么写的，前后都绿，重写了）。

## 验证

RED-CHECK：4 条新测试里 **2 条在修复前红**；另 2 条前后都绿，钉的是不能误伤的行为（新鲜的单条 commit 仍算正常发布节律）。全量 **3472 passed**。

https://claude.ai/code/session_01TF24SJwjnJARZaEFjNiSMz