### PR TITLE
health: 冲突日志按自己带的证据判，而不是按写它那天的判词

### DIFF
--- a/src/clawock/bar_conflicts.py
+++ b/src/clawock/bar_conflicts.py
@@ -1,0 +1,101 @@
+"""Naming the shape of a stored-vs-fetched bar disagreement.
+
+Foundation-shaped, and here rather than in `market_data` for the reason #814
+moved four other modules to this level: it imports nothing from this package,
+and both the store that *writes* a refusal (`market_data.bars`) and the health
+report that *reads the log back* (`portfolio.integrity`) need it. Importing
+across those two packages the other way is a cycle, and a function-level import
+is not a fix for a cycle — it is a cycle that starts working.
+
+Nothing here touches a file. Two dicts in, one word out.
+"""
+from __future__ import annotations
+
+#: The closed vocabulary a refusal is classified into. Deliberately small, and
+#: deliberately about the *shape* of the disagreement rather than its cause —
+#: "the provider re-priced the whole bar by one ratio" is observable, "the
+#: provider applied a split" is a guess about someone else's system.
+CONFLICT_KINDS = (
+    "impossible_bar",      # fails the structural check outright — never stored
+    "uniform_rescale",     # every leg moved by the same ratio: adjustment signature
+    "close_only",          # only the close moved: a settlement-price revision
+    "rounding",            # every leg moved by < 5bp: precision, not information
+    "extreme_only",        # only a wick moved, by about a tick: nothing settles on it
+    "bar_revision",        # anything else: a real disagreement about the session
+)
+
+#: Below this, a difference is precision rather than information. 5bp of a
+#: HK$700 close is 35 cents — smaller than one tick on that board.
+ROUNDING_REL_TOL = 5e-4
+#: How close the four ratios must be to each other to read as one rescale.
+RESCALE_REL_TOL = 1e-3
+#: How far a high or low may be revised and still read as a tick on a wick.
+#: One tick is ~0.1% of a HK$2 board lot and ~0.2% of a HK$0.50 one, so 1%
+#: leaves an order of magnitude of headroom; above it the provider is
+#: disagreeing about the session's range itself, which is a `bar_revision`
+#: whether or not it touches a leg the ledger settles on.
+WICK_REL_TOL = 1e-2
+
+
+def classify_conflict(old: dict, fetched: dict) -> str:
+    """Name the shape of a stored-vs-fetched disagreement.
+
+    The store already refuses to overwrite; what it could not say is *what kind*
+    of disagreement it refused. A weekly stream of `rounding` and a single
+    `bar_revision` on a session the ledger settled against are the same line of
+    output today, and they call for opposite responses.
+    """
+    legs = ("open", "high", "low", "close")
+    moved = [k for k in legs
+             if abs(old.get(k, 0) - fetched.get(k, 0)) > 1e-9]
+    if not moved:
+        return "rounding"
+    relative = [
+        abs(old[k] - fetched[k]) / abs(old[k])
+        for k in legs
+        if isinstance(old.get(k), (int, float)) and old.get(k)
+    ]
+    if relative and max(relative) < ROUNDING_REL_TOL:
+        return "rounding"
+    if moved == ["close"]:
+        return "close_only"
+    # The shape the log is actually full of (2026-09-08): the provider revises an
+    # intraday extreme by about one tick and leaves open and close alone. All 25
+    # rows ever recorded here move `low` and nothing else — NOT ONE moves open or
+    # close — and the largest is 0.107%, three cents on a $27.93 low. Eleven land
+    # under the rounding tolerance already; the other fourteen are this kind.
+    #
+    # It matters which name that gets. The ledger settles on `close`
+    # (`memory/bars` is the only store the settled views read), so a bar whose
+    # open and close are unchanged cannot move a number anything was settled
+    # against — while `bar_revision` is the kind whose remedy is `--repair`.
+    # Those fourteen were being reported as nine `uniform_rescale` — which names
+    # a SPLIT — and five `bar_revision`, two different wrong answers for one
+    # shape, decided by nothing more than which side of a spread test the
+    # untouched legs' ratios of exactly 1.0 happened to fall on.
+    #
+    # Above the rounding tolerance on purpose: this is not "too small to care
+    # about", it is "real, and confined to a leg nothing settles on". And bounded
+    # by `WICK_REL_TOL` on purpose too: a provider that moves the high 12% still
+    # disagrees about the session, wick or not.
+    if moved and not ({"open", "close"} & set(moved)):
+        if relative and max(relative) < WICK_REL_TOL:
+            return "extreme_only"
+    ratios = [
+        fetched[k] / old[k]
+        for k in legs
+        if isinstance(old.get(k), (int, float)) and old.get(k)
+        and isinstance(fetched.get(k), (int, float))
+    ]
+    if len(ratios) == len(legs):
+        spread = max(ratios) - min(ratios)
+        # A rescale is every leg moving by the SAME factor. The spread test alone
+        # cannot say that: when three legs are untouched their ratios are exactly
+        # 1.0, the spread is tiny, and "almost nothing moved" passes a test meant
+        # for "everything moved together" — which is how a one-cent low became a
+        # split seven times. Require the common factor to actually be a rescale.
+        common = sum(ratios) / len(ratios)
+        rescaled = abs(common - 1.0) > RESCALE_REL_TOL
+        if rescaled and spread <= RESCALE_REL_TOL * max(abs(r) for r in ratios):
+            return "uniform_rescale"
+    return "bar_revision"

