### PR TITLE
runtime: 120 秒的预算给了进程，没给进程里那个 CLI

### DIFF
--- a/src/clawock/providers/delivery.py
+++ b/src/clawock/providers/delivery.py
@@ -124,35 +124,24 @@ class OpenClawDelivery:
         self._runner = runner or self._run
 
     def rpc_ceiling_ms(self) -> int:
-        """How long the CLI may wait for its gateway, in ms.
+        """How long the CLI may wait for its gateway, in ms — see #1405.
 
-        The CLI's own default is 10s and its floor is 10s
-        (`resolveGatewayCallTimeout`: a configured handshake timeout only counts
-        when it is *above* 10 000). That ceiling is below the gateway's real
-        tail latency on this host, and the CLI abandoning a call is not the
-        gateway abandoning the message: on 2026-09-08 the 10:34 intraday co-send
-        and the 10:43 watchdog mirror both gave up at 10 000 ms while the
-        gateway went on to hand Telegram messageId 1318 (after 16 499 ms) and
-        1319 (after 25 708 ms). The report was delivered twice and recorded as
-        never delivered.
-
-        So give the CLI a ceiling derived from the budget we already grant the
-        process, minus room for node's startup and teardown — one number, no
-        second knob to drift. Below the CLI's own floor this is inert, which is
-        why it never returns less than 10 000.
+        The rule lives with the runtime it is about, because every call that
+        spawns that CLI needs it, not only this one.
         """
-        return max(10_000, int(self.timeout * 1000) - 15_000)
+        from clawock.providers.openclaw import rpc_ceiling_ms
+
+        return rpc_ceiling_ms(self.timeout)
 
     def _run(self, cmd):
         # The runtime's own launcher needs `node` on PATH, so a job started from
-        # the user crontab cannot spawn it with the PATH it inherited.
+        # the user crontab cannot spawn it with the PATH it inherited. And the
+        # CLI must be told to wait as long as we are waiting, or it abandons the
+        # gateway at 10s inside a 60s budget.
         from clawock.providers.openclaw import runtime_env
-        env = runtime_env()
-        # An operator who set this deliberately keeps it; nothing here is a
-        # better guess than a person who typed a number.
-        env.setdefault("OPENCLAW_HANDSHAKE_TIMEOUT_MS", str(self.rpc_ceiling_ms()))
         done = subprocess.run(cmd, capture_output=True, text=True,
-                              timeout=self.timeout, env=env)
+                              timeout=self.timeout,
+                              env=runtime_env(call_timeout=self.timeout))
         return done.returncode, (done.stdout + done.stderr)
 
     def send(self, channel: str, target: str, message: str, *,

--- a/src/clawock/providers/openclaw.py
+++ b/src/clawock/providers/openclaw.py
@@ -155,8 +155,35 @@ def _resolve_binary(env: Mapping[str, str], name: str = "openclaw") -> str:
     return name
 
 
-def runtime_env(env: Mapping[str, str] | None = None) -> dict:
+#: The runtime CLI's own floor for a gateway call: `resolveGatewayCallTimeout`
+#: takes a configured handshake timeout only when it is ABOVE this, so asking
+#: for less is inert.
+GATEWAY_CALL_FLOOR_MS = 10_000
+#: Room left inside a subprocess budget for node to start and stop. The CLI must
+#: give up before we kill it, or a reportable error becomes an opaque one.
+SPAWN_OVERHEAD_MS = 15_000
+
+
+def rpc_ceiling_ms(timeout_s: float) -> int:
+    """How long the CLI may wait for its gateway, given our budget for it, in ms.
+
+    The CLI defaults to 10s, and 10s is below this gateway's real tail latency:
+    on 2026-09-08 two sends were abandoned at 10 000 ms while the gateway went
+    on to hand Telegram messageId 1318 (16 499 ms) and 1319 (25 708 ms) — see
+    #1405. Every subprocess we spawn already carries a budget, so derive the
+    ceiling from that one number instead of adding a knob that can drift away
+    from it.
+    """
+    return max(GATEWAY_CALL_FLOOR_MS, int(timeout_s * 1000) - SPAWN_OVERHEAD_MS)
+
+
+def runtime_env(env: Mapping[str, str] | None = None, *,
+                call_timeout: float | None = None) -> dict:
     """Environment for spawning the runtime, with a PATH it can actually run on.
