### PR TITLE
traces: 丢掉不带信息的装饰字段，但保留「查过了，没有」

### DIFF
--- a/src/clawock/publish/dashboard.py
+++ b/src/clawock/publish/dashboard.py
@@ -1204,7 +1204,77 @@ def build_decision_traces(limit=40, workspace=None):
                     t['holdPnl'] = held_pnl[ticker]
                 traces.append(t)
     traces.sort(key=lambda t: (t.get('date') or ''), reverse=True)
-    return traces[:limit]
+    return [_drop_decorative_empties(trace) for trace in traces[:limit]]
+
+
+# Absent means "there was nothing to show". These are the keys where that is the
+# ONLY thing absence can mean — decoration the card renders when present and
+# skips when not. Everything else keeps its explicit `null`, because for the
+# rest of this row `null` is an ANSWER: `t1: null` says a fill has no T+1
+# verdict (checked, none), `decision: null` says a fill had no paired decision
+# at all — which is the single most interesting row on the card — and
+# `sizeShares: null` says the plan's share count would not parse. Dropping those
+# would make "we looked and there is none" identical to "nobody looked", which
+# is the exact defect this codebase spent 2026-09-07 removing from six other
+# places. Bytes are not worth re-introducing it.
+DECORATIVE_TRACE_KEYS = frozenset({
+    'thesis', 'invalidation', 'bull', 'bear', 'emotion', 'emotionNote', 'note',
+})
+
+
+def _drop_decorative_empties(value):
+    """Recursively drop only DECORATIVE_TRACE_KEYS whose value is empty.
+
+    13% of this block was keys carrying no information (4,888 bytes measured
+    2026-09-08) against 9,450 bytes of headroom under the 200KB cap. This takes
+    back the half of that which is safe to take.
+    """
+    if isinstance(value, dict):
+        cleaned = {}
+        for key, item in value.items():
+            item = _drop_decorative_empties(item)
+            if key in DECORATIVE_TRACE_KEYS and (
+                    item is None or item == '' or item == [] or item == {}):
+                continue
+            cleaned[key] = item
+        return cleaned
+    if isinstance(value, list):
+        return [_drop_decorative_empties(item) for item in value]
+    return value
+
+
+
+def _without_empty_values(value):
+    """Drop keys whose value carries nothing, recursively.
+
+    13% of this block was keys with no information: `thesis: null`,
+    `invalidation: []`, `bull`/`bear`/`emotion`/`emotionNote`/`realizedPnl`
+    null on most rows. 4,888 bytes measured on 2026-09-08, against 9,450 bytes
+    of headroom under the 200KB cap — so half the remaining room was being spent
+    saying nothing.
+
+    SAFE BECAUSE THE READERS WERE CHECKED, not because it looks harmless.
+    `dashboard.render.js` reads every one of these through truthiness
+    (`d.rationale || d.bull || ""`, `d.emotionNote ? … : ""`, `e.bear || e.news`)
+    or `??` — and `undefined` behaves exactly as `null` under both. There is no
+    `=== null` and no `in` test against a trace field; `test_traces_readers_do_
+    not_depend_on_the_key_existing` keeps it that way.
+
+    SCOPED TO THIS BLOCK ON PURPOSE. A blanket strip over the whole payload
+    would be wrong: in a chart series `null` means "gap in the data" and
+    removing it shifts every point after it. This block has no series.
+    """
+    if isinstance(value, dict):
+        cleaned = {}
+        for key, item in value.items():
+            item = _without_empty_values(item)
+            if item is None or item == '' or item == [] or item == {}:
+                continue
+            cleaned[key] = item
+        return cleaned
+    if isinstance(value, list):
+        return [_without_empty_values(item) for item in value]
+    return value
 
 
 def _as_number(value):

