### PR TITLE
delivery: 把「数能独立失败的腿」这条判据用到投递链上

### DIFF
--- a/ops/system_check.py
+++ b/ops/system_check.py
@@ -1214,6 +1214,65 @@ def check_fallback_chain_shape(r):
         r.add('fallback chain', OK, detail)
 
 
+def check_delivery_chain_shape(r):
+    """How many legs the DELIVERY chain has that can fail on their own.
+
+    The sibling of `check_fallback_chain_shape`, applying the same criterion one
+    system over: **stop counting hops, count the things that can fail
+    independently.** The model chain was measured that way in #1242 and turned
+    out to be one leg wearing three; nobody had asked the same question of the
+    path the reports actually leave on.
+
+    Two channels carry every slot — WeChat first, Telegram always co-sent — and
+    they look like two legs. They are two, for a failure on the channel's own
+    side: 2026-09-08 WeChat returned `ret=-2 prepare failed` for five slots in a
+    row and Telegram carried all five. They are ONE for a failure in the
+    transport under both: the same morning, the 10:34 co-send and the 10:43
+    watchdog mirror both gave up on the same local gateway, and the "backstop"
+    was a second call down the pipe that had just failed.
+
+    So the number reported here is the count of distinct transports, not of
+    channels, and the channels come from the ledger rather than a hardcoded pair
+    — the same reason `check_delivery_channel_health` reads them there.
+
+    WARNING, never CRITICAL, and it proposes nothing: re-send, keep-alive and
+    channel-switch have each been declined. This only says out loud how many
+    legs the desk actually has.
+    """
+    try:
+        sys.path.insert(0, str(_REPO_ROOT / 'src'))
+        from clawock.automation import workflow_outcomes  # noqa: PLC0415
+        ledger = json.loads(workflow_outcomes.public_path().read_text(encoding='utf-8'))
+    except Exception:  # noqa: BLE001
+        return  # no ledger on this host yet
+    channels = sorted({
+        key[:-3]
+        for rec in (ledger.get('records') or [])
+        for key, value in (((rec.get('stages') or {}).get('primary_delivery')) or {}).items()
+        if key.endswith('_ok') and isinstance(value, bool)
+    })
+    if len(channels) < 2:
+        return  # nothing to be wrong about: one channel is one leg by construction
+
+    try:
+        from clawock.providers.delivery import default_provider  # noqa: PLC0415
+        transports = {default_provider().name}
+    except Exception as e:  # noqa: BLE001
+        r.add('delivery chain', WARNING,
+              f'cannot resolve the delivery provider: {e}')
+        return
+
+    tally = (f'{len(channels)} channel(s) ({"/".join(channels)}) · '
+             f'{len(transports)} transport ({"/".join(sorted(transports))})')
+    if len(transports) < len(channels):
+        r.add('delivery chain', WARNING,
+              f'{tally} — a channel outage costs one leg, a transport outage '
+              f'costs every one at once, including the watchdog backstop that '
+              f'goes down the same pipe')
+    else:
+        r.add('delivery chain', OK, tally)
+
+
 def _provider_api_keys():
     """provider name → an opaque label for the account behind it. Live box only.
 
@@ -1974,6 +2033,7 @@ def main():
         check_fallback_chain_shape,
         check_model_chain_health,
         check_delivery_channel_health,
+        check_delivery_chain_shape,
         check_generated_cron_docs,
         check_research_artifacts,
         check_trading_calendar_horizon,

--- a/src/clawock/harness/_watchdog_common.py
+++ b/src/clawock/harness/_watchdog_common.py
@@ -371,9 +371,13 @@ def resolve_wechat_target(market=None):
 
 def _delivery(account=None):
     """The delivery provider for this workspace. OpenClaw today, by construction
-    swappable — that is the whole point of the interface."""
-    from clawock.providers.delivery import OpenClawDelivery
-    return OpenClawDelivery(account=account)
+    swappable — that is the whole point of the interface.
+
+    Resolved in the adapter layer so the harness is not the place that decides:
+    the operator health check needs the same answer and may not import this
+    module."""
+    from clawock.providers.delivery import default_provider
+    return default_provider(account)
 
 
 def send_wechat(channel, to, account, message, dry_run):

--- a/src/clawock/providers/delivery.py
+++ b/src/clawock/providers/delivery.py
@@ -199,6 +199,18 @@ class OpenClawDelivery:
                               idempotency_key=idempotency_key)
 
 
