### PR TITLE
bars: 一个 tick 的下影线不是拆股

### DIFF
--- a/src/clawock/market_data/bars.py
+++ b/src/clawock/market_data/bars.py
@@ -216,6 +216,7 @@ CONFLICT_KINDS = (
     "uniform_rescale",     # every leg moved by the same ratio: adjustment signature
     "close_only",          # only the close moved: a settlement-price revision
     "rounding",            # every leg moved by < 5bp: precision, not information
+    "extreme_only",        # only a wick moved, by about a tick: nothing settles on it
     "bar_revision",        # anything else: a real disagreement about the session
 )
 
@@ -224,6 +225,12 @@ CONFLICT_KINDS = (
 ROUNDING_REL_TOL = 5e-4
 #: How close the four ratios must be to each other to read as one rescale.
 RESCALE_REL_TOL = 1e-3
+#: How far a high or low may be revised and still read as a tick on a wick.
+#: One tick is ~0.1% of a HK$2 board lot and ~0.2% of a HK$0.50 one, so 1%
+#: leaves an order of magnitude of headroom; above it the provider is
+#: disagreeing about the session's range itself, which is a `bar_revision`
+#: whether or not it touches a leg the ledger settles on.
+WICK_REL_TOL = 1e-2
 
 
 def classify_conflict(old: dict, fetched: dict) -> str:
@@ -248,6 +255,28 @@ def classify_conflict(old: dict, fetched: dict) -> str:
         return "rounding"
     if moved == ["close"]:
         return "close_only"
+    # The shape the log is actually full of (2026-09-08): the provider revises an
+    # intraday extreme by about one tick and leaves open and close alone. All 25
+    # rows ever recorded here move `low` and nothing else — NOT ONE moves open or
+    # close — and the largest is 0.107%, three cents on a $27.93 low. Eleven land
+    # under the rounding tolerance already; the other fourteen are this kind.
+    #
+    # It matters which name that gets. The ledger settles on `close`
+    # (`memory/bars` is the only store the settled views read), so a bar whose
+    # open and close are unchanged cannot move a number anything was settled
+    # against — while `bar_revision` is the kind whose remedy is `--repair`.
+    # Those fourteen were being reported as nine `uniform_rescale` — which names
+    # a SPLIT — and five `bar_revision`, two different wrong answers for one
+    # shape, decided by nothing more than which side of a spread test the
+    # untouched legs' ratios of exactly 1.0 happened to fall on.
+    #
+    # Above the rounding tolerance on purpose: this is not "too small to care
+    # about", it is "real, and confined to a leg nothing settles on". And bounded
+    # by `WICK_REL_TOL` on purpose too: a provider that moves the high 12% still
+    # disagrees about the session, wick or not.
+    if moved and not ({"open", "close"} & set(moved)):
+        if relative and max(relative) < WICK_REL_TOL:
+            return "extreme_only"
     ratios = [
         fetched[k] / old[k]
         for k in legs
@@ -256,7 +285,14 @@ def classify_conflict(old: dict, fetched: dict) -> str:
     ]
     if len(ratios) == len(legs):
         spread = max(ratios) - min(ratios)
-        if spread <= RESCALE_REL_TOL * max(abs(r) for r in ratios):
+        # A rescale is every leg moving by the SAME factor. The spread test alone
+        # cannot say that: when three legs are untouched their ratios are exactly
+        # 1.0, the spread is tiny, and "almost nothing moved" passes a test meant
+        # for "everything moved together" — which is how a one-cent low became a
+        # split seven times. Require the common factor to actually be a rescale.
+        common = sum(ratios) / len(ratios)
+        rescaled = abs(common - 1.0) > RESCALE_REL_TOL
+        if rescaled and spread <= RESCALE_REL_TOL * max(abs(r) for r in ratios):
             return "uniform_rescale"
     return "bar_revision"
 

--- a/tests/test_bar_conflict_classification.py
+++ b/tests/test_bar_conflict_classification.py
@@ -48,16 +48,28 @@ def test_the_four_shapes_of_a_disagreement_are_told_apart():
         stored, {'open': 10.001, 'high': 11.0, 'low': 9.0, 'close': 10.5}
     ) == 'rounding'
 
-    # Anything else is a real disagreement about what happened that session.
+    # Anything else is a real disagreement about what happened that session —
+    # including a 12.7% high, which moves no settled leg but is not a tick.
     assert bars.classify_conflict(
         stored, {'open': 10.0, 'high': 12.4, 'low': 9.0, 'close': 10.5}
     ) == 'bar_revision'