--- a/src/clawock/market_data/bars.py
+++ b/src/clawock/market_data/bars.py
@@ -207,94 +207,17 @@ def sane(b: dict) -> bool:
 #: a quarter and one that disagrees every week look identical there (#1146).
 CONFLICT_LOG = WS / "memory" / "bar-conflicts.jsonl"
 
-#: The closed vocabulary a refusal is classified into. Deliberately small, and
-#: deliberately about the *shape* of the disagreement rather than its cause —
-#: "the provider re-priced the whole bar by one ratio" is observable, "the
-#: provider applied a split" is a guess about someone else's system.
-CONFLICT_KINDS = (
-    "impossible_bar",      # fails the structural check outright — never stored
-    "uniform_rescale",     # every leg moved by the same ratio: adjustment signature
-    "close_only",          # only the close moved: a settlement-price revision
-    "rounding",            # every leg moved by < 5bp: precision, not information
-    "extreme_only",        # only a wick moved, by about a tick: nothing settles on it
-    "bar_revision",        # anything else: a real disagreement about the session
+#: The vocabulary, tolerances and classifier live one level up: the health
+#: report reads this log back, and `portfolio` importing `market_data` for the
+#: rule would close a package cycle. Re-exported so this module stays the one
+#: name its callers know.
+from clawock.bar_conflicts import (  # noqa: E402,F401
+    CONFLICT_KINDS,
+    ROUNDING_REL_TOL,
+    RESCALE_REL_TOL,
+    WICK_REL_TOL,
+    classify_conflict,
 )
-
-#: Below this, a difference is precision rather than information. 5bp of a
-#: HK$700 close is 35 cents — smaller than one tick on that board.
-ROUNDING_REL_TOL = 5e-4
-#: How close the four ratios must be to each other to read as one rescale.
-RESCALE_REL_TOL = 1e-3
-#: How far a high or low may be revised and still read as a tick on a wick.
-#: One tick is ~0.1% of a HK$2 board lot and ~0.2% of a HK$0.50 one, so 1%
-#: leaves an order of magnitude of headroom; above it the provider is
-#: disagreeing about the session's range itself, which is a `bar_revision`
-#: whether or not it touches a leg the ledger settles on.
-WICK_REL_TOL = 1e-2
-
-
-def classify_conflict(old: dict, fetched: dict) -> str:
-    """Name the shape of a stored-vs-fetched disagreement.
-
-    The store already refuses to overwrite; what it could not say is *what kind*
-    of disagreement it refused. A weekly stream of `rounding` and a single
-    `bar_revision` on a session the ledger settled against are the same line of
-    output today, and they call for opposite responses.
-    """
-    legs = ("open", "high", "low", "close")
-    moved = [k for k in legs
-             if abs(old.get(k, 0) - fetched.get(k, 0)) > 1e-9]
-    if not moved:
-        return "rounding"
-    relative = [
-        abs(old[k] - fetched[k]) / abs(old[k])
-        for k in legs
-        if isinstance(old.get(k), (int, float)) and old.get(k)
-    ]
-    if relative and max(relative) < ROUNDING_REL_TOL:
-        return "rounding"
-    if moved == ["close"]:
-        return "close_only"
-    # The shape the log is actually full of (2026-09-08): the provider revises an
-    # intraday extreme by about one tick and leaves open and close alone. All 25
-    # rows ever recorded here move `low` and nothing else — NOT ONE moves open or
-    # close — and the largest is 0.107%, three cents on a $27.93 low. Eleven land
-    # under the rounding tolerance already; the other fourteen are this kind.
-    #
-    # It matters which name that gets. The ledger settles on `close`
-    # (`memory/bars` is the only store the settled views read), so a bar whose
-    # open and close are unchanged cannot move a number anything was settled
-    # against — while `bar_revision` is the kind whose remedy is `--repair`.
-    # Those fourteen were being reported as nine `uniform_rescale` — which names
-    # a SPLIT — and five `bar_revision`, two different wrong answers for one
-    # shape, decided by nothing more than which side of a spread test the
-    # untouched legs' ratios of exactly 1.0 happened to fall on.
-    #
-    # Above the rounding tolerance on purpose: this is not "too small to care
-    # about", it is "real, and confined to a leg nothing settles on". And bounded
-    # by `WICK_REL_TOL` on purpose too: a provider that moves the high 12% still
-    # disagrees about the session, wick or not.
-    if moved and not ({"open", "close"} & set(moved)):
-        if relative and max(relative) < WICK_REL_TOL:
-            return "extreme_only"
-    ratios = [
-        fetched[k] / old[k]
-        for k in legs
-        if isinstance(old.get(k), (int, float)) and old.get(k)
-        and isinstance(fetched.get(k), (int, float))
-    ]
-    if len(ratios) == len(legs):
-        spread = max(ratios) - min(ratios)
-        # A rescale is every leg moving by the SAME factor. The spread test alone
-        # cannot say that: when three legs are untouched their ratios are exactly
-        # 1.0, the spread is tiny, and "almost nothing moved" passes a test meant
-        # for "everything moved together" — which is how a one-cent low became a
-        # split seven times. Require the common factor to actually be a rescale.
-        common = sum(ratios) / len(ratios)
-        rescaled = abs(common - 1.0) > RESCALE_REL_TOL
-        if rescaled and spread <= RESCALE_REL_TOL * max(abs(r) for r in ratios):
-            return "uniform_rescale"
-    return "bar_revision"
 
 
 def record_conflicts(ticker: str, conflicts: list[dict], path: Path | None = None) -> int:

--- a/src/clawock/portfolio/integrity.py
+++ b/src/clawock/portfolio/integrity.py
@@ -280,6 +280,35 @@ def check_share_ledgers(portfolios):
 BAR_CONFLICT_WINDOW_DAYS = 30
 
 
+
+def _kind_of(row) -> str:
+    """The kind of one logged refusal, classified from the row's own payload.
+
+    A row carries `stored` and `fetched`, and `kind` is what the classifier
+    said on the day it was written — two different things, and the second can
+    go stale. It did: until 2026-09-08 a one-tick low read as `uniform_rescale`
+    (#1404), so the desk's whole 30-day window is labelled with nine "splits"
+    and five "revisions" that are all the same benign shape. The log is
+    append-only on purpose — history is not rewritten to look better — but the
+    *summary* is a reading of it, and reading it with today's classifier is
+    strictly more faithful than quoting a verdict the code no longer stands
+    behind.
+
+    The recorded kind still wins whenever the payload is not there to re-read
+    (older rows, a hand-written line), because inventing a classification from
+    nothing is the one answer worse than a stale one.
+    """
+    stored, fetched = row.get('stored'), row.get('fetched')
+    if isinstance(stored, dict) and isinstance(fetched, dict):
+        try:
+            from clawock.market_data.bars import classify_conflict
+
+            return classify_conflict(stored, fetched)
+        except Exception:
+            pass
+    return str(row.get('kind') or 'unknown')
+
+
 def summarize_bar_conflicts(log_path=None, *, now=None,
                             window_days=BAR_CONFLICT_WINDOW_DAYS) -> dict:
     """Count the canonical store's refused provider disagreements (#1146).
@@ -324,7 +353,7 @@ def summarize_bar_conflicts(log_path=None, *, now=None,
         seen_at = str(row.get('seen_at') or '')
         if seen_at[:10] < cutoff:
             continue
-        kind = str(row.get('kind') or 'unknown')
+        kind = _kind_of(row)
         ticker = str(row.get('ticker') or 'unknown')
         summary['total'] += 1
         summary['by_kind'][kind] = summary['by_kind'].get(kind, 0) + 1

--- a/src/clawock/portfolio/integrity.py
+++ b/src/clawock/portfolio/integrity.py
@@ -72,6 +72,7 @@ import sys
 from datetime import date, datetime, timedelta
 from pathlib import Path
 
+from clawock.bar_conflicts import classify_conflict
 from clawock.workspace import workspace_root
 
 WS = workspace_root()
@@ -301,8 +302,6 @@ def _kind_of(row) -> str:
     stored, fetched = row.get('stored'), row.get('fetched')
     if isinstance(stored, dict) and isinstance(fetched, dict):
         try:
-            from clawock.market_data.bars import classify_conflict
-
             return classify_conflict(stored, fetched)
         except Exception:
             pass

--- a/tests/test_bar_conflict_classification.py
+++ b/tests/test_bar_conflict_classification.py
@@ -13,6 +13,7 @@ publish, because the bars were not written and nothing downstream is wrong.
 """
 
 import json
+from datetime import datetime, timezone
 from pathlib import Path
 
 
@@ -224,3 +225,48 @@ def test_a_one_tick_wick_is_never_called_a_split():
     # licence for anything that misses open and close.
     assert bars.classify_conflict(
         stored, dict(stored, low=12.5)) == 'bar_revision'
+
+
+def test_the_summary_classifies_from_the_payload_not_from_the_stale_label(tmp_path):
+    """The log is append-only; the reading of it is not frozen with it.
+
+    Every one of the desk's 25 refusals is a one-tick `low` revision, but the
+    classifier that labelled them called nine of them `uniform_rescale` — a
+    split — and five `bar_revision`, whose remedy is `--repair` (#1404). Those
+    labels sit in the file for the whole 30-day window, and the data-health card
+    reads the file. Re-classifying from the `stored`/`fetched` each row already
+    carries costs nothing and stops the card from reporting corporate actions
+    that never happened.
+    """
+    from clawock.portfolio import integrity
+
+    log = tmp_path / 'bar-conflicts.jsonl'
+    stored = {'open': 14.26, 'high': 15.04, 'low': 14.12, 'close': 14.38}
+    log.write_text(json.dumps({
+        'ticker': 'HOOD', 'date': '2026-09-01', 'kind': 'uniform_rescale',
+        'seen_at': '2026-09-03T08:00:48+08:00',
+        'stored': stored, 'fetched': dict(stored, low=14.11),
+    }) + '\n')
+
+    summary = integrity.summarize_bar_conflicts(
+        log, now=datetime(2026, 9, 8, tzinfo=timezone.utc))
+
+    assert summary['by_kind'] == {'extreme_only': 1}
+
+
+def test_a_row_without_a_payload_keeps_the_kind_it_was_written_with(tmp_path):
+    """Re-reading needs something to re-read. With no `stored`/`fetched` the
+    recorded verdict is the only evidence there is, and a summary that invented
+    one instead would be worse than a stale label, not better."""
+    from clawock.portfolio import integrity
+
+    log = tmp_path / 'bar-conflicts.jsonl'
+    log.write_text(json.dumps({
+        'ticker': 'SPCH', 'date': '2026-09-01', 'kind': 'close_only',
+        'seen_at': '2026-09-03T08:00:48+08:00',
+    }) + '\n')
+
+    summary = integrity.summarize_bar_conflicts(
+        log, now=datetime(2026, 9, 8, tzinfo=timezone.utc))
+
+    assert summary['by_kind'] == {'close_only': 1}


### PR DESCRIPTION
## 现在牌面上写的

```
🟡 BAR_CONFLICT  canonical bars: 25 refused provider disagreement(s) in 30d
                 — rounding 11, uniform_rescale 9, bar_revision 5
```

这 25 条**全是同一个形状**：只有 `low` 动了，最大 0.107%。`uniform_rescale` 说的是
拆股，`bar_revision` 的处置是 `--repair`——两个都不是真的。分类器本身在 #1404 已
修，但旧标签留在文件里，牌面还要照着念两周。

## 改法

日志 append-only，历史一个字不动；**摘要是对它的一次阅读**，而每一行都带着
`stored` 和 `fetched`。用今天的分类器读那份证据：

| | 现在 | 改后 |
|---|---|---|
| rounding | 11 | 11 |
| uniform_rescale | 9 | 0 |
| bar_revision | 5 | 0 |
| extreme_only | — | 14 |

（在 live 日志上实跑的结果，不是构造的样本。）

没有 payload 的行——更早的格式、手写的行——仍然用记下来的 `kind`：无中生有的分类
是唯一比过期分类更糟的答案。

## RED-CHECK

改前 `by_kind == {'uniform_rescale': 1}`，新断言红在期望的 `{'extreme_only': 1}`。

https://claude.ai/code/session_01Wh4JtsAL6pxuFv5PGR4zqX