### PR TITLE
delivery: CLI 不等了不等于网关没发

### DIFF
--- a/src/clawock/harness/_watchdog_common.py
+++ b/src/clawock/harness/_watchdog_common.py
@@ -397,8 +397,21 @@ def send_telegram(target, message, dry_run):
     Telegram is the cold-session-proof backup channel: unlike WeChat it has no
     idle-session silent-drop (the #81096/#81316 wontfix), so when the intraday
     watchdog judges a WeChat push probably dropped it mirrors here instead."""
-    result = _delivery().send('telegram', str(target), message, dry_run=dry_run)
+    result = telegram_result(target, message, dry_run)
     return result.status != 'failed', result.detail
+
+
+def telegram_result(target, message, dry_run):
+    """The full four-state result of a Telegram send, for callers that log it.
+
+    `send_telegram` collapses this to a boolean because every existing caller
+    branches on one. But `confirmed` (the gateway named a message id) and
+    `unknown` (we stopped waiting for it, or the exit lost a race with it) are
+    both `True` there, and a log that writes them the same way cannot answer
+    "did this slot actually go out" afterwards — which is the question the
+    2026-09-08 10:34 slot could not be asked.
+    """
+    return _delivery().send('telegram', str(target), message, dry_run=dry_run)
 
 
 BRIEF_CONTRACT_MODE = 'daily-deep-brief'
@@ -748,11 +761,18 @@ def cosend_telegram(message, tag, dry_run=False):
     ALWAYS also push the same body to Telegram (the cold-proof channel, @clawock_bot).
     A duplicate when WeChat did land is far cheaper than a silent miss. Best-effort:
     never raises; logs the outcome to watchdog.jsonl. Returns (ok, tail_of_output)."""
+    status = 'failed'
     try:
-        ok, out = send_telegram(KCN_TELEGRAM, message, dry_run)
+        result = telegram_result(KCN_TELEGRAM, message, dry_run)
+        ok, out, status = result.status != 'failed', result.detail, result.status
     except Exception as e:
         ok, out = False, str(e)[:300]
     entry = {'tag': tag, 'action': 'telegram-cosend', 'sent_ok': bool(ok),
+             # `sent_ok` answers "should anything else be done about this slot".
+             # It cannot also answer "did it arrive": a co-send that timed out
+             # waiting for the gateway is `unknown` and reads as True there.
+             # Write the status down so the two are separable in the log.
+             'status': status,
              'dry_run': bool(dry_run)}
     if not ok:
         # The failure tail used to be returned to a caller that dropped it, so a

--- a/src/clawock/providers/delivery.py
+++ b/src/clawock/providers/delivery.py
@@ -43,6 +43,15 @@ def delivery_disabled() -> bool:
 
 
 _MESSAGE_ID = re.compile(r'"messageId"\s*:\s*"?([^",\s}]+)', re.IGNORECASE)
+#: The runtime CLI's own way of saying it stopped waiting for its gateway. It
+#: exits non-zero with this, which is the same *event* as our subprocess timing
+#: out — not a refusal.
+_GATEWAY_TIMEOUT = re.compile(r"gateway timeout after \d+\s*ms", re.IGNORECASE)
+
+
+def _timed_out_waiting(output: str | None) -> bool:
+    """Whether a non-zero exit is the CLI giving up on its own gateway."""
+    return bool(output) and bool(_GATEWAY_TIMEOUT.search(output))
 
 
 def _names_a_message(output: str | None) -> bool:
@@ -114,12 +123,36 @@ class OpenClawDelivery:
         self.timeout = timeout
         self._runner = runner or self._run
 
+    def rpc_ceiling_ms(self) -> int:
+        """How long the CLI may wait for its gateway, in ms.
+
+        The CLI's own default is 10s and its floor is 10s
+        (`resolveGatewayCallTimeout`: a configured handshake timeout only counts
+        when it is *above* 10 000). That ceiling is below the gateway's real
+        tail latency on this host, and the CLI abandoning a call is not the
+        gateway abandoning the message: on 2026-09-08 the 10:34 intraday co-send
+        and the 10:43 watchdog mirror both gave up at 10 000 ms while the
+        gateway went on to hand Telegram messageId 1318 (after 16 499 ms) and
+        1319 (after 25 708 ms). The report was delivered twice and recorded as
+        never delivered.
+
+        So give the CLI a ceiling derived from the budget we already grant the
+        process, minus room for node's startup and teardown — one number, no
+        second knob to drift. Below the CLI's own floor this is inert, which is
+        why it never returns less than 10 000.
+        """
+        return max(10_000, int(self.timeout * 1000) - 15_000)
+
     def _run(self, cmd):
         # The runtime's own launcher needs `node` on PATH, so a job started from
         # the user crontab cannot spawn it with the PATH it inherited.
         from clawock.providers.openclaw import runtime_env
+        env = runtime_env()
+        # An operator who set this deliberately keeps it; nothing here is a
+        # better guess than a person who typed a number.
+        env.setdefault("OPENCLAW_HANDSHAKE_TIMEOUT_MS", str(self.rpc_ceiling_ms()))
         done = subprocess.run(cmd, capture_output=True, text=True,
-                              timeout=self.timeout, env=runtime_env())
+                              timeout=self.timeout, env=env)
         return done.returncode, (done.stdout + done.stderr)
 
     def send(self, channel: str, target: str, message: str, *,
@@ -161,7 +194,15 @@ class OpenClawDelivery:
             # that had already landed. When the transport's own output names a
             # message it accepted, treat the exit the way a timeout is treated:
             # `unknown`, which still mirrors, rather than `failed`.
-            status = "unknown" if _names_a_message(output) else "failed"
+            # A gateway timeout joins that rule for the same reason one step
+            # earlier: the CLI stopped waiting, which says nothing about what
+            # the gateway did next. Measured on 2026-09-08 — both of the day's
+            # "failed" sends were sitting in the gateway and went out at 16.5s
+            # and 25.7s. `failed` there wrote tg_ok=false into the marker, the
+            # watchdog read it as a miss and mirrored a report kcn already had.
+            status = ("unknown"
+                      if _names_a_message(output) or _timed_out_waiting(output)
+                      else "failed")
             return DeliveryResult(status, channel, str(target), detail=tail,
                                   idempotency_key=idempotency_key)
         status = "confirmed" if channel in CONFIRMING_CHANNELS else "unknown"

--- a/tests/test_cosend_failure_is_explained.py
+++ b/tests/test_cosend_failure_is_explained.py
@@ -8,6 +8,11 @@ line recorded only `sent_ok: false`. The reason belongs in the same record as
 the outcome that acts on it.
 """
 from clawock.harness import _watchdog_common as common
+from clawock.providers.delivery import DeliveryResult
+
+
+def _result(status, detail):
+    return DeliveryResult(status, 'telegram', '123', detail=detail)
 
 
 def _capture(monkeypatch):
@@ -18,8 +23,8 @@ def _capture(monkeypatch):
 
 def test_a_failed_cosend_records_the_transports_reason(monkeypatch):
     written = _capture(monkeypatch)
-    monkeypatch.setattr(common, 'send_telegram',
-                        lambda target, message, dry_run: (False, 'EPIPE: broken pipe'))
+    monkeypatch.setattr(common, 'telegram_result',
+                        lambda *a: _result('failed', 'EPIPE: broken pipe'))
 
     ok, _ = common.cosend_telegram('body', 'brief')
 
@@ -32,8 +37,8 @@ def test_a_silent_failure_says_so_rather_than_leaving_the_field_out(monkeypatch)
     """An empty tail is itself a finding — "the transport said nothing" is a
     different failure from "the transport explained itself"."""
     written = _capture(monkeypatch)
-    monkeypatch.setattr(common, 'send_telegram',
-                        lambda target, message, dry_run: (False, ''))
+    monkeypatch.setattr(common, 'telegram_result',
+                        lambda *a: _result('failed', ''))
 
     common.cosend_telegram('body', 'hk-open')
 
@@ -46,7 +51,7 @@ def test_a_raising_transport_is_recorded_as_the_exception(monkeypatch):
     def boom(target, message, dry_run):
         raise RuntimeError('gateway refused the connection')
 
-    monkeypatch.setattr(common, 'send_telegram', boom)
+    monkeypatch.setattr(common, 'telegram_result', boom)
 
     ok, _ = common.cosend_telegram('body', 'intraday-hk')
 
@@ -58,10 +63,33 @@ def test_a_successful_cosend_stays_a_one_line_record(monkeypatch):
     """No detail on success: the log is read by eye, and a reason field on a
     send that worked is noise that makes the failures harder to spot."""
     written = _capture(monkeypatch)
-    monkeypatch.setattr(common, 'send_telegram',
-                        lambda target, message, dry_run: (True, 'messageId 1164'))
+    monkeypatch.setattr(common, 'telegram_result',
+                        lambda *a: _result('confirmed', 'messageId 1164'))
 
     ok, _ = common.cosend_telegram('body', 'brief')
 
     assert ok is True
     assert 'detail' not in written[0]
+    assert written[0]['status'] == 'confirmed'
+
+
+def test_a_cosend_that_only_stopped_waiting_is_not_recorded_as_delivered(monkeypatch):
+    """2026-09-08 10:34: the co-send gave up at the CLI's 10s ceiling and the
+    gateway delivered the same card 6 seconds later (messageId 1318, 16 499ms).
+
+    `sent_ok` answers a different question — "does anything else need to be
+    done about this slot" — and `unknown` correctly answers no, because a
+    backstop through the same gateway would be the duplicate kcn actually got.
+    But it must not be the only thing written down, or the log says the slot was
+    delivered when what happened is that nobody ever found out.
+    """
+    written = _capture(monkeypatch)
+    monkeypatch.setattr(
+        common, 'telegram_result',
+        lambda *a: _result('unknown', 'gateway timeout after 10000ms'))
+
+    ok, _ = common.cosend_telegram('body', 'intraday-hk')
+
+    assert ok is True, 'unknown must not trigger a mirror through the same pipe'
+    assert written[0]['status'] == 'unknown'
+    assert written[0]['sent_ok'] is True

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -222,3 +222,69 @@ def test_running_a_cron_job_reports_instead_of_raising():
 
     ok, tail = run_cron_job("job-1", runner=explode)
     assert not ok and "TimeoutError" in tail
+
+
+def test_a_gateway_timeout_is_not_a_refusal():
+    """2026-09-08, measured on the desk: both of the day's "failed" sends landed.
+
+        10:34:20  co-send gives up      GatewayTransportError: gateway timeout
+                                        after 10000ms
+        10:34:30  gateway logs          [telegram] outbound send ok messageId=1318
+                  [ws] res ✓ message.action 16499ms
+        10:43:15  watchdog mirror       same 10000ms timeout
+        10:43:40  gateway logs          messageId=1319, 25708ms
+
+    The mirror at 10:43 exists only because 10:34 was written down as a
+    failure, so kcn got the 10:34 intraday card twice while `watchdog.jsonl`
+    recorded the slot as undelivered. The CLI giving up is not the gateway
+    giving up, and it is the same event as our own subprocess timeout — which
+    this file already calls `unknown` one test above.
+    """
+    out = ("GatewayTransportError: gateway timeout after 10000ms\n"
+           "Gateway target: ws://127.0.0.1:18789\nSource: local loopback")
+    sent = OpenClawDelivery(runner=lambda cmd: (1, out)).send(
+        "telegram", "123", "hello")
+
+    assert sent.status == "unknown"
+    assert sent.reached_target is False
+    # Still worth a backstop: `unknown` is not a claim that it arrived.
+    assert sent.worth_mirroring is True
+
+
+def test_the_cli_is_told_to_wait_as_long_as_we_are_waiting():
+    """The 10s ceiling is the CLI's default, and it is ours to raise.
+
+    `resolveGatewayCallTimeout` in the runtime takes the call timeout from the
+    handshake timeout whenever that is above its 10 000 floor, so one env var
+    moves it. Measured against a socket that accepts and never answers:
+    unset → gave up at 13.2s wall, `OPENCLAW_HANDSHAKE_TIMEOUT_MS=25000` →
+    28.0s. Nothing waits longer than the subprocess budget it was given, which
+    is where this number comes from.
+    """
+    import clawock.providers.delivery as delivery
+
+    seen = {}
+
+    class _Done:
+        returncode, stdout, stderr = 0, '{"messageId":"7"}', ""
+
+    def fake_run(cmd, **kwargs):
+        seen.update(kwargs)
+        return _Done()
+
+    original = delivery.subprocess.run
+    delivery.subprocess.run = fake_run
+    try:
+        provider = OpenClawDelivery(binary="/bin/true", timeout=60)
+        result = provider.send("telegram", "123", "hi")
+    finally:
+        delivery.subprocess.run = original
+
+    assert result.status == "confirmed"
+    assert seen["timeout"] == 60
+    assert seen["env"]["OPENCLAW_HANDSHAKE_TIMEOUT_MS"] == "45000"
+    # Under the process budget it is spawned with, always: a CLI still waiting
+    # when we kill it turns a reportable error into an opaque one.
+    assert int(seen["env"]["OPENCLAW_HANDSHAKE_TIMEOUT_MS"]) < 60 * 1000
+    # And never under the runtime's own floor, where it would be inert.
+    assert OpenClawDelivery(timeout=5).rpc_ceiling_ms() == 10_000


### PR DESCRIPTION
## 今天真实发生的事

2026-09-08 10:34 的港股盘中卡 **kcn 收到了两遍**，而 `logs/watchdog.jsonl` 记的是
一遍都没发出去（两行 `sent_ok: false`）。主机 journal 是直接证据：

```
10:34:20  co-send 放弃    GatewayTransportError: gateway timeout after 10000ms
10:34:30  网关            [telegram] outbound send ok messageId=1318
          [ws] ⇄ res ✓ message.action 16499ms
10:43:15  watchdog mirror 同一条 10000ms 超时
10:43:40  网关            messageId=1319   ← 25708ms
```

10:43 那条 mirror 之所以存在，只因为 10:34 被写成了 `failed`。当天全部 16 条
telegram 投递里，正常的 4 条 ws 耗时 830–1418ms，出事的两条是 16.5s 和 25.7s——
**尾延迟越过了 CLI 的 10 秒天花板，而投递本身一次都没断。**

## 两处修

**一、10 秒是 CLI 的默认值，而它归我们设。**
runtime 的 `resolveGatewayCallTimeout` 在 handshake timeout 高于 10 000 时拿它当
调用超时。对着一个只 accept 不回话的 socket 实测：

| | 放弃用时 |
|---|---|
| 不设 | 13.2s |
| `OPENCLAW_HANDSHAKE_TIMEOUT_MS=25000` | 28.0s |

新的天花板从进程本来就有的预算推出来（`timeout` 60s − node 起停余量 15s = 45s），
不新开第二个会漂的旋钮；低于 runtime 自己的 10s 下限时它本来就是空转，所以
`rpc_ceiling_ms()` 永远不返回比 10 000 更小的数。操作者显式设过的值不覆盖。

**二、网关超时不是拒收。**
`subprocess.TimeoutExpired` 这个文件早就判 `unknown`（注释写着「可能已经发出去了，
判 failed 会招来重复投递」）；CLI 自己喊的同一件事却掉进 `failed`。现在两者同判。

**副作用是有意的**：`unknown` ⇒ `send_telegram` 的 ok 为 True ⇒ marker `tg_ok=true`
⇒ 不补发。补发走的是**同一根管子**，今天那条补发就是 kcn 手上的第二张卡。网关真死
的时候 CLI 返回的是连接错误、不是超时，那条路仍然判 `failed` 并补发。

顺带把四态状态写进 co-send 日志：`sent_ok` 回答「这槽还需不需要别人接手」，
不能同时回答「到没到」。

## RED-CHECK

改前的 `delivery.py` 上两条新测试真跑出红：
`assert 'failed' == 'unknown'`、`KeyError: 'OPENCLAW_HANDSHAKE_TIMEOUT_MS'`。

https://claude.ai/code/session_01Wh4JtsAL6pxuFv5PGR4zqX