### PR TITLE
punctuality: 五个 workflow 头注释里的准时假设，从来没人核对过

### DIFF
--- a/.github/workflows/brief-fallback.yml
+++ b/.github/workflows/brief-fallback.yml
@@ -26,9 +26,26 @@ name: Brief Fallback (off-host LLM)
 #     weekly so "can this thing work" stops being an untested assumption.
 on:
   schedule:
-    # Three attempts across the usable window rather than one. Measured drift
-    # for this slot is +89..159 minutes (#781) and it is driven by how contended
-    # the UTC hour is, not by the minute, so no single choice is reliable.
+    # Three attempts across the usable window rather than one. When this was
+    # calibrated the measured drift for the slot was +89..159 minutes (#781), so
+    # the earliest attempt to arrive in-window would win.
+    #
+    # THAT NO LONGER HOLDS, and the schedule is kept anyway. On 2026-08-27 the
+    # drift regime stepped repo-wide from a ~72min median to ~271min (the delay
+    # is in GitHub creating the run — queue wait is 0s on all 203 scheduled runs
+    # sampled — so there is nothing to tune on our side). Measured over 67
+    # scheduled days an attempt landed inside the `HOUR >= 10 HKT` window on 5,
+    # and on 0 of the 10 days since 2026-08-26. The window opens at 00:25 UTC
+    # because anything earlier races the still-generating primary brief, so no
+    # schedule can be made to fit inside it either.
+    #
+    # What actually fires this workflow is the host: `brief_watchdog
+    # --check-missing` dispatches it at 09:05 HKT (dispatch latency is seconds).
+    # These legs remain as the host-down long shot, at a cost of ~20s per run.
+    # Declared and reasoned about in `config/schedule-punctuality.json`
+    # (`enforcement: accepted`) so this stays a written decision instead of
+    # decaying into a comment nobody rechecks — `ops/ci/schedule_punctuality.py`
+    # rechecks it daily against the measurement.
     - cron: '25 0 * * 1-5'
     - cron: '47 0 * * 1-5'
     - cron: '9 1 * * 1-5'

--- a/.github/workflows/cron-health.yml
+++ b/.github/workflows/cron-health.yml
@@ -97,6 +97,26 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: python3 ops/ci/backstop_rehearsal.py --strict
 
+      # `assets/data/schedule-drift.json` has measured GitHub's delivery
+      # lateness twice a week since #781 and nothing read it, while five
+      # workflow headers carried a punctuality budget in prose ("~2.25h before
+      # the 08:00 HKT brief", "buffer for GH Actions' 1-2h delay"). When the
+      # drift regime stepped from ~72min to ~271min on 2026-08-27, every one of
+      # those sentences quietly became false — brief-fallback has not landed
+      # inside its own usefulness window on any of the last 10 scheduled days.
+      #
+      # Offline and deterministic: it reads two tracked files, no `gh`, so
+      # unlike the rollup below it can carry a verdict. Red only on a SUSTAINED
+      # breach of an *enforced* deadline — one late arrival is GitHub having a
+      # bad hour, and a deadline we have decided to live with is declared
+      # `accepted` in the contract rather than reddening the run forever.
+      - name: Scheduled-workflow punctuality
+        # `always()` for the same reason as the step above: the health check
+        # exits non-zero on any miss, which would skip this on the days it
+        # matters.
+        if: always()
+        run: python3 ops/ci/schedule_punctuality.py --strict
+
       - name: Fold Actions-side failures into the daily summary
         # cron_health_check only sees host-side products; a scheduled workflow
         # that fails (or stops firing) on the Actions side was previously