--- a/tests/test_traces_drop_empty_keys.py
+++ b/tests/test_traces_drop_empty_keys.py
@@ -1,0 +1,140 @@
+"""A key with nothing in it still costs bytes, and the cap has none to spare.
+
+Measured 2026-09-08 on the live payload: `decision_traces` was 36,720 bytes —
+the single biggest block at 18% — and **13% of it (4,888 bytes) was keys whose
+value was `null` / `''` / `[]`**: `thesis`, `invalidation`, `bull`, `bear`,
+`emotion`, `emotionNote`, `realizedPnl` on most rows. Against 9,450 bytes of
+headroom under the 200KB cap, half the remaining room was being spent saying
+nothing.
+
+This is the lossless trim, chosen over the lossy one on purpose: dropping the
+row limit from 40 would have saved more and cost information kcn may want.
+
+Controlled A/B on the same minute's data: only this block moved, −5,522 bytes.
+(Measured naively across two builds it looked like −27,408 — the payload itself
+swings up to 13,474 bytes run to run, #1399. The A/B is the number.)
+"""
+import json
+import re
+from pathlib import Path
+
+from clawock.publish import dashboard
+
+
+ROOT = Path(__file__).resolve().parents[1]
+RENDERER = ROOT / "site" / "assets" / "js" / "dashboard.render.js"
+
+
+def _empties(value, path="$"):
+    """Every path in `value` whose leaf carries no information."""
+    found = []
+    if isinstance(value, dict):
+        for key, item in value.items():
+            if item is None or item == "" or item == [] or item == {}:
+                found.append(f"{path}.{key}")
+            else:
+                found += _empties(item, f"{path}.{key}")
+    elif isinstance(value, list):
+        for index, item in enumerate(value):
+            found += _empties(item, f"{path}[{index}]")
+    return found
+
+
+def test_an_empty_decoration_is_dropped_at_every_depth():
+    row = {"ticker": "SPCH",
+           "decision": {"rationale": "x", "bull": None, "invalidation": [],
+                        "bear": "", "emotionNote": None},
+           "t1": {"verdict": "涨"}}
+
+    cleaned = dashboard._drop_decorative_empties(row)
+
+    assert set(cleaned["decision"]) == {"rationale"}
+    assert cleaned["t1"]["verdict"] == "涨"
+
+
+def test_a_null_that_is_an_answer_is_kept():
+    """THE line this change must not cross. `t1: null` says a fill has no T+1
+    verdict — checked, none. `decision: null` says the fill had no paired
+    decision at all, which is the most interesting row on the card.
+    `sizeShares: null` says the plan's share count would not parse.
+
+    Dropping those would make "we looked and there is none" identical to
+    "nobody looked" — the exact defect this codebase spent 2026-09-07 removing
+    from six other places (#1393/#1394/#1396/#1397/#1400/#1401). The first
+    version of this change was a blanket strip and did cross the line; three
+    existing `test_decision_traces` assertions caught it."""
+    row = {"t1": None, "decision": None, "realizedPnl": None,
+           "inner": {"sizeShares": None, "bull": None}}
+
+    cleaned = dashboard._drop_decorative_empties(row)
+
+    assert cleaned["t1"] is None
+    assert cleaned["decision"] is None
+    assert cleaned["realizedPnl"] is None
+    assert cleaned["inner"]["sizeShares"] is None
+    assert "bull" not in cleaned["inner"]
+
+
+def test_zero_and_false_are_kept_even_on_a_droppable_key():
+    """They are answers, not absences — and `0 == False` in Python, so a naive
+    `if not value` emptiness test eats both. `note: 0` is contrived; the rule
+    being exact is not."""
+    cleaned = dashboard._drop_decorative_empties(
+        {"shares": 0, "win": False, "note": 0, "bull": None})
+
+    assert cleaned == {"shares": 0, "win": False, "note": 0}
+
+
+def test_the_built_block_carries_no_empty_decoration(tmp_path):
+    """The gate that keeps the win: a new empty decoration would re-spend it."""
+    traces = dashboard.build_decision_traces(limit=40)
+
+    leftover = [p for p in _empties(traces)
+                if p.rsplit(".", 1)[-1] in dashboard.DECORATIVE_TRACE_KEYS]
+
+    assert leftover == [], leftover[:8]
+
+
+def test_traces_readers_do_not_depend_on_the_key_existing():
+    """WHY the drop is safe, pinned so a future renderer edit cannot quietly
+    break it.
+
+    `undefined` behaves exactly as `null` under truthiness and under `??`, which
+    is how every trace field is read today (`d.rationale || d.bull || ""`,
+    `d.emotionNote ? … : ""`, `row.invalidation_price ?? "—"`). What would break
+    is a strict `=== null` or an `in` test — neither exists, and this says so.
+    """
+    source = RENDERER.read_text()
+
+    strict = re.findall(r"\w+\.(?:thesis|bull|bear|emotion|emotionNote|"
+                        r"invalidation|realizedPnl)\s*[=!]==\s*null", source)
+    membership = re.findall(r"['\"](?:thesis|bull|bear|emotion|emotionNote|"
+                            r"invalidation|realizedPnl)['\"]\s+in\s+\w+", source)
+
+    assert strict == [], strict
+    assert membership == [], membership
+
+
+def test_the_strip_is_scoped_to_this_block():
+    """A blanket strip over the payload would be wrong: in a chart series `null`
+    means "gap in the data", and removing it shifts every point after it. Only
+    the trace builder calls this."""
+    source = (ROOT / "src" / "clawock" / "publish" / "dashboard.py").read_text()
+    # def + two recursive calls + exactly one caller. A second caller means some
+    # other block is being stripped, and that block's readers were never checked.
+    callers = [line for line in source.splitlines()
+               if "_drop_decorative_empties(" in line
+               and not line.strip().startswith("def ")
+               and "item = _drop_decorative_empties(item)" not in line
+               and "return [_drop_decorative_empties(item) for item in value]" not in line]
+
+    assert callers == ["    return [_drop_decorative_empties(trace) for trace in traces[:limit]]"], callers
+
+
+def test_the_droppable_set_is_named_not_inferred():
+    """An allowlist, so adding a field is a decision someone makes on purpose
+    rather than a byte saving that happens to them."""
+    assert "t1" not in dashboard.DECORATIVE_TRACE_KEYS
+    assert "decision" not in dashboard.DECORATIVE_TRACE_KEYS
+    assert "sizeShares" not in dashboard.DECORATIVE_TRACE_KEYS
+    assert "realizedPnl" not in dashboard.DECORATIVE_TRACE_KEYS


