### PR TITLE
delivery: 一个比率盖得住一段连续的失败

### DIFF
--- a/ops/system_check.py
+++ b/ops/system_check.py
@@ -1315,6 +1315,10 @@ def check_model_chain_health(r):
 
 DELIVERY_DEGRADED_FAILURE_RATE = 0.20
 DELIVERY_HEALTHY_SUCCESS_RATE = 0.95
+#: Consecutive failed slots that stop reading as "it drops one now and then".
+#: Intraday fires every 30 minutes, so three in a row is an hour and a half of
+#: one channel carrying alone — and it is the shape a rate cannot show.
+DELIVERY_RUN_IS_AN_OUTAGE = 3
 
 
 def check_delivery_channel_health(r):
@@ -1362,16 +1366,18 @@ def check_delivery_channel_health(r):
         channels = {k[:-3]: bool(v) for k, v in delivery.items()
                     if k.endswith('_ok') and isinstance(v, bool)}
         if channels:
-            slots.append((rec.get('slot') or '', channels))
+            reasons = {k[:-7]: str(v)[:120] for k, v in delivery.items()
+                       if k.endswith('_detail') and v}
+            slots.append((rec.get('slot') or '', channels, reasons))
     if not slots:
         return
     slots.sort(key=lambda s: s[0])
     slots = slots[-RUN_SCAN_LIMIT:]
 
-    names = sorted({name for _, ch in slots for name in ch})
+    names = sorted({name for _, ch, _ in slots for name in ch})
     totals = {n: [0, 0] for n in names}  # name -> [ok, seen]
     silent = []
-    for slot, ch in slots:
+    for slot, ch, _reasons in slots:
         for name, ok in ch.items():
             totals[name][1] += 1
             totals[name][0] += 1 if ok else 0
@@ -1381,6 +1387,31 @@ def check_delivery_channel_health(r):
     def rate(name):
         ok, seen = totals[name]
         return ok / seen if seen else 1.0
+
+    def current_run(name):
+        """Consecutive most-recent slots this channel failed, and why.
+
+        A rate cannot tell "drops one now and then" from "has been down since
+        lunch": both move it by the same amount. 2026-09-08 was the second
+        shape — WeChat carried every slot to 13:33 and then failed 14:00, 14:30
+        and 15:00 in a row on `ret=-2 prepare failed`, while the 38-slot rate
+        drifted from 79% to 71% and said nothing about when.
+        """
+        run, reason = 0, ''
+        for _slot, ch, reasons in reversed(slots):
+            if ch.get(name) is not False:
+                break
+            run += 1
+            reason = reason or reasons.get(name, '')
+        return run, reason
+
+    def run_phrase(name):
+        """"failing on the last N consecutive slot(s) (why)", or '' below the bar."""
+        run, reason = current_run(name)
+        if run < DELIVERY_RUN_IS_AN_OUTAGE:
+            return ''
+        return (f'{name} failing on the last {run} consecutive slot(s)'
+                + (f' ({reason})' if reason else ''))
 
     tally = ' · '.join(f'{n} {totals[n][0]}/{totals[n][1]}' for n in names)
     if silent:
@@ -1395,13 +1426,22 @@ def check_delivery_channel_health(r):
                if (1 - rate(n)) >= DELIVERY_DEGRADED_FAILURE_RATE and n not in healthy]
     if rotting and healthy:
         named = '; '.join(f'{n} {rate(n) * 100:.0f}%' for n in rotting)
+        runs = [phrase for phrase in (run_phrase(n) for n in rotting) if phrase]
         r.add('delivery channels', WARNING,
-              f'{named} while {"/".join(healthy)} carries every slot — nothing is '
+              (('; '.join(runs) + ' — ') if runs else '')
+              + f'{named} while {"/".join(healthy)} carries every slot — nothing is '
               f'lost today, which is why this leg can rot unnoticed '
               f'({tally} over the last {len(slots)} slots)')
     else:
-        r.add('delivery channels', OK,
-              f'{tally} over the last {len(slots)} slots')
+        runs = [phrase for phrase in (run_phrase(n) for n in names) if phrase]
+        if runs:
+            # A channel can be inside its healthy rate and down right now: the
+            # rate is the last 38 slots, the run is the last hour.
+            r.add('delivery channels', WARNING,
+                  '; '.join(runs) + f' ({tally} over the last {len(slots)} slots)')
+        else:
+            r.add('delivery channels', OK,
+                  f'{tally} over the last {len(slots)} slots')
 
 
 def check_host_cron_logs(r):