--- a/config/schedule-punctuality.json
+++ b/config/schedule-punctuality.json
@@ -1,0 +1,68 @@
+{
+  "schema_version": 1,
+  "deadline_tz": "Asia/Hong_Kong",
+  "note": "Which scheduled workflows bet on GitHub delivering them on time, and by when. Five workflow headers already asserted a punctuality budget in prose ('~2.25h before the 08:00 HKT brief', 'buffer for GH Actions' 1-2h scheduled-cron delay'); nothing ever checked those assertions against assets/data/schedule-drift.json, so when measured drift stepped from ~72min to ~271min on 2026-08-27 every one of them silently became wrong. ops/ci/schedule_punctuality.py is the consumer. Every workflow with a `schedule:` must appear here - tests/test_schedule_punctuality.py enumerates them - so a new deadline cannot be acquired silently.",
+  "enforcement": {
+    "enforced": "a sustained breach reddens the daily cron-health run",
+    "accepted": "the deadline is real and currently unmet; the reason records why that is tolerated instead of pretending otherwise"
+  },
+  "workflows": {
+    "brief-fallback.yml": {
+      "deadline_hkt": "10:00",
+      "enforcement": "accepted",
+      "why": "Its own `HOUR >= 10 HKT` gate: a pre-open brief generated after HK open is stale noise, so the deadline is real and the gate is right. #780 answered GitHub's then-measured 89-159min drift by firing three times (08:25/08:47/09:09 HKT) so the earliest in-window attempt would win. Measured over 67 scheduled days, an attempt arrived in window on 5, and on 0 of the 10 days since 2026-08-26 - the mitigation expired when the drift regime changed. Accepted, not enforced, because there is no fix on our side: the window opens at 00:25 UTC (earlier races the still-generating primary brief) and GitHub is now delivering 219-588min late, so no schedule can be made to land inside it. The real trigger is the host: brief_watchdog --check-missing dispatches this workflow at 09:05 HKT via `gh workflow run` (dispatch latency is seconds, not hours). What the scheduled legs still cover is the host-down case, and in that case they cannot arrive in time - that gap is the accepted cost."
+    },
+    "macro-scan.yml": {
+      "deadline_hkt": "08:00",
+      "enforcement": "enforced",
+      "why": "Feeds the 08:03 HKT pre-open brief. Its own header sizes the 21:45 UTC slot as '~2.25h before the brief ... GH Action scheduled crons routinely fire 1-2h LATE'. brief_preflight omits macro entirely past 36h, so a late scan does not corrupt the brief - it silently costs it a day of macro."
+    },
+    "sentiment-scan.yml": {
+      "deadline_hkt": "08:00",
+      "enforcement": "enforced",
+      "why": "Same bet as macro-scan, stated in its own header: '21:30 UTC ... ~2.5h before the 08:00 HKT brief. Scheduled this early to absorb GH Actions' typical 1-2h scheduled-cron delay.'"
+    },
+    "influencer-scan.yml": {
+      "deadline_hkt": "08:00",
+      "enforcement": "enforced",
+      "why": "Morning leg feeds the brief; its header says '~2.3h before the 08:00 HKT brief (buffer for GH Actions' 1-2h scheduled-cron delay)'. The evening leg (20:50 HKT) is measured against the NEXT morning's deadline, which is the run it actually feeds."
+    },
+    "weekly-health.yml": {
+      "deadline_hkt": "08:00",
+      "enforcement": "enforced",
+      "why": "Header: 'Sundays 23:00 UTC (Monday 07:00 HKT, before the 08:00 brief and HK open)'. A drift check that lands after the week's first brief and open has already missed what it exists to catch."
+    },
+    "news-digest.yml": {
+      "deadline_hkt": null,
+      "why": "Had a deadline and gave it up on the evidence, which is the outcome this contract is for. Its header now reads 'treat it as an around-the-open product, not a pre-open one' after measured drift put it past the 21:30 HKT US open. Nothing downstream requires it before a fixed instant."
+    },
+    "cron-health.yml": {
+      "deadline_hkt": null,
+      "why": "Explicitly drift-insensitive by its own design note: it reads the day's already-landed git products and heartbeats, so an hour later reads the same facts."
+    },
+    "eod-archive.yml": {
+      "deadline_hkt": null,
+      "why": "Appends the week's settled closing prices to a historical CSV. The prices are final before it starts; nothing reads the file on a schedule."
+    },
+    "repo-traffic.yml": {
+      "deadline_hkt": null,
+      "why": "Captures rolling-window measurements (GitHub Traffic keeps 14 days, and the schedule-drift sample this contract consumes). Twice weekly against a 14-day window - hours of lateness cost nothing."
+    },
+    "screenshot-refresh.yml": {
+      "deadline_hkt": null,
+      "why": "Keeps README visuals under a 7-day staleness bound. Hours do not move a 7-day bound."
+    },
+    "seo-visibility.yml": {
+      "deadline_hkt": null,
+      "why": "Weekly Search Console pull into the run log. No consumer waits on it."
+    },
+    "weekly-review.yml": {
+      "deadline_hkt": null,
+      "why": "Writes memory/weekly/<ISO week>.md for a week that has already ended. Late is fine; missing is not, and that is workflow_health.py's overdue check, not a punctuality question."
+    },
+    "ci.yml": {
+      "deadline_hkt": null,
+      "why": "The weekly scheduled run is a drift sweep over code that is not changing at that hour. Its PR and push triggers are the ones that gate anything."
+    }
+  }
+}