+
+    # A wick revised by about a tick, open and close untouched. The ledger
+    # settles on `close`, so this cannot move a number anything settled
+    # against — and it is above the rounding tolerance, so it is not noise
+    # either. It gets its own name instead of borrowing one that prescribes
+    # a remedy (`bar_revision` → `--repair`) or names a corporate action
+    # (`uniform_rescale` → a split).
+    assert bars.classify_conflict(
+        stored, {'open': 10.0, 'high': 11.0, 'low': 8.99, 'close': 10.5}
+    ) == 'extreme_only'
 
     # And the vocabulary is closed: every kind the classifier can emit is
     # declared, or a consumer counting kinds silently drops one.
     for fetched in ({'open': 5.0, 'high': 5.5, 'low': 4.5, 'close': 5.25},
                     {'open': 10.0, 'high': 11.0, 'low': 9.0, 'close': 10.7},
                     {'open': 10.001, 'high': 11.0, 'low': 9.0, 'close': 10.5},
+                    {'open': 10.0, 'high': 11.0, 'low': 8.99, 'close': 10.5},
                     {'open': 10.0, 'high': 12.4, 'low': 9.0, 'close': 10.5}):
         assert bars.classify_conflict(stored, fetched) in bars.CONFLICT_KINDS
 
@@ -177,3 +189,38 @@ def test_the_report_names_them_and_still_publishes(tmp_path, monkeypatch):
     assert noisy['warn_count'] == clean['warn_count'] + 1
     assert noisy['ok'] is True, 'a refused bar must never block a publish'
     assert noisy['bar_conflicts']['by_ticker'] == {'00100': 3}
+
+
+def test_a_one_tick_wick_is_never_called_a_split():
+    """The regression, in the shape the real log has it (2026-09-08).
+
+    Every one of the 25 refusals ever recorded moves `low` alone by about a
+    tick. Fourteen of them are above the rounding tolerance, and those fourteen
+    came back as nine `uniform_rescale` and five `bar_revision`: two different
+    wrong answers for one shape.
+
+    `uniform_rescale` is the worse of the two, and it is the one the spread test
+    hands out. That test asks "are the four ratios close together?", which is
+    the right question only when all four legs moved. When three legs are
+    untouched their ratios are exactly 1.0, so "almost nothing moved" scores
+    better on it than a genuine 2-for-1 does — a one-cent low reads as a
+    corporate action. The kind now has to include a common factor that is
+    actually not 1.
+    """
+    from clawock.market_data import bars
+
+    # The real 2026-09-01 row: a HK$14.12 low revised to HK$14.11.
+    stored = {'open': 14.26, 'high': 15.04, 'low': 14.12, 'close': 14.38}
+    fetched = dict(stored, low=14.11)
+    assert bars.classify_conflict(stored, fetched) == 'extreme_only'
+
+    # A real 2-for-1 still is one, so the guard did not close the door on the
+    # kind it protects.
+    half = {leg: value / 2 for leg, value in stored.items()}
+    assert bars.classify_conflict(stored, half) == 'uniform_rescale'
+
+    # And a wick moved far enough to be a disagreement about the session, not a
+    # tick on it, stays a `bar_revision` — the tolerance is a tick, not a
+    # licence for anything that misses open and close.
+    assert bars.classify_conflict(
+        stored, dict(stored, low=12.5)) == 'bar_revision'


### PR DESCRIPTION
## 现象

`memory/bar-conflicts.jsonl` 里 25 条 refusal，**形状只有一种**：只有 `low` 动了，
最大幅度 0.107%（ROBN 2026-09-02，$27.93 的低点改成 $27.90），open 与 close 一条
都没动。但落到日志里是三种名字：11 条 `rounding`、9 条 `uniform_rescale`、5 条
`bar_revision`。

## 两个缺陷

1. **spread 检验在腿没动的时候会把「几乎什么都没动」判成 rescale。**
   它问的是「四条腿的比值是不是彼此接近」——这只有在四条腿都动了时才是对的问题。
   三条腿未动时比值恰好 1.0，spread 极小，于是一分钱的低点得分比真正的 1 拆 2
   还高。现在要求共同因子 `|mean(ratios) - 1| > RESCALE_REL_TOL` 才算 rescale。

2. **词表里没有这个形状。** 账本按 `close` 结算（settled views 只读
   `memory/bars`），所以 open/close 未动的 bar 动不了任何已结算的数字；而
   `bar_revision` 的处置是 `--repair`。新增 `extreme_only`，并卡在 `WICK_REL_TOL`
   (1%) 以内——provider 把最高价改 12% 仍然是对成交区间的分歧，影线与否都一样。

## 重放真实日志

| | 现在 | 改后 |
|---|---|---|
| rounding | 11 | 11 |
| uniform_rescale | 9 | 0 |
| bar_revision | 5 | 0 |
| extreme_only | — | 14 |

（日志是 append-only 的，历史 14 行的旧名字不改写；健康报告的 30 天窗口滚出去后
自然干净。）

## RED-CHECK

master 版 `bars.py` 下新增断言红在
`AssertionError: assert 'uniform_rescale' == 'extreme_only'`，两条测试失败。

https://claude.ai/code/session_01Wh4JtsAL6pxuFv5PGR4zqX