--- a/src/clawock/harness/intraday_postflight.py
+++ b/src/clawock/harness/intraday_postflight.py
@@ -465,6 +465,11 @@ def main(argv=None):
     # record the real send result to a marker so intraday_watchdog only re-sends on
     # a CONFIRMED failure (never doubles a report that went out here).
     wechat_sent = None
+    # Why the WeChat leg did not land, when it did not. `wechat_sent=false` is
+    # what a health surface counts; without the reason next to it, a channel
+    # that is DOWN and a channel that drops one now and then are the same row
+    # (#1231 made exactly this argument for the Telegram co-send).
+    send_out = ''
     tg_ok = None
     # Set when claim_send refuses this process the send right: it then has no
     # evidence about whether delivery happened and must not file a
@@ -605,6 +610,10 @@ def main(argv=None):
         heartbeat_state,
         job_name=heartbeat.get('job'), slot=heartbeat.get('slot'),
         postflight_status=product, wechat_sent=wechat_sent,
+        # Only when it failed: a reason field on a send that worked is noise in
+        # a record read by eye, and the same rule the co-send log follows.
+        wechat_detail=(send_out or 'no output from the transport')[-200:]
+        if wechat_sent is False else None,
         telegram_sent=tg_ok, dashboard_published=dashboard_published,
         data_plane_status=data_plane_status,
         insights_sidecar=insights_written, issue_count=len(issues),

--- a/src/clawock/harness/report_postflight.py
+++ b/src/clawock/harness/report_postflight.py
@@ -481,6 +481,12 @@ def main(argv=None):
     # delivery evidence and must not file a primary_delivery verdict over the
     # concurrent holder's (#1006).
     claim_declined = False
+    # Why the WeChat leg did not land. Returned by `deliver_wechat` and, until
+    # now, dropped by all three call sites — the same shape #1231 fixed for the
+    # Telegram co-send: the field a health surface counts (`wechat_ok=false`)
+    # arriving with no reason beside it, so a channel that is DOWN and one that
+    # drops the occasional slot read identically.
+    send_out = ''
     if blocked:
         print(f'idempotency: {args.market}-{args.phase} already delivered today — skip re-send',
               file=sys.stderr)
@@ -493,7 +499,7 @@ def main(argv=None):
         # in flight and skip the corrected report (caught by
         # test_a_failed_slot_can_be_superseded_once_then_locks).
         send_claim = 'upgrade'