--- a/ops/ci/schedule_punctuality.py
+++ b/ops/ci/schedule_punctuality.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+"""Do the workflows that bet on GitHub being punctual still win that bet?
+
+`assets/data/schedule-drift.json` has been measuring GitHub's delivery lateness
+twice a week since #781. Nothing read it. Five workflow headers meanwhile carry
+a punctuality budget in prose — "~2.25h before the 08:00 HKT brief", "buffer for
+GH Actions' 1-2h scheduled-cron delay" — and those sentences were the only thing
+holding the design together.
+
+On 2026-08-27 the drift regime changed. Measured on `news-digest.yml`, the
+cleanest probe in the repo (one daily cron, `0 13 * * 1-5`):
+
+    07-28..08-26   n=22   median  72.5 min   max 157.2
+    08-27..09-07   n=8    median 271.4 min   min 219.1
+
+The step is clean (the post-08-27 minimum exceeds the pre-08-27 maximum) and it
+is not ours: it lands on four different UTC hours at once, runs/day went *down*
+over the same period (206 -> 145), and `created_at == run_started_at` on all 203
+scheduled runs sampled, so the delay is in GitHub creating the run, not in
+waiting for a runner. Nothing on our side can shorten it.
+
+What can be fixed is that no gate noticed. `workflow_health.py` asks "did it
+fail" and "did it run at all"; a workflow delivered four hours late still ran, so
+lateness is invisible to it. `brief-fallback.yml`'s three-attempt mitigation —
+correct when it was calibrated against 89-159 minutes — has not landed inside its
+own usefulness window on any of the last 10 scheduled days, and said nothing.
+
+## The contract
+
+`config/schedule-punctuality.json` classifies every scheduled workflow: a
+`deadline_hkt` (the instant past which the run has lost its purpose) or `null`
+with the reason it has none. `tests/` enumerates the workflow directory against
+it, so a new workflow cannot acquire a deadline silently.
+
+A deadline is `enforced` (a sustained breach reddens the daily run) or
+`accepted` (real, currently unmet, and the reason says why that is tolerated).
+`accepted` exists so the answer to an unfixable breach is a written decision
+rather than either a lie or a permanently red check nobody can act on.
+
+## Why "sustained"
+
+One late arrival is GitHub having a bad hour; that is a warning, and the count is
+reported. A red means the bet is structurally lost — the last
+`SUSTAINED_BREACH_RUNS` measured arrivals ALL missed the deadline. That is the
+difference between brief-fallback (0 in window in 10 days) and macro-scan (late
+6 times in 20, median arrival still 25 minutes early).
+
+Usage:
+    schedule_punctuality.py            # table, always exit 0
+    schedule_punctuality.py --strict   # exit 1 on a sustained enforced breach
+    schedule_punctuality.py --json
+"""
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+CONTRACT = ROOT / "config" / "schedule-punctuality.json"
+DRIFT = ROOT / "assets" / "data" / "schedule-drift.json"
+WORKFLOW_DIR = ROOT / ".github" / "workflows"
+HKT = dt.timezone(dt.timedelta(hours=8))
+# How many consecutive missed deadlines turn a warning into a verdict. Five is
+# a working week for a daily workflow: long enough that a bad GitHub day cannot
+# reach it, short enough that a design which has actually stopped working is
+# caught inside a week.
+SUSTAINED_BREACH_RUNS = 5
+
+
+def load(path):
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def _parse(value):
+    try:
+        return dt.datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except (TypeError, ValueError):
+        return None
+
+
+def deadline_instant(scheduled, deadline_hkt):
+    """The instant this run had to arrive by, given when it was scheduled.
+
+    The deadline is a time of day. It belongs to the scheduled run's own HKT day
+    when it falls later that day, and to the next one otherwise — which is what
+    makes an evening scan (20:50 HKT) measure against the brief it actually
+    feeds, tomorrow's 08:00, rather than against one that was already over.
+    """
+    hour, minute = (int(part) for part in deadline_hkt.split(":"))
+    local = scheduled.astimezone(HKT)
+    due = local.replace(hour=hour, minute=minute, second=0, microsecond=0)
+    if due <= local:
+        due += dt.timedelta(days=1)
+    return due
+
+
+def assess_workflow(rule, runs):
+    """Verdict for one workflow's measured arrivals against its deadline."""
+    deadline = rule.get("deadline_hkt")
+    if not deadline:
+        return {"status": "no-deadline"}
+
+    samples = []
+    for run in runs:
+        scheduled, started = _parse(run.get("scheduled_at")), _parse(run.get("started_at"))
+        if not scheduled or not started:
+            continue
+        due = deadline_instant(scheduled, deadline)
+        samples.append({
+            "started_at": run.get("started_at"),
+            "arrived_hkt": started.astimezone(HKT).strftime("%m-%d %H:%M"),
+            "due_hkt": due.strftime("%m-%d %H:%M"),
+            "late": started > due,
+            "minutes_late": round((started - due).total_seconds() / 60, 1),
+        })
+    if not samples:
+        return {"status": "unmeasured", "deadline_hkt": deadline,
+                "reason": "no usable drift samples for this workflow"}
+
+    samples.sort(key=lambda s: str(s["started_at"]), reverse=True)
+    recent = samples[:SUSTAINED_BREACH_RUNS]
+    late = [s for s in samples if s["late"]]
+    sustained = len(recent) == SUSTAINED_BREACH_RUNS and all(s["late"] for s in recent)
+
+    enforcement = rule.get("enforcement", "enforced")
+    if sustained:
+        status = "breached" if enforcement == "enforced" else "accepted-breach"
+    elif late:
+        status = "late-sometimes"
+    else:
+        status = "ok"
+    return {
+        "status": status,
+        "deadline_hkt": deadline,
+        "enforcement": enforcement,
+        "samples": len(samples),
+        "late": len(late),
+        "worst_minutes_late": max((s["minutes_late"] for s in late), default=0.0),
+        "latest_arrivals": [f"{s['arrived_hkt']} (due {s['due_hkt']})" for s in recent[:3]],
+    }
+
+
+# `None` is a real answer here — it is what `load` returns for a file that is
+# missing or corrupt, and telling that apart from a met deadline is the whole
+# job. So "argument not supplied" needs its own value, or a test cannot inject
+# the unreadable case and the seam quietly tests nothing.
+_UNSET = object()
+
+
+def report(contract=_UNSET, drift=_UNSET):
+    contract = load(CONTRACT) if contract is _UNSET else contract
+    drift = load(DRIFT) if drift is _UNSET else drift
+    if not contract:
+        return {"status": "unknown", "reason": f"cannot read {CONTRACT.name}",
+                "workflows": {}}
+    if not drift:
+        return {"status": "unknown", "reason": f"cannot read {DRIFT.name}",
+                "workflows": {}}
+
+    measured = {entry.get("workflow"): entry.get("runs") or []
+                for entry in drift.get("workflows") or []}
+    rows = {}
+    for name, rule in (contract.get("workflows") or {}).items():
+        rows[name] = assess_workflow(rule, measured.get(name, []))
+        rows[name]["why"] = rule.get("why", "")
+    breached = [n for n, r in rows.items() if r["status"] == "breached"]
+    return {
+        "status": "breached" if breached else "ok",
+        "measured_at": drift.get("generated_at"),
+        "breached": breached,
+        "workflows": rows,
+    }
+
+
+MARKS = {"ok": "✓", "late-sometimes": "·", "breached": "✗",
+         "accepted-breach": "~", "no-deadline": " ", "unmeasured": "~"}
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0],
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--strict", action="store_true",
+                    help="exit 1 when an enforced deadline is sustainedly breached")
+    ap.add_argument("--all", action="store_true",
+                    help="also list the workflows that have no deadline")
+    ap.add_argument("--json", action="store_true")
+    args = ap.parse_args(argv)
+
+    result = report()
+    if args.json:
+        print(json.dumps(result, ensure_ascii=False, sort_keys=True))
+        return 1 if (args.strict and result["status"] == "breached") else 0
+
+    if result["status"] == "unknown":
+        print(f"  ~ schedule punctuality      {result['reason']}")
+        return 0
+    print(f"schedule punctuality · drift measured {(result['measured_at'] or '?')[:16]}")
+    for name, row in sorted(result["workflows"].items()):
+        if row["status"] == "no-deadline" and not args.all:
+            continue
+        mark = MARKS.get(row["status"], "?")
+        detail = ""
+        if row["status"] in ("ok", "late-sometimes", "breached", "accepted-breach"):
+            detail = (f"deadline {row['deadline_hkt']} HKT · "
+                      f"{row['late']}/{row['samples']} late")
+            if row["late"]:
+                detail += f" · worst +{row['worst_minutes_late']:.0f}min"
+        elif row["status"] == "unmeasured":
+            detail = row["reason"]
+        print(f"  {mark} {name:26} {detail}")
+        if row["status"] in ("breached", "accepted-breach"):
+            for arrival in row["latest_arrivals"]:
+                print(f"      arrived {arrival}")
+    if result["breached"]:
+        print(f"\n🔴 punctuality — {', '.join(result['breached'])} "
+              f"missed its deadline on the last {SUSTAINED_BREACH_RUNS} measured runs")
+    if args.strict and result["status"] == "breached":
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_schedule_punctuality.py
+++ b/tests/test_schedule_punctuality.py
@@ -1,0 +1,200 @@
+"""Contracts for the scheduled-workflow punctuality gate.
+
+The defect being fenced off is not a bug in this module — it is that
+`assets/data/schedule-drift.json` was measured twice a week for three weeks with
+no consumer, while five workflow headers asserted a punctuality budget in prose.
+So the enumeration test matters as much as the logic ones: a workflow that
+acquires a deadline without declaring it here puts the design straight back into
+prose nobody checks.
+"""
+
+import datetime as dt
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+from ops.ci import schedule_punctuality as sp
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW_DIR = ROOT / ".github" / "workflows"
+CONTRACT = json.loads((ROOT / "config" / "schedule-punctuality.json").read_text())
+RULES = CONTRACT["workflows"]
+
+
+def _scheduled_workflows():
+    return sorted(
+        path.name for path in WORKFLOW_DIR.glob("*.yml")
+        if re.search(r"^\s*-\s*cron:", path.read_text(encoding="utf-8"), re.M)
+    )
+
+
+def _run(scheduled_at, started_at):
+    return {"scheduled_at": scheduled_at, "started_at": started_at}
+
+
+def _drift(workflow, runs):
+    return {"generated_at": "2026-09-08T08:19:10Z",
+            "workflows": [{"workflow": workflow, "runs": runs}]}
+
+
+# --- the enumeration gate -------------------------------------------------
+
+def test_every_scheduled_workflow_is_classified():
+    missing = set(_scheduled_workflows()) - set(RULES)
+    assert not missing, (
+        f"{sorted(missing)} run on a schedule but declare no punctuality budget. "
+        "Add an entry to config/schedule-punctuality.json — a deadline_hkt, or "
+        "null with the reason it has none. A workflow whose timing matters and "
+        "says so only in a header comment is how brief-fallback's mitigation "
+        "expired without anything noticing.")
+
+
+def test_the_contract_names_no_workflow_that_stopped_existing():
+    stale = set(RULES) - set(_scheduled_workflows())
+    assert not stale, f"{sorted(stale)} is in the contract but no longer scheduled"
+
+
+@pytest.mark.parametrize("name", sorted(RULES))
+def test_every_entry_gives_a_reason(name):
+    assert RULES[name].get("why", "").strip(), (
+        f"{name} must say why it has (or has not) a deadline")
+
+
+@pytest.mark.parametrize("name", sorted(RULES))
+def test_every_deadline_declares_a_known_enforcement(name):
+    rule = RULES[name]
+    if not rule.get("deadline_hkt"):
+        return
+    assert rule.get("enforcement") in CONTRACT["enforcement"], (
+        f"{name}: enforcement must be one of {sorted(CONTRACT['enforcement'])}")
+
+
+@pytest.mark.parametrize("name", sorted(RULES))
+def test_deadlines_are_well_formed(name):
+    deadline = RULES[name].get("deadline_hkt")
+    if deadline is not None:
+        assert re.fullmatch(r"\d{2}:\d{2}", deadline), f"{name}: {deadline!r}"
+
+
+# --- deadline_instant -----------------------------------------------------
+
+def test_a_deadline_later_the_same_day_belongs_to_that_day():
+    scheduled = dt.datetime(2026, 9, 8, 21, 45, tzinfo=dt.timezone.utc)   # 05:45 HKT
+    assert sp.deadline_instant(scheduled, "08:00").strftime("%m-%d %H:%M") == "09-09 08:00"
+
+
+def test_an_evening_run_is_measured_against_the_next_mornings_deadline():
+    """20:50 HKT feeds tomorrow's 08:00 brief, not one that is already over."""
+    scheduled = dt.datetime(2026, 9, 8, 12, 50, tzinfo=dt.timezone.utc)   # 20:50 HKT
+    assert sp.deadline_instant(scheduled, "08:00").strftime("%m-%d %H:%M") == "09-09 08:00"
+
+
+# --- verdicts -------------------------------------------------------------
+
+def _five_late():
+    return [_run(f"2026-09-0{d}T00:25:00Z", f"2026-09-0{d}T05:00:00Z") for d in range(1, 6)]
+
+
+def test_a_sustained_breach_of_an_enforced_deadline_is_red():
+    rule = {"deadline_hkt": "10:00", "enforcement": "enforced"}
+    assert sp.assess_workflow(rule, _five_late())["status"] == "breached"
+
+
+def test_a_sustained_breach_of_an_accepted_deadline_is_recorded_not_red():
+    """`accepted` is a written decision about an unfixable breach, not a lie:
+    the row still shows the misses, it just does not redden the daily run."""
+    rule = {"deadline_hkt": "10:00", "enforcement": "accepted"}
+    verdict = sp.assess_workflow(rule, _five_late())
+    assert verdict["status"] == "accepted-breach"
+    assert verdict["late"] == 5
+
+
+def test_one_bad_day_is_a_warning_not_a_verdict():
+    runs = _five_late()[:1] + [
+        _run(f"2026-09-0{d}T00:25:00Z", f"2026-09-0{d}T01:00:00Z") for d in range(2, 7)]
+    verdict = sp.assess_workflow({"deadline_hkt": "10:00", "enforcement": "enforced"}, runs)
+    assert verdict["status"] == "late-sometimes"
+    assert verdict["late"] == 1
+
+
+def test_punctual_runs_are_ok():
+    runs = [_run(f"2026-09-0{d}T00:25:00Z", f"2026-09-0{d}T00:40:00Z") for d in range(1, 6)]
+    assert sp.assess_workflow({"deadline_hkt": "10:00"}, runs)["status"] == "ok"
+
+
+def test_fewer_samples_than_the_window_cannot_reach_a_verdict():
+    """Three late runs are not evidence that the bet is structurally lost."""
+    runs = _five_late()[:3]
+    verdict = sp.assess_workflow({"deadline_hkt": "10:00", "enforcement": "enforced"}, runs)
+    assert verdict["status"] == "late-sometimes"
+
+
+def test_no_deadline_short_circuits():
+    assert sp.assess_workflow({"deadline_hkt": None}, _five_late())["status"] == "no-deadline"
+
+
+def test_a_workflow_with_no_drift_samples_is_unmeasured_not_ok():
+    verdict = sp.assess_workflow({"deadline_hkt": "08:00"}, [])
+    assert verdict["status"] == "unmeasured"
+
+
+# --- report + exit codes --------------------------------------------------
+
+def test_report_flags_only_enforced_breaches():
+    contract = {"enforcement": {"enforced": "", "accepted": ""}, "workflows": {
+        "a.yml": {"deadline_hkt": "10:00", "enforcement": "enforced", "why": "x"},
+        "b.yml": {"deadline_hkt": "10:00", "enforcement": "accepted", "why": "x"},
+    }}
+    drift = {"generated_at": "2026-09-08T08:19:10Z", "workflows": [
+        {"workflow": "a.yml", "runs": _five_late()},
+        {"workflow": "b.yml", "runs": _five_late()},
+    ]}
+    result = sp.report(contract=contract, drift=drift)
+    assert result["breached"] == ["a.yml"]
+    assert result["status"] == "breached"
+
+
+def test_an_unreadable_drift_file_is_unknown_and_never_red(capsys):
+    """A missing measurement must not be reported as a met deadline, and must
+    not redden a run either — same rule as backstop_rehearsal's `unknown`."""
+    result = sp.report(contract=CONTRACT, drift=None)
+    assert result["status"] == "unknown"
+    capsys.readouterr()
+
+
+def test_the_real_loader_also_reaches_unknown_when_the_file_is_gone(monkeypatch, tmp_path):
+    """Not just the injected seam: the production path with no drift file on
+    disk must reach the same verdict."""
+    monkeypatch.setattr(sp, "DRIFT", tmp_path / "nope.json")
+    assert sp.report()["status"] == "unknown"
+    assert sp.main(["--strict"]) == 0
+
+
+def test_strict_exits_1_only_on_a_breach(monkeypatch, capsys):
+    monkeypatch.setattr(sp, "report", lambda: {"status": "breached", "breached": ["a.yml"],
+                                               "measured_at": "2026-09-08T08:19:10Z",
+                                               "workflows": {}})
+    assert sp.main(["--strict"]) == 1
+    assert sp.main([]) == 0
+    monkeypatch.setattr(sp, "report", lambda: {"status": "unknown", "reason": "no file",
+                                               "workflows": {}})
+    assert sp.main(["--strict"]) == 0
+    capsys.readouterr()
+
+
+# --- coupling to the daily run -------------------------------------------
+
+def test_cron_health_runs_the_gate_and_does_not_skip_it_on_a_red_verdict():
+    cron_health = (WORKFLOW_DIR / "cron-health.yml").read_text(encoding="utf-8")
+    assert "ops/ci/schedule_punctuality.py --strict" in cron_health
+    block = cron_health.split("- name: Scheduled-workflow punctuality", 1)[1].split("run:", 1)[0]
+    assert "if: always()" in block
+
+
+def test_the_repo_still_produces_the_measurement_this_gate_consumes():
+    """The gate is only as alive as its input; repo-traffic writes the samples."""
+    traffic = (WORKFLOW_DIR / "repo-traffic.yml").read_text(encoding="utf-8")
+    assert "schedule_drift.py" in traffic