+
+    `call_timeout` is the subprocess budget the caller is about to grant, in
+    seconds. Passing it makes the CLI wait that long for its gateway instead of
+    its own 10s — the difference between a slow gateway and a missing one.
 
     Resolving the launcher is not enough: the pnpm launcher is a shell script
     whose last line is `exec node …`, so a bare cron PATH turns
@@ -176,6 +203,11 @@ def runtime_env(env: Mapping[str, str] | None = None) -> dict:
                for item in base.iterdir()):
             existing.append(entry)
     resolved["PATH"] = os.pathsep.join(existing)
+    if call_timeout is not None:
+        # An operator who set this deliberately keeps it; nothing here is a
+        # better guess than a person who typed a number.
+        resolved.setdefault("OPENCLAW_HANDSHAKE_TIMEOUT_MS",
+                            str(rpc_ceiling_ms(call_timeout)))
     return resolved
 
 
@@ -199,6 +231,13 @@ def runtime_paths(environ: Mapping[str, str] | None = None) -> OpenClawPaths:
 # `cron list --json` round-trips through the gateway and has been observed at
 # ~42s on a loaded host. A tight timeout trips TimeoutExpired, which callers
 # read as "no data" and quietly fall back to a stale source.
+#
+# That budget only ever belonged to the subprocess. The CLI inside it was still
+# abandoning the gateway at its own 10s (measured idle on 2026-09-08: three
+# `cron list --json` at 7.6s, 3.3s, 3.0s — the first already two thirds of the
+# way to the ceiling), so the 42s read this number was chosen for could not
+# have completed and the fallback it was chosen to prevent happened anyway.
+# `runtime_env(call_timeout=…)` is what makes the CLI serve the same budget.
 CRON_TIMEOUT_SECONDS = 120
 
 
@@ -215,7 +254,8 @@ def cron_cli_json(cli_args, *, binary: str | None = None,
     """
     selected_binary = binary or runtime_paths().binary
     run = runner or (lambda cmd: subprocess.run(
-        cmd, capture_output=True, text=True, timeout=timeout, env=runtime_env()))
+        cmd, capture_output=True, text=True, timeout=timeout,
+        env=runtime_env(call_timeout=timeout)))
     try:
         done = run([selected_binary, "cron", *cli_args])
         # Deliberately NOT gated on returncode: the original helper parsed
@@ -248,7 +288,8 @@ def run_cron_job(job_id, *, binary: str | None = None,
     """
     selected_binary = binary or runtime_paths().binary
     run = runner or (lambda cmd: subprocess.run(
-        cmd, capture_output=True, text=True, timeout=timeout, env=runtime_env()))
+        cmd, capture_output=True, text=True, timeout=timeout,
+        env=runtime_env(call_timeout=timeout)))
     try:
         done = run([selected_binary, "cron", "run", str(job_id)])
         tail = ((done.stdout or "") + (done.stderr or ""))[-400:]

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -288,3 +288,61 @@ def test_the_cli_is_told_to_wait_as_long_as_we_are_waiting():
     assert int(seen["env"]["OPENCLAW_HANDSHAKE_TIMEOUT_MS"]) < 60 * 1000
     # And never under the runtime's own floor, where it would be inert.
     assert OpenClawDelivery(timeout=5).rpc_ceiling_ms() == 10_000