-        wechat_sent, _ = deliver_wechat(args.market, args.phase, today, wechat_prefix, body,
+        wechat_sent, send_out = deliver_wechat(args.market, args.phase, today, wechat_prefix, body,
                                         delivery_state=delivery_state,
                                         context_id=ctx.get('context_id'),
                                         context_generated_at=ctx.get('generated_at'))
@@ -512,7 +518,8 @@ def main(argv=None):
             wechat_sent = False
             claim_declined = True
         else:
-            wechat_sent, _ = deliver_wechat(args.market, args.phase, today, wechat_prefix, body,
+            wechat_sent, send_out = deliver_wechat(
+                args.market, args.phase, today, wechat_prefix, body,
                                             delivery_state=delivery_state,
                                             context_id=ctx.get('context_id'),
                                             context_generated_at=ctx.get('generated_at'),
@@ -548,6 +555,10 @@ def main(argv=None):
             channel=workflow_outcomes.delivery_channel(wechat_ok, telegram_ok),
             wechat_ok=wechat_ok,
             telegram_ok=telegram_ok,
+            # Only on failure: a reason on a send that worked is noise in a
+            # record read by eye.
+            **({} if wechat_ok else {
+                'wechat_detail': (send_out or 'no output from the transport')[-200:]}),
             deterministic_fallback=(status == 'fail'),
         )
 

--- a/tests/test_system_check_delivery_channels.py
+++ b/tests/test_system_check_delivery_channels.py
@@ -114,3 +114,54 @@ def test_a_ledger_that_is_not_there_is_silent(system_check, monkeypatch, tmp_pat
     r = system_check.Result()
     system_check.check_delivery_channel_health(r)
     assert not [row for row in r.checks if row[0] == "delivery channels"]
+
+
+def test_a_channel_down_right_now_is_named_as_a_run_not_only_a_rate(
+        system_check, monkeypatch, tmp_path):
+    """2026-09-08: WeChat carried every slot to 13:33, then failed 14:00, 14:30,
+    15:00 and 15:30 in a row on `ret=-2 prepare failed`.
+
+    The 38-slot rate moved from 79% to 68% — the same drift a channel that drops
+    one slot now and then produces. A rate is an average over the window; the
+    question an operator has at 15:30 is whether the leg is there *now*.
+    """
+    slots = ([{"wechat_ok": True, "telegram_ok": True}] * 30
+             + [{"wechat_ok": False, "telegram_ok": True,
+                 "wechat_detail": "OutboundDeliveryError: sendMessage ret=-2 "
+                                  "errmsg=prepare failed"}] * 4)
+    rows = _run(system_check, monkeypatch, tmp_path, slots)
+
+    assert len(rows) == 1
+    _, level, message = rows[0]
+    assert level == system_check.WARNING
+    assert "last 4 consecutive slot(s)" in message
+    # And it says why, because the record now carries the transport's reason.
+    assert "ret=-2" in message
+
+
+def test_a_run_is_reported_even_while_the_rate_still_reads_healthy(
+        system_check, monkeypatch, tmp_path):
+    """The rate is the last 38 slots; the run is the last two hours.
+
+    A channel that has been perfect for weeks and died an hour ago sits well
+    inside its healthy rate — which is exactly the moment somebody would want
+    to be told.
+    """
+    slots = ([{"wechat_ok": True, "telegram_ok": True}] * 60
+             + [{"wechat_ok": False, "telegram_ok": True}] * 3)
+    rows = _run(system_check, monkeypatch, tmp_path, slots)
+
+    assert len(rows) == 1
+    _, level, message = rows[0]
+    assert level == system_check.WARNING, 'a healthy rate must not hide a run'
+    assert "last 3 consecutive slot(s)" in message
+
+
+def test_the_same_rate_scattered_is_not_a_run(system_check, monkeypatch, tmp_path):
+    """Same failure count, spread out: that is the case the rate already covers,
+    and calling it an outage would make the run signal meaningless."""
+    slots = [{"wechat_ok": i % 4 != 0, "telegram_ok": True} for i in range(32)]
+    rows = _run(system_check, monkeypatch, tmp_path, slots)
+
+    assert len(rows) == 1
+    assert "consecutive" not in rows[0][2]


### PR DESCRIPTION
## 今天下午发生的事

| 槽 | wechat | telegram |
|---|---|---|
| 13:33 港股午后快报 | ✅ | ✅ |
| **14:00 盘中盯盘** | ❌ | ✅ |
| **14:30 盘中盯盘** | ❌ | ✅ |
| **15:00 盘中盯盘** | ❌ | ✅ |
| **15:30 盘中盯盘** | ❌ | ✅ |

marker 里写着原因：`OutboundDeliveryError: sendMessage ret=-2 errmsg=prepare failed`。

而 `check_delivery_channel_health` 说的是「wechat 68%」。**同一条比率，既可能是
「隔一阵掉一条」，也可能是「午饭后就没了」**——比率是 38 个槽的平均，而 15:30 那
一刻想知道的是这条腿现在还在不在。

## 两处改

**1. 报连续段。** 除了比率，再算每条通道最近**连续**失败的槽数，≥3 就点名（盘中
30 分钟一槽，三连即一个半小时只剩一条腿在扛）。

- **比率健康也照报**：一条稳了几周、一小时前刚死的通道正好落在健康区间里，而那恰恰
  是最该说话的时刻。
- **打散的同样失败次数不算**：那是比率已经覆盖的情形，混进来会让这个信号失去意义。

**2. 把理由带上。** `deliver_wechat` 一直返回 `(sent_ok, out)`，而**三个调用点全都
把第二个值丢了**——和 #1231 修过的 co-send 完全同形：健康面数的那个字段
（`wechat_ok=false`）旁边没有原因。现在失败时写进 `primary_delivery.wechat_detail`
（成功时不写），连续段于是能自己说出 `ret=-2 prepare failed`。

## 线上实跑

```
⚠ delivery channels  wechat failing on the last 4 consecutive slot(s) —
                     wechat 68% while telegram carries every slot — nothing is
                     lost today, which is why this leg can rot unnoticed
                     (telegram 37/38 · wechat 26/38 over the last 38 slots)
```

**不动投递机制**：补发／保活／换通道都被否过三次，这条 PR 只让趋势和当下状态可读
（`ret=-2` 本身是上游 wontfix、kcn 已决定不追——正因如此才要可数，见 #771 那段注释）。

## RED-CHECK

改前两条新用例分别红在「healthy 比率把连续段藏掉」和「连续段说不出原因」。

https://claude.ai/code/session_01QGcWeWzCPsvUoojnZCjTLm