### PR DESCRIPTION
## 症状

`assets/data/schedule-drift.json` 从 #781 起每周采两次 GitHub 的投递延迟，**没有任何消费者**（5 个 workflow 的注释引用它、pages 发布它、两个测试测它的形状，没有一个读它的数）。同时有五个 workflow 的头注释把一条准时预算写成散文：

- `macro-scan.yml`：「~2.25h before the 08:00 HKT brief … GH Action scheduled crons routinely fire 1-2h LATE」
- `sentiment-scan.yml`：「Scheduled this early to absorb GH Actions' typical 1-2h scheduled-cron delay」
- `influencer-scan.yml`：「buffer for GH Actions' 1–2h scheduled-cron delay」
- `weekly-health.yml`：「Monday 07:00 HKT, before the 08:00 brief and HK open」
- `brief-fallback.yml`：三次尝试，按「+89..159 分钟」标定

**那几句话就是整个设计唯一的支撑。**

## 2026-08-27 漂移换了一个量级

用 `news-digest.yml`（本仓最干净的探针，单条日 cron `0 13 * * 1-5`）：

| 区间 | n | 中位 | 边界 |
|---|---:|---:|---|
| 07-28..08-26 | 22 | **72.5 min** | max 157.2 |
| 08-27..09-07 | 8 | **271.4 min** | min 219.1 |

