### PR TITLE
data-plane: 自己好了的那次失败，事后一个时间戳都不剩

### DIFF
--- a/ops/pages/fetch_data_plane.py
+++ b/ops/pages/fetch_data_plane.py
@@ -39,6 +39,21 @@ from clawock.publish import GitBranchStore  # noqa: E402
 from publish_data_branch import DATA_BRANCH, DATA_PLANE_FILES  # noqa: E402
 
 
+READ_FAILED = "data_plane_read_failed"
+
+
+def note_failure(reason: str) -> None:
+    """Count a failed read where a rate is readable. Never raises — same rule as
+    the writer's (`ops/publish/publish_data_branch.py`): the reason is a class,
+    not this incident's text, because the sink aggregates on it."""
+    try:
+        from clawock.automation import workflow_outcomes
+
+        workflow_outcomes.note_degradation(None, READ_FAILED, reason)
+    except Exception:
+        pass
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--repo", type=Path, default=ROOT)
@@ -56,6 +71,7 @@ def main() -> int:
         # reached the caller as a traceback instead of a diagnosis (2026-09-07).
         print(f"✗ data-plane: reading {args.remote}/{args.branch} exceeded "
               f"{exc.timeout:g}s — the remote hung", file=sys.stderr)
+        note_failure("the remote hung past the git call timeout")
         return 1
     except subprocess.CalledProcessError as exc:
         detail = (exc.stderr or b"")
@@ -63,9 +79,11 @@ def main() -> int:
             detail = detail.decode("utf-8", "replace")
         print(f"✗ data-plane: cannot read {args.remote}/{args.branch}: "
               f"{detail.strip() or exc}", file=sys.stderr)
+        note_failure("git could not read the branch")
         return 1
     except FileNotFoundError as exc:
         print(f"✗ data-plane: {exc}", file=sys.stderr)
+        note_failure("the branch does not carry every file of a generation")
         return 1
     print(f"✓ data-plane: {len(written)} outputs from {args.remote}/{args.branch}")
     return 0

--- a/ops/publish/publish_data_branch.py
+++ b/ops/publish/publish_data_branch.py
@@ -52,6 +52,37 @@ DATA_PLANE_EXTRA = (
 )
 DATA_PLANE_FILES = output_paths(ROOT) + DATA_PLANE_EXTRA
 
+# Failure classes, and the whole reason they are classes: `note_degradation`
+# aggregates on (kind, detail), so a detail carrying this incident's text —
+# a sha, a hostname, git's wording — writes a new row every time and the count
+# that makes a rate readable never rises above 1. The incident's text is already
+# on stderr, one line above.
+PUBLISH_FAILED = "data_plane_publish_failed"
+
+
+def note_failure(kind: str, reason: str) -> None:
+    """Record a publisher failure where it can be counted, and never raise.
+
+    The publisher runs every 20 minutes from host cron. Until now a failed tick
+    left exactly one undated line in `logs/publish_dashboard.log`
+    (`logs/dashboard_build_status.json` is a snapshot: the next tick overwrites
+    it, so a failure that repaired itself is gone from every structured
+    surface). That is the same state #1146 described for refused bars — "a
+    source that fails once a quarter and one that fails every week look
+    identical" — and the same answer applies: append it where it accrues a
+    count and a first/last timestamp.
+
+    Best-effort by construction. A publisher that crashed while recording that
+    it had failed would be strictly worse than one that failed quietly.
+    """
+    try:
+        from clawock.automation import workflow_outcomes
+
+        workflow_outcomes.note_degradation(None, kind, reason)
+    except Exception:
+        pass
+
+
 # Same bot identity the scheduled publisher commits under. Injected per
 # invocation by the store (`git -c`), never written to git config — a persistent
 # identity would clobber kcn's interactive one.
@@ -104,6 +135,7 @@ def main() -> int:
             # replaced wholesale, so a missing member is not "unchanged", it is
             # deleted from the data plane.
             print(f"✗ data-plane: cannot read {path}: {exc}", file=sys.stderr)
+            note_failure(PUBLISH_FAILED, "an output file could not be read")
             return 1
 
     store = GitBranchStore(
@@ -120,6 +152,7 @@ def main() -> int:
         print(f"✗ data-plane: {' '.join(map(str, exc.cmd))!r} exceeded "
               f"{exc.timeout:g}s — the remote hung, the generation was not "
               f"published", file=sys.stderr)
+        note_failure(PUBLISH_FAILED, "the remote hung past the git call timeout")
         return 1
     except subprocess.CalledProcessError as exc:
         # Hooks commonly explain a refusal on stdout while git writes only its
@@ -131,9 +164,11 @@ def main() -> int:
             part.strip() for part in (exc.stdout, exc.stderr) if part and part.strip()
         ) or str(exc)
         print(f"✗ data-plane: git failed:\n{detail}", file=sys.stderr)