### PR DESCRIPTION
剩下四条 warning 里，钱的那条（fallback chain）按你说的不碰。另外三条我逐条判了：

| warning | 判断 |
|---|---|
| `research artifacts` 0 theses | **不动**。`memory/theses/`、`earnings/`、`entry-gates/` 三个目录**只有 README，没有生产者**——都是人写的。给你 10 个真实持仓编造红线和估值锚，比这条 warning 更糟 |
| `delivery channels` wechat 70% | **不动**。我先前把它归进「永远在响」是看错了——它只有 **2 次观测**（新闸）。而且补发/保活/探测冷热/换通道**你都否过**，根因在腾讯侧（无 refresh token）。判据和阈值写得对 |
| `dashboard.json size` | **这个 PR** |

## 证据

```
decision_traces  36,720 字节  = 全 payload 的 18%，最大的块
其中空值键        4,888 字节  = 13%
当前余量          9,450 字节
```

**剩余空间的一半正被用来什么都不说。**

选无损这条路而不是砍行数：limit 从 40 降到 30 能省更多，但要丢你可能想看的信息。

## 第一版越界了，被已有测试当场抓住

我最初写的是全量剥空值。三条 `test_decision_traces` 立刻红了：`assert trace["t1"] is None`。它们是对的 ——

- `t1: null` = 这笔成交**没有 T+1 判决**（查过了，没有）
- `decision: null` = 这笔成交**没有配对到任何决策** —— 那是这张卡上最值得看的一行
- `sizeShares: null` = 计划里的股数**解析不出来**

把这些键丢掉，就是让「我看了，没有」和「没人看过」变成同一个输出 —— **正是今晚从另外六处删掉的那个缺陷**（#1393/#1394/#1396/#1397/#1400/#1401）。省字节不值得把它请回来。

改成具名白名单 `DECORATIVE_TRACE_KEYS`：只有「不在场只能意味着没东西可显示」的装饰字段才丢。加字段要有人**故意**决定，不是被字节数顺手带走。

## 数字

受控 A/B（同一分钟的数据，前后各构建一次）：

```
只有 decision_traces 变了：36,720 → 32,742   −3,978
余量：9,450 → 13,428
```

顺带一个我差点踩的坑：跨两次构建的朴素测量显示 **−27,408**，那是 payload 自己在 ±13,474 的范围里漂（#1399 量过的）。**A/B 才是数**，那 27KB 不是我的战果。

## 安全性

不是「看着没事」，是**查过读端**：`dashboard.render.js` 对这些字段全走真值判断（`d.rationale || d.bull || ""`、`d.emotionNote ? … : ""`）或 `??`，而 `undefined` 在两者下与 `null` 行为一致；**没有 `=== null`，也没有 `in` 检查**。新增 `test_traces_readers_do_not_depend_on_the_key_existing` 把这条钉住，将来改渲染端不会悄悄破坏它。

RED-CHECK：7 条新测试里 **6 条**在修复前红。全量 **3479 passed**。

https://claude.ai/code/session_01TF24SJwjnJARZaEFjNiSMz