阶跃干净（后段最小值 219 > 前段最大值 157），**且不是我们造成的**：

- 同时落在四个不同 UTC 小时的 workflow 上（brief-fallback 00:25 / cron-health 09:17 / news-digest 13:00 / macro-scan 21:45）；
- 同期每天 run 数反而从 206 降到 145；
- 采样的 203 次排程运行 `created_at == run_started_at`，排队等待中位数 **0.0 秒** ⇒ 延迟在 GitHub 创建 run 之前，不是在等 runner。

我们这边没有可调的东西。**能修的是「没有闸注意到」。** `workflow_health.py` 问的是「有没有失败」「还跑不跑」——晚四小时的运行照样跑了，迟到对它完全透明。brief-fallback 那个三次尝试的缓解最近 10 个排程日一次都没落进自己的可用窗口，一声没吭。

## 契约

`config/schedule-punctuality.json` 给每个排程 workflow 一个 `deadline_hkt`，或 `null` + 没有 deadline 的理由。`tests/` 拿 workflow 目录枚举它——新 workflow 不能悄悄获得一个 deadline。

`enforced`（持续违约判红）/ `accepted`（真实存在、当前没满足、理由写清为什么容忍）。**`accepted` 是给「修不了的违约」用的**：答案应该是一条写下来的决定，而不是撒谎，也不是一个永远红、没人能处置的检查——那正是 cron-health 最近 6 次红 5 次的病。

