### PR TITLE
brief: 板块全景 悄悄停了八场，只有一张卡上一行灰字知道

### DIFF
--- a/src/clawock/harness/brief_postflight.py
+++ b/src/clawock/harness/brief_postflight.py
@@ -868,6 +868,15 @@ def main(argv=None):
         # underlying fact.
         for issue in render_issues:
             print(f'warn: {issue}', file=sys.stderr)
+        # One of them is counted rather than only printed. The sector sweep is
+        # written by the model, and it stopped after 2026-08-27: eight sessions
+        # with no `sector-scan-*.json`, the report's 板块全景 quietly degrading
+        # to the read alone, and the only trace anywhere a grey 「12天前 · 待
+        # brief 刷新」 on one dashboard card. A cron log nobody reads twice
+        # cannot answer "since when, and how often" (#1146).
+        if brief_render.SECTOR_SCAN_MISSING in render_issues:
+            workflow_outcomes.note_degradation(
+                None, 'sector_scan_missing', brief_render.SECTOR_SCAN_MISSING)
     except Exception as exc:
         issues.append(f'简报渲染失败（保留现有 pre-open.md）: {exc}')
         print(f'warn: brief render failed: {exc}', file=sys.stderr)

--- a/src/clawock/harness/brief_render.py
+++ b/src/clawock/harness/brief_render.py
@@ -959,6 +959,13 @@ def artifact_paths(workspace, date):
     }
 
 
