### PR TITLE
debate: 别让模型拼引用 id，把拼好的给它

### DIFF
--- a/skills/daily-deep-brief/SKILL.md
+++ b/skills/daily-deep-brief/SKILL.md
@@ -761,10 +761,9 @@ postflight 严格 schema 校验：
   - `judge`：Judge 的合成判词一句话（不是 Bull/Bear 的复述）。
   - `evidence_ids`（≤6 条，选填）：这场辩论**站在**哪几条 context 证据上（#1141）。只认三个能被解析的命名空间，postflight 逐条对着本次 context 核，**核不上的直接丢掉并记一条 degradation**（不会让流水线变红，但会被数出来）：
     - `news:<event_id>` —— `context.news_evidence_graph.events[].event_id`
-    - `risk:<type>`、`risk:<type>:<ticker>` 或 `risk:<type>:<leg>` —— `context.risk_guardrail` 的 breach / hard_stop_watch / concentration_review：
-      - 可引的 `<type>` 全集（**逐字照抄那一行自己的 `type` 字段**）：`single_name`、`single_name_review`、`leveraged_exposure`、`leveraged_hard_stop`、`regime_delever`、`factor_concentration`、`beta`
-      - 带票的行用 `:<ticker>`；`ticker` 为 null 的**整条腿**的闸用 `:<leg>`（`HK` / `US` / `BOOK`）或者干脆不带后缀
-      - 别自己起名（`concentration`、`hard_stop` 这种核不上），也**不要从那行的 `action` 文案里捞一个 ticker 拼上去**——那样引用的是一个不存在的行
+    - `risk:…` —— **照抄那一行的 `evidence_id` 字段**。`context.risk_guardrail` 的 breach / hard_stop_watch / concentration_review 每一行都自带一条，形如 `risk:single_name_review:00100`；你不需要拼，也不要拼。
+      - 这条规则以前是一段语法（命名空间 + `<type>` 全集 + ticker 形还是 leg 形 + 「别自己起名」），2026-09-08 仍然被拼成 `risk:single_name:00100` 去指一行 `type` 是 `single_name_review` 的记录——票是对的，名字取了另一行合法拥有的那一半。所以现在只有一条：**那一行写着什么就抄什么**。
+      - 想引整条腿的闸（`leveraged_exposure`、`beta` 这种 `ticker` 为 null 的行）同理，它的 `evidence_id` 已经是 `:<leg>` 形。
     - `quant:<ticker>:<field>` —— `context.quant_signals.rows[<ticker>]` 上一个非空字段（如 `quant:SPCH:dist_ma200_pct`）。**只有 `rows` 里真有的 ticker 能引**：杠杆 ETF 通常没有自己的行（07226 没有，它的底层 HSTECH 有），要引就引你真正读的那一行
     **没有可引的证据就不填**，别为了填而造 id：造出来的引用比不引更糟，它看起来像证据。portable workflow lane 早就要求每个 case 带 `evidence_ids`（`workflows/validators.py`），这里是把同一条纪律接到日报这条 lane 上。
   - **不会因为格式错误让 08:00 流水线变红**：postflight 的 normalizer 会裁剪超长文本、丢弃未知键与不在枚举内的 frame，整块为空则记为「没写」。但缺席是被数出来的——dashboard 的 `debate_coverage.bear_case_pct` 就是这条纪律的实测曲线，别用空块凑覆盖率。

--- a/src/clawock/decision/risk.py
+++ b/src/clawock/decision/risk.py
@@ -418,6 +418,36 @@ def _standing(record: dict) -> dict:
     }
 
 
+#: The three lists a guardrail context carries, in the order the brief reads them.
+GUARDRAIL_ROW_KEYS = ("breaches", "hard_stop_watch", "concentration_reviews")
+
+
+def evidence_ref(row: dict) -> str:
+    """The debate citation that resolves to this exact row.
+
+    Composed here, once, so the model that cites it and the postflight that
+    resolves it are reading the same string rather than two descriptions of one
+    (#1141). The SKILL used to spell the grammar out — namespace, the full list
+    of legal `type` values, ticker form vs leg form, "do not invent a name" —
+    and the model still spent 2026-09-08 citing `risk:single_name:00100` at a
+    row whose own type is `single_name_review`: right row, wrong half of a name
+    that another row legitimately carries. A rule the model will not follow is
+    a wish, not a rule; the fix is to stop asking it to compose an identifier
+    and hand it one to copy.
+
+    Ticker first, then leg: a cap on a name is about the name, and a leg-level
+    breach (`leveraged_exposure`, `beta`) has no ticker to be about.
+    """
+    kind = str(row.get("type") or "").strip()
+    if not kind:
+        return ""
+    for scope in (row.get("ticker"), row.get("leg")):
+        scoped = str(scope or "").strip()
+        if scoped:
+            return f"risk:{kind}:{scoped}"
+    return f"risk:{kind}"
+
+
 def attach_breach_ids(guardrail: dict) -> dict:
     """Return a context copy whose current detector rows carry stable IDs."""
     out = copy.deepcopy(guardrail)