### 为什么要「持续」

迟到一次是 GitHub 那个小时不好，计数照报但只是 warning。判红意味着赌注结构性地输了——最近 5 次实测到达**全部**过线。这正好分开 brief-fallback（10 天 0 次进窗口）和 macro-scan（20 次迟 6 次、中位到达仍早 25 分钟）。

## 今天的实测：全绿，但话是实话

```
schedule punctuality · drift measured 2026-09-08T08:19
  ~ brief-fallback.yml    deadline 10:00 HKT · 16/20 late · worst +297min   (accepted)
      arrived 09-08 13:52 (due 09-08 10:00)
  · weekly-health.yml     deadline 08:00 HKT ·  8/17 late · worst  +62min
  · macro-scan.yml        deadline 08:00 HKT ·  6/20 late · worst +350min
  · sentiment-scan.yml    deadline 08:00 HKT ·  6/20 late · worst +350min
  · influencer-scan.yml   deadline 08:00 HKT ·  3/20 late · worst +335min
```

`weekly-health` 近一半迟到、macro/sentiment 六次落在简报之后（36h staleness 闸兜着不会读到垃圾，但那六天的简报用的是前一天的宏观）——这些以前一个面都没有。

顺带把 brief-fallback.yml 那段已不成立的注释改成实测值，并写明真正触发它的是主机 `brief_watchdog --check-missing`（09:05 HKT，`gh workflow run`，延迟秒级），排程那三条腿留作「主机挂了」的长尾。

## 判据同 #1416：查不到 ≠ 是坏的

drift 文件读不到 ⇒ `unknown` ⇒ 退 0，绝不判红。离线确定性（只读两个 tracked 文件，不调 `gh`），所以它可以带判词，不像旁边那条 rollup 必须 report-only。

写测试时发现注入口把「读不到」和「没传参」都写成 `None`，那个缝等于没测——改成 `_UNSET` 哨兵，并补一条走真实 loader 的用例。

## 本地验证

- `tests/test_schedule_punctuality.py` 56 passed
- **全量 `pytest tests/` 3608 passed / 5 skipped / 4 xfailed**
- 对线上真数据跑 `--strict`：exit 0，输出即上表

https://claude.ai/code/session_0147aMJtz1vX1aNdJ7SXA19u