+        note_failure(PUBLISH_FAILED, "git refused the publish")
         return 1
     except ValueError as exc:
         print(f"✗ data-plane: {exc}", file=sys.stderr)
+        note_failure(PUBLISH_FAILED, "the generation was rejected before publishing")
         return 1
     if not result.changed:
         # No deploy request either: the site already serves this generation, and
@@ -157,6 +192,11 @@ def main() -> int:
         detail = getattr(exc, "stderr", "") or exc
         print(f"✗ data-plane: published, but the site deploy was not requested: "
               f"{detail}", file=sys.stderr)
+        # Its own class: the branch has the generation and the site does not,
+        # which is the one failure here that does not repair itself on the next
+        # tick — the next tick finds the branch unchanged and asks for nothing.
+        note_failure("data_plane_deploy_not_requested",
+                     "published to the branch, the site deploy was refused")
         return 1
     print(f"✓ data-plane: requested {receipt}")
     return 0

--- a/tests/test_data_plane_timeout_is_diagnosed.py
+++ b/tests/test_data_plane_timeout_is_diagnosed.py
@@ -54,3 +54,107 @@ def test_the_handler_reports_a_failure_not_a_success(path):
     assert "✗ data-plane:" in body
     assert re.search(r"\breturn 1\b", body)
     assert "file=sys.stderr" in body
+
+
+def _run_publisher_with(monkeypatch, tmp_path, failure):
+    """Drive `publish_data_branch.main()` to one failure, in a scratch workspace."""
+    import importlib.util
+
+    # Import against the real checkout: module scope resolves the output list
+    # from `config/`, which a scratch workspace does not have. A second call in
+    # one test would otherwise import with the env already pointed at tmp_path.
+    monkeypatch.delenv('CLAWOCK_WORKSPACE', raising=False)
+    spec = importlib.util.spec_from_file_location(
+        'pdb_under_test', ROOT / 'ops' / 'publish' / 'publish_data_branch.py')
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    # After the import: module scope resolves the real checkout's output list,
+    # while the ledger this test reads is resolved per call.
+    monkeypatch.setenv('CLAWOCK_WORKSPACE', str(tmp_path))
+    for name in module.DATA_PLANE_FILES:
+        path = tmp_path / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text('{}\n')
+
+    class Store:
+        def __init__(self, *a, **k):
+            pass
+
+        def publish(self, files, label=None):
+            raise failure
+
+    monkeypatch.setattr(module, 'GitBranchStore', Store)
+    monkeypatch.setattr(
+        'sys.argv', ['publish_data_branch.py', '--root', str(tmp_path)])
+    assert module.main() == 1
+    return module
+
+
+def _degradations(tmp_path):
+    import json
+
+    return json.loads(
+        (tmp_path / 'memory' / '.tmp' / 'workflow-outcomes.json').read_text()
+    )['degradations']
+
+
+def test_a_failed_publish_is_countable_afterwards(monkeypatch, tmp_path):
+    """A tick that failed and repaired itself used to leave nothing dated.
+
+    `logs/publish_dashboard.log` gets one undated line and
+    `logs/dashboard_build_status.json` is a snapshot the next tick overwrites —
+    so on 2026-09-08 the log held exactly one `✗ data-plane:` and there was no
+    way to say when it happened or whether that rate was one a day or one a
+    week. Same shape as the refused bars in #1146, same answer: append it where
+    it accrues a count and a first/last timestamp.
+    """
+    import json
+    import subprocess as sp
+
+    from clawock.automation import workflow_outcomes
+
+    _run_publisher_with(
+        monkeypatch, tmp_path,
+        sp.TimeoutExpired(cmd=['git', 'push'], timeout=120))
+
+    rows = _degradations(tmp_path)
+    assert [r['kind'] for r in rows] == ['data_plane_publish_failed']
+    assert rows[0]['first_at'] and rows[0]['last_at']
+
+
+def test_two_incidents_of_one_class_are_a_count_not_two_rows(monkeypatch, tmp_path):
+    """The detail is the aggregation key, so it must name the class.
+
+    Carrying the incident's own text — a sha, git's wording, the command line —
+    would write a new row each time and leave every count at 1, which is the
+    number that made the log unreadable in the first place.
+    """
+    import json
+    import subprocess as sp
+
+    _run_publisher_with(monkeypatch, tmp_path,
+                        sp.TimeoutExpired(cmd=['git', 'push'], timeout=120))
+    _run_publisher_with(monkeypatch, tmp_path,
+                        sp.TimeoutExpired(cmd=['git', 'fetch', 'other'],
+                                          timeout=120))
+
+    rows = _degradations(tmp_path)
+    assert len(rows) == 1, rows
+    assert rows[0]['count'] == 2
+
+
+def test_recording_a_failure_can_never_be_the_failure(monkeypatch, tmp_path):
+    """A publisher that crashed while writing down that it failed would be
+    strictly worse than one that failed quietly."""
+    import subprocess as sp
+
+    import clawock.automation.workflow_outcomes as outcomes
+
+    def boom(*a, **k):
+        raise RuntimeError('the ledger is unwritable')
+
+    monkeypatch.setattr(outcomes, 'note_degradation', boom)
+    # Still exits 1 from the real failure, not from this one.
+    _run_publisher_with(monkeypatch, tmp_path,
+                        sp.TimeoutExpired(cmd=['git', 'push'], timeout=120))