+
+
+def test_a_cron_read_gives_the_cli_the_same_budget_it_gives_the_process():
+    """`CRON_TIMEOUT_SECONDS` was 120s of subprocess and 10s of CLI (#1405).
+
+    The comment on that constant says a tight timeout makes callers "read as
+    'no data' and quietly fall back to a stale source" — which is exactly what
+    the CLI's own 10s ceiling was doing inside the 120s, unseen. `read_jobs`
+    then drops to SQLite or to the fossil JSONL it prints STALE over, and
+    `brief_cron_job` returns None and logs the brief watchdog inert for the
+    slot. Both happen precisely when the host is loaded enough to be slow.
+    """
+    from types import SimpleNamespace
+
+    import clawock.providers.openclaw as openclaw
+
+    seen = {}
+
+    def fake_run(cmd, **kwargs):
+        seen['cmd'] = cmd
+        seen.update(kwargs)
+        return SimpleNamespace(returncode=0, stdout='{"jobs": []}', stderr='')
+
+    original = openclaw.subprocess.run
+    openclaw.subprocess.run = fake_run
+    try:
+        assert openclaw.cron_cli_json(['list', '--json']) == {'jobs': []}
+    finally:
+        openclaw.subprocess.run = original
+
+    assert seen['cmd'][1:] == ['cron', 'list', '--json']
+    assert seen['timeout'] == openclaw.CRON_TIMEOUT_SECONDS == 120
+    assert seen['env']['OPENCLAW_HANDSHAKE_TIMEOUT_MS'] == '105000'
+
+
+def test_the_ceiling_is_one_rule_for_every_call_that_spawns_the_runtime():
+    from clawock.providers.delivery import OpenClawDelivery
+    from clawock.providers.openclaw import (
+        GATEWAY_CALL_FLOOR_MS, rpc_ceiling_ms, runtime_env)
+
+    # Same rule, whoever asks.
+    assert OpenClawDelivery(timeout=60).rpc_ceiling_ms() == rpc_ceiling_ms(60)
+    # Under the process budget always: a CLI still waiting when we kill it turns
+    # a reportable error into an opaque one.
+    for budget in (30, 60, 120, 600):
+        assert rpc_ceiling_ms(budget) < budget * 1000
+    # Never below the runtime's own floor, where asking would be inert.
+    assert rpc_ceiling_ms(1) == GATEWAY_CALL_FLOOR_MS
+
+    # And nothing is set when no budget was named — this env is a statement
+    # about one call, not a global.
+    assert 'OPENCLAW_HANDSHAKE_TIMEOUT_MS' not in runtime_env({'PATH': '/usr/bin'})
+    assert runtime_env({'PATH': '/usr/bin'}, call_timeout=60)[
+        'OPENCLAW_HANDSHAKE_TIMEOUT_MS'] == '45000'
+    # An operator who typed a number keeps it.
+    kept = runtime_env({'PATH': '/usr/bin', 'OPENCLAW_HANDSHAKE_TIMEOUT_MS': '7'},
+                       call_timeout=60)
+    assert kept['OPENCLAW_HANDSHAKE_TIMEOUT_MS'] == '7'


### PR DESCRIPTION
## 一条注释把自己写的事情做反了

```python
# `cron list --json` round-trips through the gateway and has been observed at
# ~42s on a loaded host. A tight timeout trips TimeoutExpired, which callers
# read as "no data" and quietly fall back to a stale source.
CRON_TIMEOUT_SECONDS = 120
```

那 120 秒**只属于 subprocess**。里面那个 CLI 仍然在自己的 10 秒放弃网关
（#1405 量到的同一个天花板）。于是：

- 注释里那次 **42 秒的读取根本不可能完成**；
- 它想拦住的退化照样发生——`read_jobs` 掉到 SQLite，或掉到那份自己打着 `STALE`
  的 fossil JSONL；`brief_cron_job` 返回 None，日志记「brief watchdog cannot
  identify its cron job — re-run and retry-budget limbs are inert this slot」；
- **而这只在主机慢到那个程度时发生，也就是最需要它的时候。**

09-08 空载实测三次 `cron list --json`：**7.6s / 3.3s / 3.0s**——第一次已经走完了
天花板的三分之二。今天两条投递的 ws 往返是 16.5s 和 25.7s，同一个网关。

## 改法

把 #1405 那条规则从 `delivery.py` 挪进它该在的地方（`providers/openclaw.py`），
成为「谁 spawn 这个 runtime 谁用」的一条规则：

- `rpc_ceiling_ms(budget)` = `max(10_000, budget*1000 - 15_000)`
- `runtime_env(call_timeout=…)` 一处生效，不传就什么都不设（这是关于**一次调用**
  的声明，不是全局开关）
- 两个 cron 调用点把自己的预算交给 CLI：120s ⇒ 105 000ms
- `OpenClawDelivery.rpc_ceiling_ms()` 改成转调同一条规则

天花板永远**低于**进程预算：CLI 得赶在我们杀它之前自己报错，否则一个能读的错误会
变成一个读不出的错误。也永远**不低于** runtime 自己的 10s 下限——低于那里问了白问。
操作者显式设过的值一律不覆盖。

## RED-CHECK

改前 `cron_cli_json` 交给 subprocess 的 env 上
`KeyError: 'OPENCLAW_HANDSHAKE_TIMEOUT_MS'`。

https://claude.ai/code/session_01Wh4JtsAL6pxuFv5PGR4zqX