+#: Worded identically every morning, because the consumer aggregates on the
+#: text: an issue carrying the date would file a new row each day and never
+#: show a count — the same rule the publisher's failure classes follow (#1409).
+SECTOR_SCAN_MISSING = (
+    "板块全景 没有落盘 sector-scan：本篇只有 sector_read 文字，没有表")
+
+
 def render_from_workspace(workspace, date, *, plan=None, page_url=None, write=True):
     """Render both artifacts for one date. Returns (issues, brief_markdown).
 
@@ -978,10 +985,15 @@ def render_from_workspace(workspace, date, *, plan=None, page_url=None, write=Tr
 
     # The sector sweep is optional: a day the search quota was spent still has
     # to publish, with the section carrying the model's read and no table.
+    # Optional is not the same as unremarkable, though — the file is written by
+    # the model, and it stopped after 2026-08-27 without anything noticing for
+    # eight sessions. Say so; the caller counts it.
     try:
         sector_scan = _load(paths["sector_scan"])
     except (OSError, ValueError):
         sector_scan = None
+    if not (sector_scan or {}).get("sectors"):
+        issues.append(SECTOR_SCAN_MISSING)
 
     body = render_brief(context, judgment, plan, date=date, sector_scan=sector_scan)
     card = render_card(context, judgment, plan, date=date, page_url=page_url)

--- a/tests/test_brief_plan_normalization.py
+++ b/tests/test_brief_plan_normalization.py
@@ -251,6 +251,10 @@ def test_main_normalizes_before_calling_plan_validation(tmp_path, monkeypatch):
         return []
 
     monkeypatch.setattr(brief_postflight, "WS", tmp_path)
+    # The degradation ledger resolves its path at call time, so the
+    # module attribute above is not enough: without this a postflight
+    # run from a test writes into the developer's own workspace (#816).
+    monkeypatch.setenv("CLAWOCK_WORKSPACE", str(tmp_path))
     monkeypatch.setattr(
         brief_postflight.trading_calendar, "closed_reason", lambda _market: None
     )
@@ -299,6 +303,10 @@ def test_dry_run_validates_normalized_plan_without_rewriting_source(
         return observed["issues"]
 
     monkeypatch.setattr(brief_postflight, "WS", tmp_path)
+    # The degradation ledger resolves its path at call time, so the
+    # module attribute above is not enough: without this a postflight
+    # run from a test writes into the developer's own workspace (#816).
+    monkeypatch.setenv("CLAWOCK_WORKSPACE", str(tmp_path))
     monkeypatch.setattr(
         brief_postflight.trading_calendar, "closed_reason", lambda _market: None
     )

--- a/tests/test_brief_projection_publication_gate.py
+++ b/tests/test_brief_projection_publication_gate.py
@@ -47,6 +47,10 @@ def _run_postflight(tmp_path, monkeypatch, capsys, *, projection_error=None):
     stages = []
     commits = []
     monkeypatch.setattr(postflight, 'WS', tmp_path)
+    # The degradation ledger resolves its path at call time, so the module
+    # attribute above is not enough: without this a postflight run from a
+    # test writes into the developer's own workspace (#816).
+    monkeypatch.setenv('CLAWOCK_WORKSPACE', str(tmp_path))
     monkeypatch.setattr(
         postflight.trading_calendar, 'closed_reason', lambda _market: None
     )

--- a/tests/test_brief_render.py
+++ b/tests/test_brief_render.py
@@ -247,6 +247,12 @@ def test_rendering_from_a_workspace_writes_both_artifacts(tmp_path):
         json.dumps(_judgment(), ensure_ascii=False), encoding="utf-8")
     (tmp_path / "memory" / "2026-08-31-plan.json").write_text(
         json.dumps(PLAN, ensure_ascii=False), encoding="utf-8")
+    # A complete morning includes the sector sweep; without it the render is
+    # still published and now says so (see the two tests below).
+    (tmp / "sector-scan-2026-08-31.json").write_text(json.dumps({
+        "date": "2026-08-31",
+        "sectors": [{"theme": "HK AI", "top_movers": [], "self": []}],
+    }, ensure_ascii=False), encoding="utf-8")
 
     issues, body = render.render_from_workspace(tmp_path, "2026-08-31")
 
@@ -412,3 +418,59 @@ def test_the_card_keeps_its_own_ornament_and_the_page_does_not():
     assert "▎" in card
     assert not any(line.startswith("#") and "▎" in line for line in page.splitlines())
 
+
+
+def _workspace_without_a_sweep(tmp_path, date="2026-08-31"):
+    tmp = tmp_path / "memory" / ".tmp"
+    tmp.mkdir(parents=True)
+    (tmp / f"brief-context-{date}.json").write_text(
+        json.dumps(CONTEXT, ensure_ascii=False), encoding="utf-8")
+    (tmp / f"brief-judgment-{date}.json").write_text(
+        json.dumps(_judgment(), ensure_ascii=False), encoding="utf-8")
+    (tmp_path / "memory" / f"{date}-plan.json").write_text(
+        json.dumps(PLAN, ensure_ascii=False), encoding="utf-8")
+    return tmp_path
+
+
+def test_a_missing_sector_sweep_is_reported_and_still_publishes(tmp_path):
+    """The sweep is model-written, and it stopped after 2026-08-27.
+
+    Eight sessions produced no `sector-scan-*.json`: the report's 板块全景
+    quietly degraded to the model's read with no table, and the only trace
+    anywhere was a grey 「12天前 · 待 brief 刷新」 on one dashboard card. The
+    section is optional by design — a day the search quota is spent still has to
+    publish — but optional is not the same as unremarkable.
+    """
+    issues, body = render.render_from_workspace(
+        _workspace_without_a_sweep(tmp_path), "2026-08-31")
+
+    assert render.SECTOR_SCAN_MISSING in issues
+    assert body, 'the brief still publishes without the sweep'
+    assert "板块全景" in body, 'the section stays, carrying the read alone'
+
+
+def test_the_report_is_worded_the_same_every_morning(tmp_path):
+    """It is aggregated on, so it must not carry the day in it: a message with
+    the date would open a new row daily and the count would never leave 1."""
+    first, _ = render.render_from_workspace(
+        _workspace_without_a_sweep(tmp_path / "mon"), "2026-08-31")
+    second, _ = render.render_from_workspace(
+        _workspace_without_a_sweep(tmp_path / "tue", "2026-09-01"),
+        "2026-09-01")
+
+    assert render.SECTOR_SCAN_MISSING in first
+    assert render.SECTOR_SCAN_MISSING in second
+    assert "2026" not in render.SECTOR_SCAN_MISSING
+
+
+def test_a_sweep_with_no_sectors_counts_as_missing(tmp_path):
+    """An empty `sectors` renders exactly the same section as no file at all,
+    so it must read the same way here — a written-but-empty artifact is the
+    shape that makes "we looked" and "there is none" identical."""
+    ws = _workspace_without_a_sweep(tmp_path)
+    (ws / "memory" / ".tmp" / "sector-scan-2026-08-31.json").write_text(
+        json.dumps({"date": "2026-08-31", "sectors": []}), encoding="utf-8")
+
+    issues, _ = render.render_from_workspace(ws, "2026-08-31")
+
+    assert render.SECTOR_SCAN_MISSING in issues


### PR DESCRIPTION
## 证据

`memory/.tmp/` 里 `sector-scan-*.json` **总共只有两份**：

```
5667  Aug 27 08:06  sector-scan-2026-08-27.json
5236  Aug 26 08:10  sector-scan-2026-08-26.json
```

之后**八个交易日一份都没有**。后果两处：

- 报告的「### 板块全景」自动退化成只有 `sector_read` 一段文字、没有表；
- dashboard 那张卡老老实实写着 `as of 2026-08-27 · 12天前 · 待 brief 刷新`
  ——**而这是整个系统里唯一知道这件事的地方**。

这份文件是**模型写的**（SKILL Step 3：「同时落盘到 `sector-scan-{date}.json`」）。
`render_from_workspace` 早就把它当可选——搜索额度用光的日子照样要发，这是对的。
但**可选不等于不值一提**：在现在这套里，「今天没做」和「已经八场没做」长得一模一样。

## 改法

缺文件、或者 `sectors` 为空（写了个空文件跟没写渲染出来完全一样，正是那种让
「查过了」和「没有」变成同一个形状的写法），就：

1. 往 `render_from_workspace` 的 issues 里加一条；
2. postflight 记一条 `sector_scan_missing` degradation。

**措辞每天完全一致**，因为消费端按文本聚合：带日期的消息会每天开一行、计数永远
停在 1（#1409 那条规则，低一层）。

不改「它是可选的」这件事，也不去催模型多做什么——只是让「多久没有了」变成一个
能读的数。

## 顺带

这条 `note_degradation` 让四个跑 `brief_postflight.main()` 的测试写进了真 workspace，
**#816 的闸当场抓到**。它按调用时解析路径，所以 `monkeypatch.setattr(…, 'WS',
tmp_path)` 挡不住，必须同时给 `CLAWOCK_WORKSPACE`。

## RED-CHECK

改前三条新用例红在「缺 sweep 时 issues 是空的」。

https://claude.ai/code/session_01QGcWeWzCPsvUoojnZCjTLm