### PR TITLE
traces: 判定卡读的是一套已经不再写入的字段

### DIFF
--- a/src/clawock/publish/dashboard.py
+++ b/src/clawock/publish/dashboard.py
@@ -1167,6 +1167,18 @@ def build_decision_traces(limit=40, workspace=None):
                     subject = best.get('subject') or {}
                     mind = best.get('mind') or {}
                     emotion = best.get('emotion') or {}
+                    # Two writers, one card. `mind` is the hand-recorded
+                    # decision-mind record (`clawock record`) and carries prose;
+                    # `debate` is what the 08:00 brief writes on its own
+                    # decisions (#1117). This block read only the first, so the
+                    # card's own fallback — `why = rationale || bull` — and its
+                    # 「当时情绪」 line could not fire on a model-authored row:
+                    # measured 2026-09-08, 1 of the ledger's 809 rows has
+                    # `mind`, 68 have `debate`, and all 40 published traces
+                    # carried neither bull nor bear. The hand-written record
+                    # still wins where it exists — a person said it — and the
+                    # debate is the fallback rather than nothing.
+                    debate = best.get('debate') or {}
                     size = best.get('size') or {}
                     evaluation = best.get('evaluation') or {}
                     t['decision'] = {
@@ -1177,8 +1189,8 @@ def build_decision_traces(limit=40, workspace=None):
                         'rationale': _readable_rationale(best.get('rationale')),
                         'thesis': mind.get('thesis'),
                         'invalidation': mind.get('invalidation') if isinstance(mind.get('invalidation'), list) else [],
-                        'bull': (mind.get('bull') or {}).get('summary'),
-                        'bear': (mind.get('bear') or {}).get('summary'),
+                        'bull': (mind.get('bull') or {}).get('summary') or debate.get('bull'),
+                        'bear': (mind.get('bear') or {}).get('summary') or debate.get('bear'),
                         'emotion': emotion.get('pressure'),
                         'emotionNote': emotion.get('note'),
                         'execution': (best.get('execution') or {}).get('status'),
@@ -1397,6 +1409,11 @@ def build_decision_trace_scope(traces, workspace=None, limit=40):
         # visible instead of silently rendering nothing (#738).
         'emotionShown': sum(1 for t in shown if (t.get('decision') or {}).get('emotion')),
         'mindShown': sum(1 for t in shown if (t.get('decision') or {}).get('thesis')),
+        # Split from `mindShown` because they have different writers: the two
+        # above come from a hand-recorded mind record, this one from the brief's
+        # own debate block. Reporting them as one number would say the card got
+        # better on days nobody typed anything.
+        'argumentShown': sum(1 for t in shown if (t.get('decision') or {}).get('bull')),
         't1Verdicts': verdicts,
         't1Sides': sides,
         't1Shown': sum(1 for t in shown if t.get('t1')),

--- a/tests/test_decision_traces.py
+++ b/tests/test_decision_traces.py
@@ -379,3 +379,60 @@ def test_rationale_keeps_text_that_only_looks_like_a_breach_id(ws, tmp_path):
     assert dashboard._readable_rationale("(breach risk-abc123def456 30d)") is None
     assert dashboard._readable_rationale(None) is None
     assert dashboard._readable_rationale(12) is None
+
+
+def _relink(ws_path, ticker, **fields):
+    """Rewrite one ledger row in the fixture desk and rebuild."""
+    path = ws_path / "memory" / "decisions.jsonl"
+    rows = [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+    for row in rows:
+        if row.get("ticker") == ticker and row.get("plan_date"):
+            row.update(fields)
+    path.write_text("".join(json.dumps(r, ensure_ascii=False) + "\n" for r in rows),
+                    encoding="utf-8")
+
+
+def test_a_model_authored_debate_reaches_the_card_the_hand_record_used_to_own(
+        ws, tmp_path):
+    """Measured 2026-09-08: 0 of 40 published traces carried a bull or a bear.
+
+    The card's own fallback is `why = rationale || bull`, and this builder read
+    only `mind.bull.summary` — the hand-recorded decision-mind record, present
+    on 1 of the ledger's 809 rows. The 08:00 brief writes its argument to
+    `debate` instead (#1117), which 68 rows carry and every new plan adds.
+    Same card, second writer.
+    """
+    _relink(tmp_path, "SPCH", debate={"bull": "HBM 短缺到 2030 长期支撑",
+                                      "bear": "5d +9.9% 顶部属追高低质",
+                                      "judge": "hold, 1 股无操作空间"})
+
+    trace = next(t for t in dashboard.build_decision_traces()
+                 if t["ticker"] == "SPCH")
+
+    assert trace["decision"]["bull"] == "HBM 短缺到 2030 长期支撑"
+    assert trace["decision"]["bear"] == "5d +9.9% 顶部属追高低质"
+
+
+def test_a_hand_written_mind_record_still_wins(ws, tmp_path):
+    """A person typed it; the debate is the fallback, not the override."""
+    _relink(tmp_path, "SPCH",
+            mind={"bull": {"summary": "手写的多方"},
+                  "bear": {"summary": "手写的空方"}},
+            debate={"bull": "模型的多方", "bear": "模型的空方"})
+
+    trace = next(t for t in dashboard.build_decision_traces()
+                 if t["ticker"] == "SPCH")
+
+    assert trace["decision"]["bull"] == "手写的多方"
+    assert trace["decision"]["bear"] == "手写的空方"
+
+
+def test_the_two_writers_are_counted_separately(ws, tmp_path):
+    """`mindShown` says a person wrote one; reporting the debate under it would
+    claim the card got better on days nobody typed anything."""
+    _relink(tmp_path, "SPCH", debate={"bull": "模型的多方"})
+
+    scope = dashboard.build_decision_trace_scope(dashboard.build_decision_traces())
+
+    assert scope["argumentShown"] >= 1
+    assert scope["mindShown"] == 1, 'the hand-recorded row, and only it'


### PR DESCRIPTION
## 线上量的

**40 条决策轨迹里，0 条带 `bull`、0 条带 `bear`。**

卡片自己的兜底写着 `why = rationale || bull`，情绪那行写着 `d.emotion` —— 而
builder 读的是 `mind.bull.summary` / `emotion.pressure`，那是 v1「决策心智记录」
（`clawock record`，人手写）的字段。

| 字段 | 809 行账本里有几行 |
|---|---|
| `mind` | **1** |
| `emotion` | **1** |
| `debate`（08:00 简报写的，#1117） | **68**，且每份新计划都在加 |

同一张卡，两个写入方，builder 只认识人手那一个。#738 早就把 `emotionShown` /
`mindShown` 两个覆盖数发出来了（当时就是 0），**但没人问过为什么是 0**——答案是这个。

## 改法

```python
'bull': (mind.get('bull') or {}).get('summary') or debate.get('bull'),
'bear': (mind.get('bear') or {}).get('summary') or debate.get('bear'),
```

**人写的那份仍然赢**——是个人说的话；debate 是兜底，不是覆盖。

`thesis` / `invalidation` / `emotion` 没有 v2 对应物，原样不动：`thesis_id` 是个
slug 不是散文，拿它冒充会比空着更糟。

覆盖数拆成两个，`argumentShown` 单独数 debate 那一侧——合成一个数会让「没人打字的
日子」看起来像卡片变好了。

## RED-CHECK

改前新用例红在 `KeyError`：debate 的多空一个都到不了卡上。

https://claude.ai/code/session_01QGcWeWzCPsvUoojnZCjTLm