@@ -427,6 +457,14 @@ def attach_breach_ids(guardrail: dict) -> dict:
     for row in out.get("hard_stop_watch") or []:
         row["breach_id"] = _stable_id(
             "hard_stop", row.get("leg"), row.get("ticker"))
+    # Every row, including the concentration reviews `breach_id` skips: a review
+    # is not a breach, but it is just as citable, and it was the one the model
+    # got wrong.
+    for key in GUARDRAIL_ROW_KEYS:
+        for row in out.get(key) or []:
+            ref = evidence_ref(row)
+            if ref:
+                row["evidence_id"] = ref
     return out
 
 

--- a/src/clawock/harness/brief_postflight.py
+++ b/src/clawock/harness/brief_postflight.py
@@ -235,8 +235,14 @@ def _citable_refs(context) -> set[str]:
             refs.add(f'news:{event_id}')
 
     guardrail = context.get('risk_guardrail') or {}
-    for key in ('breaches', 'hard_stop_watch', 'concentration_reviews'):
+    for key in risk_discipline.GUARDRAIL_ROW_KEYS:
         for row in guardrail.get(key) or []:
+            # The one the row itself advertises. Reading the same field the
+            # context hands the model is what makes "copy this" true — a
+            # second spelling of the grammar here is a second thing to drift.
+            advertised = str((row or {}).get('evidence_id') or '').strip()
+            if advertised:
+                refs.add(advertised)
             kind = str((row or {}).get('type') or '').strip()
             if not kind:
                 continue

--- a/tests/test_debate_evidence_citations.py
+++ b/tests/test_debate_evidence_citations.py
@@ -224,30 +224,49 @@ def test_every_guardrail_row_the_producer_emits_can_be_cited():
             assert f"risk:{kind}:{row['leg']}" in citable
 
 
-def test_the_skill_names_exactly_the_row_types_the_producer_can_emit():
-    """The model cites by copying `type` verbatim; an undocumented one is a guess.
+def test_every_row_the_producer_emits_advertises_an_id_the_resolver_accepts():
+    """The model copies an id now; this is what keeps the copy resolvable.
 