+def default_provider(account: str | None = None):
+    """The provider this workspace delivers through.
+
+    The choice of implementation belongs in the adapter layer, not in whichever
+    caller happens to need one — `providers/__init__.py` exists to be the one
+    place that knows. The harness asks here, and so does the operator health
+    check, which must not import the harness at all
+    (`test_system_check_reads_cron_state_only_through_the_core_provider`).
+    """
+    return OpenClawDelivery(account=account)
+
+
 @dataclass
 class NullDelivery:
     """Records instead of sending — foreign workspaces, dry runs, tests.

--- a/tests/test_system_check_delivery_chain.py
+++ b/tests/test_system_check_delivery_chain.py
@@ -1,0 +1,106 @@
+"""Count the delivery legs that can fail on their own (the #1242 criterion).
+
+`check_fallback_chain_shape` asked that question of the model chain and found
+three hops behind one credential — one leg wearing three. Nobody had asked it of
+the path the reports actually leave on.
+
+2026-09-08 answered both halves of it in one morning:
+
+* WeChat returned `ret=-2 prepare failed` on five consecutive slots and Telegram
+  carried every one — a channel failure costs one leg, and the second leg is
+  real;
+* the 10:34 co-send and the 10:43 watchdog mirror both gave up on the same local
+  gateway at its 10s ceiling — a transport failure costs every channel at once,
+  and the "backstop" was a second call down the pipe that had just failed.
+
+So the reported number is transports, not channels.
+"""
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+@pytest.fixture(scope="module")
+def system_check():
+    for path in (ROOT, ROOT / "src"):
+        if str(path) not in sys.path:
+            sys.path.insert(0, str(path))
+    spec = importlib.util.spec_from_file_location(
+        "kcnyu_system_check_delivery_chain", ROOT / "ops" / "system_check.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _run(system_check, monkeypatch, tmp_path, channels_per_slot):
+    out = tmp_path / "assets" / "data"
+    out.mkdir(parents=True, exist_ok=True)
+    (out / "workflow-outcomes.json").write_text(json.dumps({
+        "schema_version": 1,
+        "records": [{"job": "盘中盯盘", "slot": "2026-09-08T10:00:00+08:00",
+                     "stages": {"primary_delivery": {"status": "success",
+                                                     **channels_per_slot}}}],
+    }), encoding="utf-8")
+    monkeypatch.setenv("CLAWOCK_WORKSPACE", str(tmp_path))
+    r = system_check.Result()
+    system_check.check_delivery_chain_shape(r)
+    return [row for row in r.checks if row[0] == "delivery chain"]
+
+
+def test_two_channels_down_one_pipe_are_one_leg(system_check, monkeypatch, tmp_path):
+    rows = _run(system_check, monkeypatch, tmp_path,
+                {"wechat_ok": True, "telegram_ok": True})
+
+    assert len(rows) == 1
+    _, level, message = rows[0]
+    assert level == system_check.WARNING
+    assert "2 channel(s)" in message and "1 transport" in message
+    # The sentence has to name the backstop, because that is the part that reads
+    # as redundancy and is not.
+    assert "backstop" in message
+
+
+def test_a_single_channel_is_not_reported(system_check, monkeypatch, tmp_path):
+    """One channel is one leg by construction — saying so adds no information,
+    and a warning that fires on a correct configuration trains the reader to
+    skip the row."""
+    rows = _run(system_check, monkeypatch, tmp_path, {"telegram_ok": True})
+
+    assert rows == []
+
+
+def test_the_channels_come_from_the_ledger_not_a_hardcoded_pair(
+        system_check, monkeypatch, tmp_path):
+    """Same reason the rate check reads them there: a third channel must be
+    counted the day it starts writing its result, not the day someone edits a
+    list."""
+    rows = _run(system_check, monkeypatch, tmp_path,
+                {"wechat_ok": True, "telegram_ok": True, "signal_ok": False})
+
+    assert "3 channel(s)" in rows[0][2]
+    assert "signal" in rows[0][2]
+
+
+def test_transports_are_asked_of_the_harness_not_assumed(
+        system_check, monkeypatch, tmp_path):
+    """The count must come from the code that actually sends. If a channel is
+    ever routed through a second provider, this check improves on its own —
+    and if the provider cannot be resolved at all, it says that instead of
+    quietly reporting a number it did not measure.
+    """
+    from clawock.providers import delivery
+
+    def boom(*a, **k):
+        raise RuntimeError('no provider')
+
+    monkeypatch.setattr(delivery, 'default_provider', boom)
+    rows = _run(system_check, monkeypatch, tmp_path,
+                {"wechat_ok": True, "telegram_ok": True})
+
+    assert rows and 'cannot resolve the delivery provider' in rows[0][2]


### PR DESCRIPTION
## 一条已有的判据，从没用在这条链上

#1242 对**模型链**问过这个问题——别数跳数，数**能各自单独挂掉的东西**——答案是
三跳穿着一个 credential，实际一条腿。**没人对报告真正走的那条路问过同一个问题。**

09-08 一个上午把两半都答了：

| | 发生了什么 | 花掉几条腿 |
|---|---|---|
| **通道侧** | 微信连着 5 个槽 `ret=-2 prepare failed`，Telegram 5 个全接住 | 1（第二条腿是真的）|
| **传输侧** | 10:34 co-send 与 10:43 watchdog 补投，在同一个本地网关的 10s 天花板上一起放弃 | **全部**——那个「兜底」是往刚失败的同一根管子里再打一次 |

所以新检查报的是**传输数**，不是通道数。通道从账本读（与投递率那条同源：第三个通道
开始写结果的当天就被数进来，不用等谁改列表）；传输向真正发送的那段代码要。

线上：

```
⚠ delivery chain  2 channel(s) (telegram/wechat) · 1 transport (openclaw) —
                  a channel outage costs one leg, a transport outage costs
                  every one at once, including the watchdog backstop that
                  goes down the same pipe
```

WARNING，且**不提任何方案**：补发／保活／换通道被否过三次。它只把「这本账到底有
几条腿」说出口。单通道不报——一条腿本来就是一条腿，对着正确配置报警只会训练读者
跳过这一行。

## 顺带一处分层修正

provider 的选择挪进 adapter 层（`providers.delivery.default_provider`），harness 的
`_delivery()` 转调它。原因是硬的：`system_check` **不允许** import
`_watchdog_common`（`test_system_check_reads_cron_state_only_through_the_core_provider`
——它是能脱离本仓分发运行的运维工具），而它需要同一个答案。一份实现，两个调用方，
不会漂。

## RED-CHECK

改前四条新用例全红（`AttributeError: check_delivery_chain_shape`）。

https://claude.ai/code/session_01QGcWeWzCPsvUoojnZCjTLm