### PR TITLE
health: 兜底的彩排失败了六天，没有一个面在看

### DIFF
--- a/.github/workflows/brief-fallback.yml
+++ b/.github/workflows/brief-fallback.yml
@@ -158,13 +158,28 @@ jobs:
         # narrower and is fully answered by this point: can the provider chain
         # generate today's brief inside the job's budget. Postflight is
         # exercised for real by the primary path every trading day.
-        if: steps.check.outputs.branch == 'rehearsal'
+        #
+        # `always()`: without it this step is itself `skipped` whenever the
+        # generation chain fails — i.e. in precisely the case it exists to
+        # report. On 2026-09-02 the chain died (MiniMax timeout x3, opencode
+        # `CreditsError: Insufficient balance`) and the drill's own verdict step
+        # never ran; the summary said only "Job status: failure". Same class as
+        # #1230: the branch that runs only when something is wrong is not
+        # exercised by a green run.
+        if: always() && steps.check.outputs.branch == 'rehearsal'
         run: |
           set -euo pipefail
           TODAY=$(TZ=Asia/Hong_Kong date +%Y-%m-%d)
           target="memory/${TODAY}-pre-open.md"
           if [ ! -s "$target" ]; then
             echo "::error::rehearsal produced no brief at $target — the backstop would NOT have worked today"
+            {
+              echo "### Rehearsal"
+              echo
+              echo "**The backstop would NOT have worked today.** The generation"
+              echo "chain did not produce \`$target\`. See the step log above for"
+              echo "which providers failed and why."
+            } >> "$GITHUB_STEP_SUMMARY"
             exit 1
           fi
           bytes=$(wc -c < "$target")

--- a/.github/workflows/cron-health.yml
+++ b/.github/workflows/cron-health.yml
@@ -75,6 +75,28 @@ jobs:
           # do NOT open an issue: per kcn's "no per-cron alerts" preference the daily review
           # covers it.
 
+      # The one brief-fallback run per week that carries information — the
+      # Wednesday rehearsal — used to reach nobody. It failed on 2026-09-02
+      # (MiniMax timed out, opencode returned `CreditsError: Insufficient
+      # balance`) and sat unnoticed for six days: one red among ~20 green
+      # no-op skips, demoted by the rollup below to a dot, with its verdict
+      # written only into that run's own step summary.
+      #
+      # Separate step, not folded into the rollup: the rollup is report-only
+      # because a `gh` hiccup must not redden a check that has its own verdict,
+      # and that tolerance is right for it. Here the distinction is made inside
+      # the script instead — `unknown` (no gh, bad JSON, renamed steps) exits 0,
+      # and only a *determined* dead backstop is allowed to redden. So this
+      # keeps the gh-hiccup tolerance without paying for it in silence.
+      - name: Off-host brief backstop — did its last rehearsal pass?
+        # `always()`, or this never runs on the days it matters most: the health
+        # check above exits non-zero on any miss (5 of its last 6 runs), which
+        # would skip every later step without it.
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: python3 ops/ci/backstop_rehearsal.py --strict
+
       - name: Fold Actions-side failures into the daily summary
         # cron_health_check only sees host-side products; a scheduled workflow
         # that fails (or stops firing) on the Actions side was previously

--- a/ops/ci/README.md
+++ b/ops/ci/README.md
@@ -5,3 +5,9 @@ scheduled-workflow health, and the generated command catalog in
 `docs/reference/commands.md` (`python3 ops/ci/generate_tool_reference.py`,
 `--check` to fail on drift). They report on package and profile behavior but
 are not runtime APIs and do not belong in the wheel.
+
+`backstop_rehearsal.py` answers one question daily from `cron-health.yml`: did
+`brief-fallback.yml`'s weekly drill last prove the off-host brief chain works?
+Every other run of that workflow is a no-op skip, so its green ticks say
+nothing — `--strict` reddens only on a *determined* dead backstop and never on
+a `gh` lookup failure.