--- a/tests/test_site_deploy.py
+++ b/tests/test_site_deploy.py
@@ -44,6 +44,13 @@ def workspace(tmp_path):
     # named them would have silently tested a smaller generation.
     sys.path.insert(0, str(ROOT / "ops" / "publish"))
     from publish_data_branch import DATA_PLANE_FILES
+    # The contract that names them, so the child resolves its own outputs from
+    # this workspace rather than from the developer's checkout — which is what
+    # `CLAWOCK_WORKSPACE` below makes it do for everything it writes too.
+    contract = ROOT / "config" / "dashboard-outputs.json"
+    (work / "config").mkdir(parents=True, exist_ok=True)
+    (work / "config" / contract.name).write_text(
+        contract.read_text(encoding="utf-8"), encoding="utf-8")
     for name in DATA_PLANE_FILES:
         target = work / name
         target.parent.mkdir(parents=True, exist_ok=True)
@@ -80,7 +87,11 @@ def _fake_gh(tmp_path, *, exit_code=0):
 
 
 def _publish(workspace, bin_dir, *extra):
-    env = {**os.environ, "PATH": f"{bin_dir}:{os.environ['PATH']}"}
+    # Name the workspace for the child too: the publisher now records a failed
+    # publish as a degradation, and a run that did not say where it lives would
+    # write that into the developer's own checkout.
+    env = {**os.environ, "PATH": f"{bin_dir}:{os.environ['PATH']}",
+           "CLAWOCK_WORKSPACE": str(workspace)}
     return subprocess.run(
         [sys.executable, str(ROOT / "ops/publish/publish_data_branch.py"),
          "--root", str(workspace), "--remote", "origin", *extra],


### PR DESCRIPTION
## 今天查不出来的一件事

`logs/publish_dashboard.log` 里有一条：

```
✗ data-plane: 'git … fetch …' exceeded 120s — the remote hung, the generation was not published
```

**它发生在几点，说不出来；这是一天一次还是一周一次，也说不出来。**

- 那个日志一行时间戳都没有（20 分钟一跳，一直追加）；
- `logs/dashboard_build_status.json` 是**快照**，下一跳覆盖 ⇒ 一次自己好了的失败，
  在所有结构化的面上都不存在（今天 13:34 那份写着 `ok: true`）；
- `workflow-outcomes.records` 只装 agent 的 11 个槽，20 分钟的发布器不在里面。

#1146 给「被拒绝的 bar」写过同一句话：*一个季度出一次错的源和每周都出错的源，在那
种日志里长得一模一样*。答案也一样。

## 改法

发布器与读取端的每条失败路径补一次 `note_degradation`：

| kind | 说明 |
|---|---|
| `data_plane_publish_failed` | 四条路径：输出读不了 / 远端挂了 / git 拒了 / 发布前被否 |
| `data_plane_read_failed` | 读回已发布那一代的三条路径 |
| `data_plane_deploy_not_requested` | **单独一类**：分支拿到了这一代而站点没有——这里唯一一种下一跳修不好的失败（下一跳看到分支没变，什么都不问） |

两条约束写进了代码注释，也各有一条用例：

1. **`detail` 是聚合键**，所以写的是失败的「类」而不是这次的正文。带上 sha、git
   的措辞或命令行，就会每次新开一行、计数永远停在 1——而计数正是当初读不出来的
   那个东西。
2. **记录失败本身绝不能成为失败**：整段 best-effort。

## 顺带

`test_site_deploy` 的 workspace 现在是个真 workspace（带 `config/dashboard-outputs.json`，
并给子进程 `CLAWOCK_WORKSPACE`）。否则那条 deploy 失败用例会把 degradation 写进
开发者自己的检出——#816 的闸当场就看见了。

## RED-CHECK

改前两条新用例红在 `FileNotFoundError: …/workflow-outcomes.json`：失败了，但哪儿
都没记。

https://claude.ai/code/session_01QGcWeWzCPsvUoojnZCjTLm