-    Both directions matter. A type the producer emits but the skill never names
-    is a row the model can only cite by inventing a name for it (`hard_stop`,
-    `concentration` — both observed, both dropped). A type the skill names but
-    nothing emits teaches a citation that can never resolve.
+    The skill used to teach the grammar — namespace, the full `type`
+    vocabulary, ticker form vs leg form, "do not invent a name" — and a gate
+    here kept that vocabulary equal to the producer's. It was not enough: on
+    2026-09-08 the day's only two dropped citations were both
+    `risk:single_name:00100`, aimed at a row whose own type is
+    `single_name_review`. Right row, and a name another row legitimately
+    carries. Composing an identifier from a grammar is the step that fails, so
+    the row now carries the finished string and the skill says to copy it.
+
+    Which moves the invariant: not "the skill lists what the producer emits",
+    but "every row the producer emits advertises an id, and every advertised id
+    resolves". Built from the producer plus `attach_breach_ids`, because that
+    pair is what the morning's context actually contains.
     """
-    import re
+    from clawock.decision import risk as discipline
+    from clawock.harness import brief_postflight
 
-    root = Path(__file__).resolve().parents[1]
-    produced = set(re.findall(
-        r"'type':\s*'([a-z_]+)'",
-        (root / 'src' / 'clawock' / 'portfolio' / 'guardrail.py').read_text(
-            encoding='utf-8')))
-    skill = (root / 'skills' / 'daily-deep-brief' / 'SKILL.md').read_text(
-        encoding='utf-8')
-    vocabulary = [line for line in skill.split('\n') if '可引的 `<type>` 全集' in line]
-    assert len(vocabulary) == 1, 'the skill must state the vocabulary exactly once'
-    documented = set(re.findall(r'`([a-z_]+)`', vocabulary[0])) - {'type'}
+    guardrail = discipline.attach_breach_ids(_guardrail_from_the_real_producer())
+    citable = brief_postflight._citable_refs({'risk_guardrail': guardrail})
 
-    assert documented == produced, (
-        f'skill-only: {sorted(documented - produced)}; '
-        f'producer-only: {sorted(produced - documented)}')
+    rows = [(key, row) for key in discipline.GUARDRAIL_ROW_KEYS
+            for row in guardrail.get(key) or []]
+    assert rows, 'the fixture stopped tripping any cap — it proves nothing now'
+    assert any(key == 'concentration_reviews' for key, _ in rows), (
+        'the family the model got wrong on 09-08 must stay in this fixture')
+
+    for key, row in rows:
+        advertised = row.get('evidence_id')
+        assert advertised, f'{key} row carries no evidence_id to copy: {row}'
+        assert advertised in citable, (
+            f'{key} advertises {advertised!r}, which resolves to nothing')
+        # Scoped, always: an unscoped `risk:<type>` on a book with two legs
+        # points at whichever row the reader guesses.
+        assert advertised.count(':') == 2, advertised
+
+    skill = (Path(__file__).resolve().parents[1]
+             / 'skills' / 'daily-deep-brief' / 'SKILL.md').read_text(
+                 encoding='utf-8')
+    assert '`evidence_id`' in skill, (
+        'the skill must tell the model which field to copy')
 
 
 def test_one_hard_stop_has_one_name_across_every_surface_that_shows_it():

--- a/tests/test_risk_discipline.py
+++ b/tests/test_risk_discipline.py
@@ -242,3 +242,23 @@ def test_plan_local_override_cannot_bypass_durable_open_breach(tmp_path):
     record["override"]["expires_at"] = "2000-01-01T00:00:00+00:00"
     issues = brief_postflight.validate_plan_json(plan_path, context)
     assert any("杠杆硬止损未处理" in issue for issue in issues)
+
+
+def test_a_row_is_scoped_by_the_thing_the_cap_is_about():
+    """`evidence_ref` picks ticker over leg, and leg when there is no ticker.
+
+    A cap on a name is about the name; `leveraged_exposure` and `beta` are
+    about the book's leg and have no ticker to be about. Unscoped is the last
+    resort — on a two-leg book it names two rows.
+    """
+    from clawock.decision import risk as discipline
+
+    assert discipline.evidence_ref(
+        {'type': 'single_name_review', 'ticker': '00100', 'leg': 'HK'}
+    ) == 'risk:single_name_review:00100'
+    assert discipline.evidence_ref(
+        {'type': 'beta', 'ticker': None, 'leg': 'US'}) == 'risk:beta:US'
+    assert discipline.evidence_ref({'type': 'beta'}) == 'risk:beta'
+    # A row with no type cannot be named at all — that was the `hard_stop_watch`
+    # family, uncitable for a week (#1392). Empty, never a half-formed id.
+    assert discipline.evidence_ref({'ticker': '00100'}) == ''


### PR DESCRIPTION
## 今天只掉了两条引用，是同一条

```
debate_citation_unresolved ×2
  dec-e9a46ba589be:risk:single_name:00100
  dec-1ff7e6957dbc:risk:single_name:00100
```

而今天 context 里那一行是：

```json
"concentration_reviews": [{"type": "single_name_review", "ticker": "00100", "leg": "HK"}]
"breaches":              [{"type": "single_name",        "ticker": "SPCH",  "leg": "US"}, …]
```

**票是对的，名字取了另一行合法拥有的那一半。**

## 为什么不是再写清楚一点

SKILL 里这条规则已经有五个 bullet（命名空间、`<type>` 全集、`:<ticker>` vs
`:<leg>`、「逐字照抄那一行自己的 `type`」、「别自己起名」），还配了一条闸把那份
`<type>` 全集钉死在生产者输出上。#1392 之后掉落数 16 → 11 → 8 → 3 → 1，
**降不到 0**。剩下的这一条不是没写清楚——是「自己拼一个标识符」这一步本身会错。

判据（[[clawock-issue-loop-0905]]）：**一条模型不会遵守的规则不是规则，是愿望。**

## 改法

- `attach_breach_ids` 给三张表每一行挂 `evidence_id`，形如
  `risk:single_name_review:00100`。包括 **`concentration_reviews`**——`breach_id`
  本来就不给它（review 不是 breach），而它正是今天被引错的那张表。
- SKILL 的五个 bullet 收成一句：**照抄那一行的 `evidence_id`**。
- `_citable_refs` 先收这个字段：**发给模型的字符串就是解析器认的字符串**，
  中间没有第二份语法可以漂。旧的 `type` 推导保留，老 plan 仍解析得到。

## 闸换了位置，没有变少

原来的「SKILL 列的 type 全集 == 生产者能发的 type 全集」在模型不再念 `type` 之后
不再是有效不变量，换成对着**真生产者 + `attach_breach_ids`**（也就是早晨 context
真正的样子）断言：每一行都挂着一个 id、每个挂出来的 id 都解析得到、且都是带 scope
的形式。`evidence_ref` 自身的三种形状另有单测；没有 `type` 的行返回空串而不是半成品
id——那正是 #1392 里整族核不上的形状。

## RED-CHECK

改前的闸红在 `KeyError: 'evidence_id'`。

https://claude.ai/code/session_01QGcWeWzCPsvUoojnZCjTLm