--- a/ops/ci/backstop_rehearsal.py
+++ b/ops/ci/backstop_rehearsal.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""Did the off-host brief backstop's weekly rehearsal pass, and how long ago?
+
+`brief-fallback.yml` rehearses its generation chain every Wednesday (`23 4 * * 3`)
+precisely because every other run of that workflow is a no-op: the primary brief
+lands, the run takes the `already-exists` branch in 20 seconds, and a green tick
+says nothing at all about whether the backstop could produce a brief. The
+rehearsal is the ONE run per week that carries information.
+
+Nothing read it. On 2026-09-02 the rehearsal failed — MiniMax timed out three
+times, opencode returned `HTTP 401 CreditsError: Insufficient balance`, so the
+whole off-host chain was dead — and it stayed unnoticed for six days, because:
+
+  - the failure is one red run among ~20 green skips, and `workflow_health.py`'s
+    generic heuristic (`streak >= 2` is attention, one failure is a dot) demotes
+    it to `· brief-fallback.yml 1 failure(s) in 7d`. For a workflow whose runs are
+    almost all no-ops that heuristic is backwards: one failure IS the signal;
+  - the rehearsal's verdict is written only to `$GITHUB_STEP_SUMMARY` on that run;
+  - nothing else on the daily path looks at brief-fallback at all.
+
+## Identifying the rehearsal run
+
+The GitHub API does not report which cron expression triggered a scheduled run
+(`/actions/runs/<id>` has `event`, never the schedule), so the run is identified
+by the **shape of its step conclusions**, which is unambiguous and was verified
+against real runs:
+
+    branch          preflight/LLM steps    "Commit + push"
+    already-exists  skipped                skipped
+    too-late        skipped                skipped
+    rehearsal       ran                    skipped
+    generated       ran                    ran
+
+Note the rehearsal's own check step (`Rehearsal — did the chain…`) is NOT the
+discriminator: when the generation chain fails, that step is itself `skipped`,
+which is exactly the case this module exists to catch. `tests/` pins the step
+names against the workflow file so a rename cannot silently turn every run into
+`unknown`.
+
+## Reporting rules
+
+A lookup that failed and a rehearsal that failed must never collapse into the
+same answer — that is the same lie `_gh_json` was written to stop telling in
+`_watchdog_common`. `status` is one of:
+
+    pass     the last rehearsal generated a brief
+    fail     the last rehearsal did not — the backstop would not work today
+    overdue  the last rehearsal is older than two of its own weekly periods
+    unknown  could not be determined (no gh, bad JSON, no runs, renamed steps)
+
+`--strict` exits non-zero for `fail`/`overdue` only. `unknown` always exits 0:
+a gh hiccup must not redden a health check that has its own verdict.
+
+Usage:
+    backstop_rehearsal.py              # human-readable verdict, always exit 0
+    backstop_rehearsal.py --strict     # exit 1 on a determined failure
+    backstop_rehearsal.py --json
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime, timezone
+
+WORKFLOW = "brief-fallback.yml"
+# Steps whose conclusion carries the branch signature. Pinned by
+# tests/test_backstop_rehearsal.py against the workflow file itself.
+GENERATION_STEP = "Call off-host LLM to generate brief"
+PUBLISH_STEP = "Commit + push"
+# The rehearsal fires weekly; allow two of its own periods before calling it
+# overdue, matching workflow_health.MISSED_CADENCE_FACTOR's intent — one delayed
+# or skipped week is a slow scheduler, two is a backstop nobody is testing.
+OVERDUE_DAYS = 15
+RUN_LOOKBACK = 30
+
+
+def _run(cmd, timeout=60):
+    return subprocess.run(cmd, capture_output=True, text=True, timeout=timeout).stdout
+
+
+def _json(runner, cmd):
+    """Parsed JSON, or None. None means 'could not determine', never 'empty'."""
+    try:
+        raw = runner(cmd)
+    except Exception:
+        return None
+    try:
+        return json.loads(raw or "")
+    except (json.JSONDecodeError, TypeError):
+        return None
+
+
+def _steps(runner, run_id, repo):
+    payload = _json(runner, ["gh", "api", f"/repos/{repo}/actions/runs/{run_id}/jobs"])
+    if not isinstance(payload, dict):
+        return None
+    steps = {}
+    for job in payload.get("jobs") or []:
+        for step in job.get("steps") or []:
+            name = step.get("name")
+            if name:
+                steps[name] = step.get("conclusion")
+    return steps or None
+
+
+def classify(steps):
+    """Which branch of brief-fallback.yml did this run take?
+
+    Returns 'rehearsal', 'generated', 'skipped', or None when the signature
+    cannot be read — a renamed step must produce None, not a wrong branch.
+    """
+    if not steps or GENERATION_STEP not in steps or PUBLISH_STEP not in steps:
+        return None
+    if steps[GENERATION_STEP] == "skipped":
+        return "skipped"
+    return "rehearsal" if steps[PUBLISH_STEP] == "skipped" else "generated"
+
+
+def _parse(value):
+    try:
+        return datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except (TypeError, ValueError):
+        return None
+
+
+def assess(runner=None, now=None, repo=None, limit=RUN_LOOKBACK):
+    """Verdict on the most recent rehearsal of the off-host brief backstop."""
+    runner = runner or _run
+    # GITHUB_REPOSITORY first so the check reads the repository it is running
+    # in (a fork included) rather than a hard-coded upstream.
+    repo = (repo or os.environ.get("GITHUB_REPOSITORY")
+            or os.environ.get("CLAWOCK_TRAFFIC_REPO") or "KCNyu/clawock")
+    now = now or datetime.now(timezone.utc)
+
+    runs = _json(runner, [
+        "gh", "run", "list", "--workflow", WORKFLOW, "--limit", str(limit),
+        "--json", "databaseId,createdAt,conclusion,event,url",
+    ])
+    if not isinstance(runs, list):
+        return {"status": "unknown", "reason": "could not list brief-fallback runs"}
+    if not runs:
+        return {"status": "unknown", "reason": "no brief-fallback runs in history"}
+
+    unreadable = 0
+    for entry in sorted(runs, key=lambda r: str(r.get("createdAt")), reverse=True):
+        run_id = entry.get("databaseId")
+        if run_id is None:
+            continue
+        branch = classify(_steps(runner, run_id, repo))
+        if branch is None:
+            unreadable += 1
+            continue
+        if branch != "rehearsal":
+            continue
+        at = _parse(entry.get("createdAt"))
+        age_days = round((now - at).total_seconds() / 86400, 1) if at else None
+        conclusion = entry.get("conclusion")
+        result = {
+            "run_id": run_id,
+            "run_url": entry.get("url"),
+            "at": entry.get("createdAt"),
+            "age_days": age_days,
+            "conclusion": conclusion,
+        }
+        if conclusion != "success":
+            result["status"] = "fail"
+            result["reason"] = (
+                f"the last rehearsal ({conclusion or 'no conclusion'}) did not produce "
+                "a brief — the off-host backstop would not work today")
+            return result
+        if age_days is not None and age_days > OVERDUE_DAYS:
+            result["status"] = "overdue"
+            result["reason"] = (
+                f"the last passing rehearsal was {age_days}d ago (weekly cadence, "
+                f"cutoff {OVERDUE_DAYS}d) — the backstop is untested")
+            return result
+        result["status"] = "pass"
+        result["reason"] = "the off-host generation chain produced a brief"
+        return result
+
+    if unreadable:
+        return {"status": "unknown",
+                "reason": f"{unreadable} run(s) had an unreadable step signature — "
+                          "brief-fallback.yml step names may have changed"}
+    return {"status": "overdue",
+            "reason": f"no rehearsal found in the last {len(runs)} runs — "
+                      "the weekly drill is not firing"}
+
+
+MARKS = {"pass": "✓", "fail": "✗", "overdue": "✗", "unknown": "~"}
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0],
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--strict", action="store_true",
+                    help="exit 1 on a determined failure (never on 'unknown')")
+    ap.add_argument("--json", action="store_true")
+    args = ap.parse_args(argv)
+
+    verdict = assess()
+    if args.json:
+        print(json.dumps(verdict, ensure_ascii=False, sort_keys=True))
+    else:
+        mark = MARKS.get(verdict["status"], "~")
+        print(f"  {mark} off-host brief backstop   {verdict['reason']}")
+        if verdict.get("run_url"):
+            print(f"      last rehearsal: {verdict['run_url']} "
+                  f"({verdict.get('at')})")
+    if args.strict and verdict["status"] in ("fail", "overdue"):
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_backstop_rehearsal.py
+++ b/tests/test_backstop_rehearsal.py
@@ -1,0 +1,184 @@
+"""Contracts for the off-host brief backstop's rehearsal check.
+
+Two things are under test and only one of them is the code:
+
+  - the verdict logic, including the distinction this module exists for —
+    "the rehearsal failed" and "I could not find out" must never produce the
+    same answer;
+  - the coupling to `brief-fallback.yml`. The rehearsal run is identified by the
+    conclusions of two named steps, so a rename in the workflow would silently
+    turn every run into `unknown` and the check would go quiet exactly the way
+    the thing it replaced did. The workflow file is asserted against here.
+"""
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from ops.ci import backstop_rehearsal as br
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "brief-fallback.yml"
+NOW = datetime(2026, 9, 8, 12, 0, tzinfo=timezone.utc)
+
+
+def _steps(**names):
+    return {"jobs": [{"steps": [{"name": n, "conclusion": c}
+                                for n, c in names.items()]}]}
+
+
+def _signature(generation, publish):
+    return _steps(**{
+        "Set up job": "success",
+        br.GENERATION_STEP: generation,
+        br.PUBLISH_STEP: publish,
+    })
+
+
+def fake_gh(runs, jobs):
+    """A `gh` stand-in: `run list` yields `runs`, `api .../jobs` yields `jobs[id]`."""
+    def runner(cmd):
+        if cmd[:3] == ["gh", "run", "list"]:
+            return json.dumps(runs)
+        if cmd[:2] == ["gh", "api"]:
+            run_id = int(cmd[2].split("/runs/")[1].split("/")[0])
+            return json.dumps(jobs[run_id])
+        raise AssertionError(f"unexpected command {cmd}")
+    return runner
+
+
+def _run(run_id, created_at, conclusion="success"):
+    return {"databaseId": run_id, "createdAt": created_at,
+            "conclusion": conclusion, "event": "schedule",
+            "url": f"https://github.com/KCNyu/clawock/actions/runs/{run_id}"}
+
+
+# --- classify -------------------------------------------------------------
+
+@pytest.mark.parametrize("generation,publish,expected", [
+    ("skipped", "skipped", "skipped"),      # already-exists / too-late
+    ("success", "skipped", "rehearsal"),
+    ("failure", "skipped", "rehearsal"),    # the case that matters
+    ("success", "success", "generated"),
+])
+def test_classify_reads_the_branch_from_step_conclusions(generation, publish, expected):
+    steps = {br.GENERATION_STEP: generation, br.PUBLISH_STEP: publish}
+    assert br.classify(steps) == expected
+
+
+def test_classify_returns_none_when_a_step_name_is_missing():
+    """A renamed step must read as 'cannot tell', never as a branch."""
+    assert br.classify({"Some Renamed Step": "success"}) is None
+    assert br.classify({}) is None
+    assert br.classify(None) is None
+
+
+# --- assess ---------------------------------------------------------------
+
+def test_failed_rehearsal_is_reported_as_fail_not_as_a_missing_run():
+    runs = [_run(3, "2026-09-08T05:52:02Z"), _run(2, "2026-09-02T08:51:01Z", "failure")]
+    jobs = {3: _signature("skipped", "skipped"),
+            2: _signature("failure", "skipped")}
+    verdict = br.assess(runner=fake_gh(runs, jobs), now=NOW)
+    assert verdict["status"] == "fail"
+    assert verdict["run_id"] == 2
+    assert verdict["age_days"] == 6.1
+
+
+def test_passing_rehearsal_is_pass():
+    runs = [_run(3, "2026-09-08T05:52:02Z"), _run(2, "2026-09-02T08:51:01Z")]
+    jobs = {3: _signature("skipped", "skipped"),
+            2: _signature("success", "skipped")}
+    assert br.assess(runner=fake_gh(runs, jobs), now=NOW)["status"] == "pass"
+
+
+def test_a_real_fallback_run_is_not_mistaken_for_a_rehearsal():
+    """`generated` commits; only the drill leaves the publish step skipped."""
+    runs = [_run(9, "2026-09-07T01:00:00Z"), _run(2, "2026-09-02T08:51:01Z")]
+    jobs = {9: _signature("success", "success"),      # generated, for real
+            2: _signature("success", "skipped")}      # the rehearsal
+    verdict = br.assess(runner=fake_gh(runs, jobs), now=NOW)
+    assert verdict["run_id"] == 2
+
+
+def test_stale_passing_rehearsal_is_overdue():
+    runs = [_run(2, "2026-08-01T08:51:01Z")]
+    jobs = {2: _signature("success", "skipped")}
+    verdict = br.assess(runner=fake_gh(runs, jobs), now=NOW)
+    assert verdict["status"] == "overdue"
+
+
+def test_no_rehearsal_in_history_is_overdue_not_pass():
+    """A drill that stopped firing is a fact, not an absence of facts."""
+    runs = [_run(3, "2026-09-08T05:52:02Z")]
+    jobs = {3: _signature("skipped", "skipped")}
+    assert br.assess(runner=fake_gh(runs, jobs), now=NOW)["status"] == "overdue"
+
+
+def test_broken_gh_is_unknown_never_pass_and_never_fail():
+    def runner(cmd):
+        raise RuntimeError("gh: could not connect")
+    assert br.assess(runner=runner, now=NOW)["status"] == "unknown"
+
+
+def test_unparseable_output_is_unknown():
+    assert br.assess(runner=lambda cmd: "not json", now=NOW)["status"] == "unknown"
+
+
+def test_renamed_steps_are_unknown_not_overdue():
+    """The failure mode this check must not have: going quiet after a rename."""
+    runs = [_run(3, "2026-09-08T05:52:02Z")]
+    jobs = {3: _steps(**{"Totally Renamed": "success"})}
+    verdict = br.assess(runner=fake_gh(runs, jobs), now=NOW)
+    assert verdict["status"] == "unknown"
+    assert "step names" in verdict["reason"]
+
+
+# --- exit codes -----------------------------------------------------------
+
+@pytest.mark.parametrize("status,strict_exit", [
+    ("pass", 0), ("fail", 1), ("overdue", 1), ("unknown", 0),
+])
+def test_strict_exits_only_on_a_determined_failure(monkeypatch, capsys, status, strict_exit):
+    monkeypatch.setattr(br, "assess", lambda: {"status": status, "reason": "r"})
+    assert br.main(["--strict"]) == strict_exit
+    assert br.main([]) == 0                     # never red without --strict
+    capsys.readouterr()
+
+
+# --- coupling to the workflow --------------------------------------------
+
+def test_the_step_names_this_check_keys_on_still_exist_in_the_workflow():
+    text = WORKFLOW.read_text(encoding="utf-8")
+    for step in (br.GENERATION_STEP, br.PUBLISH_STEP):
+        assert f"- name: {step}" in text, (
+            f"backstop_rehearsal.py keys on the step {step!r}, which is no longer "
+            f"in {WORKFLOW.name}. Update both together — a rename here makes every "
+            "run read as 'unknown' and the check goes silent.")
+
+
+def test_the_publish_step_is_still_skipped_on_a_rehearsal():
+    """The whole discriminator rests on this condition; assert it is still there."""
+    text = WORKFLOW.read_text(encoding="utf-8")
+    publish = text.split(f"- name: {br.PUBLISH_STEP}", 1)[1].split("- name:", 1)[0]
+    assert "branch != 'rehearsal'" in publish
+
+
+def test_the_rehearsal_verdict_step_runs_even_when_the_chain_failed():
+    """`if: always()` — the 2026-09-02 defect: the drill's verdict step was itself
+    skipped by the failure it existed to report."""
+    text = WORKFLOW.read_text(encoding="utf-8")
+    block = text.split("- name: Rehearsal", 1)[1].split("run: |", 1)[0]
+    assert "always()" in block
+
+
+def test_cron_health_runs_this_check_and_does_not_skip_it_on_a_red_verdict():
+    cron_health = (ROOT / ".github" / "workflows" / "cron-health.yml").read_text()
+    assert "ops/ci/backstop_rehearsal.py --strict" in cron_health
+    block = cron_health.split("- name: Off-host brief backstop", 1)[1].split("run:", 1)[0]
+    assert "if: always()" in block, (
+        "the cron health check exits non-zero on a miss; without always() this "
+        "step is skipped on exactly the days somebody is reading the run")


### PR DESCRIPTION
## 症状

`brief-fallback.yml` 每周三彩排一次生成链（`23 4 * * 3`），因为它其余每一次运行都是空转：主简报落地 → `already-exists` 分支 20 秒返回绿。**那些绿说明不了兜底能不能用**，一周一次的彩排是唯一带信息的那次运行。

[2026-09-02 的彩排失败了](https://github.com/KCNyu/clawock/actions/runs/33610915081)：

```
minimax:  ConnectionError: RemoteDisconnected → timeout after 74s (attempt 2)
opencode: HTTP 401 {"type":"CreditsError","message":"Insufficient balance"}
RuntimeError: all LLM providers failed
BRANCH: rehearsal   REHEARSAL_RESULT: failure
```

整条 off-host 链是死的，然后躺了六天。三件事同时成立：

1. 它是 ~20 次空转绿里的一条红，`workflow_health.py` 的通用启发式（`streak >= 2` 才算 attention）把它降成一个点：`· brief-fallback.yml 1 failure(s) in 7d`。对一个绝大多数运行都是空转的 workflow，这条启发式是反的——**一次失败就是信号**。
2. 彩排的判词只写进那次运行自己的 `$GITHUB_STEP_SUMMARY`。
3. 日常路径上没有任何东西看 brief-fallback。

## 怎么认出彩排那次运行

GitHub 不报是哪条 cron 触发了排程运行（`/actions/runs/<id>` 只有 `event`，没有 schedule），所以按**步骤结论的形状**认，对着真实运行核过：

| 分支 | preflight/LLM 步 | `Commit + push` |
|---|---|---|
| already-exists | skipped | skipped |
| too-late | skipped | skipped |
| **rehearsal** | 跑了 | skipped |
| generated | 跑了 | 跑了 |

彩排自己那个检查步 **不能** 当判据：生成链一失败，那步自己就是 `skipped`——而那正是要抓的情况。09-02 的摘要因此只剩一句 `Job status: failure`。顺手把它改成 `if: always() && ...`，让判词在链挂掉时也照样写出来（#1230 那一族：只在出事时才走的分支，跑绿的运行证明不了它）。

## 判据：查不到 ≠ 是坏的

只有 `fail` / `overdue` 允许 `--strict` 判红；`unknown`（没有 gh / JSON 坏了 / 步骤被改名）永远退 0。

cron-health 里那条 rollup 是 report-only 的，理由写着「gh 打嗝不该染红一个自己有判词的检查」——那条容忍是对的，所以没去动它，而是把区分做进脚本本身：**保留同样的容忍，但不再用沉默去换**。

新步骤带 `if: always()`：上面的 cron health check 一有缺漏就退非零（最近 6 次里 5 次），没有 `always()` 这步恰好会在有人看的那些天被跳过。

## 闸

`tests/test_backstop_rehearsal.py` 21 条，除了判词逻辑，还把两个步骤名钉在 workflow 文件上——改名会让每次运行都读成 `unknown`、检查就又哑了，那正是它要替掉的失败模式。另外钉住 `Commit + push` 仍然 `branch != 'rehearsal'`（整个判据压在这个条件上）、彩排判词步仍然 `always()`、cron-health 那步仍然 `always()`。

## 本地验证

- `tests/test_backstop_rehearsal.py` 21 passed
- `-k "workflow or cron or health or fallback or brief"` 681 passed / 1 xfailed
- `test_pr_publish_gate_contract` + `test_pages_deployment_contract` + `test_schedule_drift` 46 passed
- `ops/ci/argparse_probe.py` OK · `generate_tool_reference.py --check` OK
- 对线上真数据跑：正确抓到 09-02 那次，10 秒，`status: fail`

## 不在本 PR 里

彩排失败的**原因**（opencode 钱包清零 + MiniMax 超时）要 kcn 处理账单侧；本 PR 只保证它下次不会再无声无息躺六天。

https://claude.ai/code/session_0147aMJtz1vX1aNdJ7SXA19u