### PR TITLE
dashboard: 数据健康牌的手机版（三条泳道各自展开 + 收掉读不动的图）

### DIFF
--- a/site/assets/css/dashboard.css
+++ b/site/assets/css/dashboard.css
@@ -2643,6 +2643,9 @@
   .hero-health-meta {
     margin-top: 6px; color: var(--text-tertiary); font: 500 var(--fs-micro)/1.45 var(--mono);
   }
+  /* 每段各自不折行，换行只发生在段与段之间的分隔点上（渲染端已把每段包成
+     一个 .dh-meta-bit）。 */
+  .hero-health-meta .dh-meta-bit { white-space: nowrap; }
   .dh-toggle {
     margin-left: auto; flex: none; padding: 6px 12px; border-radius: 8px;
     border: 1px solid var(--border-subtle); background: var(--surface-1);
@@ -2780,6 +2783,8 @@
   .dh-rail-name {
     color: var(--text-secondary); font: 500 var(--fs-micro)/1.4 var(--mono);
   }
+  /* 宽档由下面那张图回答「接下来轮到谁」，这句话是窄档的替身，默认不显示。 */
+  .dh-rail-next { display: none; }
   .dh-rail-keys { display: flex; flex-wrap: wrap; gap: 3px 9px; }
   .dh-rail-key {
     display: inline-flex; align-items: center; gap: 4px;
@@ -3462,7 +3467,7 @@
     /* 两列 × 两行 + 每格一件图形：293 = 360~600 全档数据态实测上界。 */
     .hero-rail { grid-template-columns: repeat(2, minmax(0, 1fr)); min-height: 293px; }
     /* 窄档泳道收成三带：名称+计数+处置牌一行，形状一行，说明一行。
-       五列硬塞进 360px 会把说明挤成一个省略号，那正是这次要修的病。
+       五列硬塞进 360px 会把说明挤成一个省略号，那正是 #1270 要修的病。
        外层那套 46+150+168+58+1fr 的定死列宽也要一起塌 —— 泳道 span 的是
        父栅格的轨道和，422px 的和会把处置牌顶到 390px 屏幕外面去。 */
     .dh-lanes { grid-template-columns: minmax(0, 1fr); }
@@ -3473,16 +3478,66 @@
     .dh-lane-name { grid-area: name; }
     .dh-lane-stat { grid-area: stat; }
     .dh-lane-shape, .dh-strip { grid-area: shape; }
-    .dh-lane-note { grid-area: note; white-space: normal; }
+    /* 形状那一带按内容高：体检常态是一两个 7px 的计数点，18px 的固定高在
+       窄档留出一条空带，读起来像这一行渲染坏了。 */
+    .dh-lane-shape { height: auto; min-height: 8px; }
+    /* 体检的形状是计数点，不是条 —— 它没有宽度诉求，独占一带时读成一个孤零
+       零的项目符号。挂到计数后面去，这条泳道就只剩两带。 */
+    #dh-lane-integrity {
+      grid-template-columns: auto auto minmax(0, 1fr) auto;
+      grid-template-areas: "name stat shape chip" "note note note note";
+    }
+    #dh-lane-integrity .dh-lane-shape { justify-self: start; gap: 4px; }
+    .dh-lane-note { grid-area: note; white-space: normal; line-height: 1.55; }
     .dh-chip { grid-area: chip; }
-    .dh-row.is-todo { grid-template-columns: minmax(0, 1fr) auto; }
-    .dh-row.is-todo .dh-state { grid-column: 1 / -1; text-align: left; }
+    /* 拇指要够得着：34px 是这块牌上唯一的控件，窄档给它一个正常的点按面积。 */
+    .dh-toggle { padding: 9px 14px; }
+    /* 卡底那行说明是四个处置词的唯一词典，10px 在手机上读不动。 */
+    .dh-caption { font-size: var(--fs-xs); line-height: 1.6; }
+
+    /* 24 小时压进 ~217px 的轨道 + 11 个全是省略号的行名 = 手机上读不出东西
+       的条形码（3px 的针脚和每小时一条的刻度线粗细相同）。窄档收掉图，留下
+       计数摘要 + 「下一槽」那一句；同一份「谁 · 几点 · 怎么了」在「逐项」里
+       是逐行的文字，比这张图更好读 —— 这是改版式，不是删数据。 */
+    .dh-rail-body, .dh-rail-axis, .dh-rail-keys { display: none; }
+    .dh-rail { gap: 3px; }
+    .dh-rail-next {
+      display: block; color: var(--text-tertiary);
+      font: 500 var(--fs-micro)/1.45 var(--mono);
+    }
+
+    /* 逐项：显式指派栅格位置。原来靠自动排布，而 .dh-bar / .dh-detail 都是
+       整行 span ⇒ 状态词被挤到第四行、右对齐地单独占一行（实测每行 154px，
+       11 个 job 就是 1700px 的空转）。名字和状态本来就该在同一行。 */
     .dh-row {
       grid-template-columns: minmax(0, 1fr) auto; gap: 4px 10px; row-gap: 4px;
+      grid-template-areas: "name state" "bar bar" "detail detail";
     }
+    .dh-name { grid-area: name; }
+    .dh-state { grid-area: state; }
+    .dh-bar { grid-area: bar; }
+    .dh-detail { grid-area: detail; white-space: normal; }
     .dh-file { display: none; }
-    .dh-bar { grid-column: 1 / -1; }
-    .dh-detail { grid-column: 1 / -1; white-space: normal; }
+    /* 处置行是这块牌上唯一的待办，三样东西都要留：名字、位置（文件名或槽位
+       时刻）、下一步。窄档给它自己一套三带 —— 位置和「多旧/怎么了」并排一
+       行（位置是短的，说明是长的），下一步整行。位置一律不折不省略：
+       `portfolio.json` 被断成 `portfol/io.json` 或吃掉半截，都等于把「去哪看」
+       这条线索毁掉。 */
+    .dh-row.is-todo {
+      grid-template-columns: auto minmax(0, 1fr);
+      grid-template-areas: "name name" "where detail" "state state";
+      /* 说明常折成两行，居中会把左边那格的位置吊在两行中间。 */
+      align-items: start;
+    }
+    .dh-row.is-todo .dh-file {
+      display: block; grid-area: where; text-align: left;
+      overflow: visible; white-space: nowrap;
+    }
+    .dh-row.is-todo .dh-state { text-align: left; }
+    /* 灯是「这一槽跑了没有」的唯一逐槽答案（时刻表只说几点，不说结果），
+       7px 的空心圈在手机上几乎看不见。窄档放大到 9px 并拉开间距。 */
+    .dh-row.is-cron .dh-bar.is-lamps { gap: 4px; }
+    .dh-row.is-cron .dh-bar.is-lamps .dh-pip { width: 9px; height: 9px; }
     /* 386：360~767 扫宽忙日实测上界 350.39（在 360）+ 露边 16 + gap 8
        + 指示点 10 = 384.39，+2（第八次迭代重扫）。窄档是留白重灾区，但那
        段空高现在被异动条吃掉：地板不动，正文吃满。 */
@@ -3516,7 +3571,10 @@
     .hero-rail-v { font-size: var(--fs-lg); }
     .hero-deck-lead { padding: 22px var(--card-inset) 18px; }
     .hero-rail-cell { padding: 12px 0 14px; }
-    .dh-seg { width: 11px; height: 26px; }
+    /* 段更宽（不是更高）：窄档只有 15 段，横向有的是余量，而 26px 高的
+       色块把泳道那一带撑成了整块牌里最重的东西。width 在 flex:1 1 0 +
+       max-width 面前是空写的，真正生效的是 max-width。 */
+    .dh-seg { max-width: 12px; height: 22px; }
   }
 
   /* =========================================================

--- a/site/assets/css/dashboard.css
+++ b/site/assets/css/dashboard.css
@@ -2669,19 +2669,57 @@
      那行右移 37px）。用 subgrid 让三行吃 .dh-lanes 的同一套列；不支持
      subgrid 的浏览器落到同一组定死的列宽，一样对得齐。 */
   .dh-lanes {
-    display: grid; grid-template-columns: 46px 150px 168px minmax(0, 1fr) 58px;
+    display: grid; grid-template-columns: 46px 150px 168px minmax(0, 1fr) 58px 12px;
   }
+  /* 泳道是按钮（整行都是点按面积），所以要把浏览器给按钮的那套外观全部撤掉，
+     只留下它的行为：焦点、Enter/Space、aria-expanded。 */
   .dh-lane {
     display: grid; grid-column: 1 / -1; align-items: center;
-    gap: 10px 12px; padding: 9px 0;
-    grid-template-columns: 46px 150px 168px minmax(0, 1fr) 58px;
-    border-bottom: 1px solid var(--border-subtle);
+    gap: 10px 12px; padding: 9px 0; width: 100%; text-align: left;
+    grid-template-columns: 46px 150px 168px minmax(0, 1fr) 58px 12px;
+    -webkit-appearance: none; appearance: none; background: none; color: inherit;
+    border: 0; border-bottom: 1px solid var(--border-subtle); border-radius: 6px;
+    cursor: pointer;
     font: 500 var(--fs-xs)/1.35 var(--mono); font-variant-numeric: tabular-nums;
+    transition: background-color var(--duration-fast) ease;
+  }
+  .dh-lane:active { background: color-mix(in srgb, var(--text) 5%, transparent); }
+  .dh-lane:focus-visible { outline: 2px solid var(--accent); outline-offset: -2px; }
+  @media (hover: hover) and (pointer: fine) {
+    .dh-lane:hover { background: color-mix(in srgb, var(--text) 3%, transparent); }
+    .dh-lane:hover .dh-lane-chev { border-color: var(--text-secondary); }
+  }
+  /* 「这一行还能点开」必须看得见，否则整块牌读起来是死的。 */
+  .dh-lane-chev {
+    justify-self: end; width: 6px; height: 6px; margin-right: 2px;
+    border-right: 1.5px solid var(--text-tertiary);
+    border-bottom: 1.5px solid var(--text-tertiary);
+    transform: translateY(-2px) rotate(45deg);
+    transition: transform var(--duration-standard) var(--ease-out);
+  }
+  .dh-lane[aria-expanded="true"] .dh-lane-chev { transform: translateY(1px) rotate(-135deg); }
+  /* 展开动画只动 grid-template-rows（0fr→1fr），内容不 reflow 成两份。
+     收起的那一组仍在 DOM 里，靠 inert + aria-hidden 退出 Tab 与读屏。 */
+  .dh-group {
+    display: grid; grid-column: 1 / -1; grid-template-rows: 0fr;
+    transition: grid-template-rows var(--duration-standard) var(--ease-out);
+  }
+  .dh-group.is-open { grid-template-rows: 1fr; }
+  .dh-group-inner { overflow: hidden; min-height: 0; }
+  /* 摊开的那一组是「压在这条泳道下面」的一块，不是卡片里又一段正文：淡一档
+     的底 + 收进去的圆角，让它和上面那行绑在一起。 */
+  .dh-group-body {
+    padding: 2px 10px 8px; background: var(--surface-1);
+    border-radius: 0 0 8px 8px;
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .dh-group, .dh-lane-chev { transition: none; }
   }
   @supports (grid-template-columns: subgrid) {
     .dh-lane { grid-template-columns: subgrid; }
   }
-  .dh-lane:last-child { border-bottom: 0; }
+  /* 最后一条泳道现在后面跟着它自己那一组（section），所以是 last-of-type。 */
+  .dh-lane:last-of-type { border-bottom: 0; }
   .dh-lane-name {
     color: var(--text-tertiary); font: 700 var(--fs-micro)/1.2 var(--mono);
     letter-spacing: .08em; white-space: nowrap;
@@ -2862,7 +2900,11 @@
   }
   .dh-seg.is-late i { background: var(--warning); }
   .dh-seg.is-missing i { background: var(--red); }
-  .dh-files { margin-top: 14px; border-top: 1px solid var(--border-subtle); }
+  /* 处置清单：常显，但没有待办时整块不占位。（类名不叫 .dh-todo —— 那个
+     已经是判词后半截那个 span 的类，撞名会给判词画上一条边线。） */
+  .dh-todo-list:not(:empty) {
+    margin-top: 12px; padding-top: 10px; border-top: 1px solid var(--border-subtle);
+  }
   .dh-row {
     display: grid; align-items: center; gap: 12px; padding: 8px 0;
     /* 末列 34px 是照「在期 / 逾期 / 缺失」两个字量的，投递行写的是「TG 已兜」
@@ -2878,8 +2920,9 @@
     font: 700 var(--fs-micro)/1.2 var(--mono); letter-spacing: .08em;
   }
   .dh-sub:first-child { padding-top: 4px; }
-  /* 投递行 / 处置行没有期限用量可画：空的灰槽会被读成「一根 0% 的条」。 */
-  .dh-row.is-delivery .dh-bar, .dh-row.is-todo .dh-bar { background: none; }
+  /* 投递行 / 处置行 / 体检行没有期限用量可画：空的灰槽会被读成「一根 0% 的条」。 */
+  .dh-row.is-delivery .dh-bar, .dh-row.is-todo .dh-bar,
+  .dh-row.is-check .dh-bar { background: none; }
   /* 处置行的末列是「下一步去哪看」，不是一个状态词 —— 34px 装不下，
      单独给它一套列宽，并且左侧留一道红边把待办从台账里挑出来。 */
   .dh-row.is-todo {
@@ -3472,11 +3515,16 @@
        父栅格的轨道和，422px 的和会把处置牌顶到 390px 屏幕外面去。 */
     .dh-lanes { grid-template-columns: minmax(0, 1fr); }
     .dh-lane {
-      grid-template-columns: auto minmax(0, 1fr) auto; gap: 6px 10px;
-      grid-template-areas: "name stat chip" "shape shape shape" "note note note";
+      grid-template-columns: auto minmax(0, 1fr) auto auto; gap: 6px 10px;
+      padding: 10px 8px 10px 0;
+      grid-template-areas: "name stat chip chev" "shape shape shape shape"
+                           "note note note note";
     }
     .dh-lane-name { grid-area: name; }
-    .dh-lane-stat { grid-area: stat; }
+    /* 计数是这条泳道的答案，10px 的等宽小字里它和标签、说明一样重 —— 手机上
+       给它自己的字号，一眼扫下来先看见三个数。 */
+    .dh-lane-stat { grid-area: stat; font-size: var(--fs-sm); }
+    .dh-lane-chev { grid-area: chev; margin-right: 0; }
     .dh-lane-shape, .dh-strip { grid-area: shape; }
     /* 形状那一带按内容高：体检常态是一两个 7px 的计数点，18px 的固定高在
        窄档留出一条空带，读起来像这一行渲染坏了。 */
@@ -3484,11 +3532,19 @@
     /* 体检的形状是计数点，不是条 —— 它没有宽度诉求，独占一带时读成一个孤零
        零的项目符号。挂到计数后面去，这条泳道就只剩两带。 */
     #dh-lane-integrity {
-      grid-template-columns: auto auto minmax(0, 1fr) auto;
-      grid-template-areas: "name stat shape chip" "note note note note";
+      grid-template-columns: auto auto minmax(0, 1fr) auto auto;
+      grid-template-areas: "name stat shape chip chev"
+                           "note note note note note";
     }
     #dh-lane-integrity .dh-lane-shape { justify-self: start; gap: 4px; }
-    .dh-lane-note { grid-area: note; white-space: normal; line-height: 1.55; }
+    /* 说明收成两行的引子：体检那条印的是体检报告的原文（英文、三行），在折叠
+       态里它是整块牌最重的一坨。全文就在这条泳道自己的那一组里（点开就有），
+       所以这里是「引子 + 展开」，不是把一句话截掉不给。 */
+    .dh-lane-note {
+      grid-area: note; white-space: normal; line-height: 1.55;
+      display: -webkit-box; -webkit-box-orient: vertical; -webkit-line-clamp: 2;
+      overflow: hidden;
+    }
     .dh-chip { grid-area: chip; }
     /* 拇指要够得着：34px 是这块牌上唯一的控件，窄档给它一个正常的点按面积。 */
     .dh-toggle { padding: 9px 14px; }

--- a/site/assets/js/dashboard.hero.js
+++ b/site/assets/js/dashboard.hero.js
@@ -1105,6 +1105,22 @@
         + `${escapeHtml(CRON_STATES[k].cn)}</span>`).join("");
     }
 
+    // 窄屏把这张图收掉了（24 小时压进 ~217px 的轨、11 个名字全是省略号，
+    // 在手机上读不出任何东西；同一份「谁·几点·怎么了」在「逐项」里是逐行
+    // 的文字）。图不在的时候，「接下来轮到谁」必须仍然有一句话回答，否则
+    // 收图就等于删掉一个答案。CSS 只在窄档显示它。
+    const nextEl = document.getElementById("dh-rail-next");
+    if (nextEl) {
+      const hhmm = now
+        ? `${String(now.getHours()).padStart(2, "0")}:${String(now.getMinutes()).padStart(2, "0")}`
+        : "";
+      const next = cells.find(c => ["upcoming", "running"].includes(c.state)
+        && (!hhmm || c.at >= hhmm));
+      nextEl.textContent = next
+        ? `下一槽 ${next.at} · ${next.job}`
+        : "今天没有待跑的槽位了";
+    }
+
     // 轴刻度：每 3 小时一个数字、每小时一条细线（CSS 背景画），比原来只有
     // 00/06/12/18/24 四个地标精确得多；同一条轴下面每个 job 一行，行内的点
     // 用同一把尺子绝对定位，于是「谁、什么时候」不用悬停就读得出来。
@@ -1356,7 +1372,10 @@
       // Telegram 兜住了，它属于「已知不修」，位置就该在这条安静的行里。
       if (droppedTotal) bits.push(`微信掉投 ${droppedTotal} 档 · TG 已兜 · 已知不修`);
       if (bs.generated_at) bits.push(`构建 ${String(bs.generated_at).replace("T", " ").slice(0, 16)}`);
-      metaEl.textContent = bits.join(" · ");
+      // 每一段各自不折行：窄屏实测把「构建 2026-09-09 00:05」在「构建」后面
+      // 折开，一个时刻被读成两条信息。折行只准发生在分隔点上。
+      metaEl.innerHTML = bits.map(b => `<span class="dh-meta-bit">${escapeHtml(b)}</span>`)
+        .join(`<span class="dh-meta-sep"> · </span>`);
     }
 
     if (stripEl) {

--- a/site/assets/js/dashboard.hero.js
+++ b/site/assets/js/dashboard.hero.js
@@ -1196,7 +1196,6 @@
     const verdictEl = document.getElementById("dh-verdict") || document.getElementById("dh-title");
     const metaEl = document.getElementById("dh-meta");
     const stripEl = document.getElementById("dh-strip");
-    const filesEl = document.getElementById("dh-files");
     const ig = bs.integrity || {};
     const wf = safe(DATA, "workflow_outcomes") || {};
     const wc = wf.counts || {};
@@ -1394,9 +1393,10 @@
         + "观察＝兜底已生效、成品到了，只记不动；已知不修＝已拍板不处理。";
     }
 
-    if (filesEl) {
-      // 逐项第一组是「处置清单」：只列 需处理 的那几条，每条带下一步该去
-      // 哪看。剩下两组（投递掉投 / 数据面逐项）是台账，不是待办。
+    {
+      // 「处置清单」不再藏在「逐项」后面：它是这块牌上唯一「你该动手」的
+      // 东西，藏在一次点击后面等于把答案放进抽屉。它自己一块（#dh-todo，
+      // 在判词底下），没有待办时是空的、整块不占位。
       const todo = [];
       late.forEach(f => todo.push({
         name: dataFileCn(f.name), where: f.name, why: detailOf(f),
@@ -1446,8 +1446,7 @@
             : "")
         : "";
 
-      const cronRows = cronScheduleRows(safe(DATA, "cron_schedule"));
-      filesEl.innerHTML = todoRows + cronRows + deliveryRows + `<div class="dh-sub">数据面</div>` + files
+      const fileRows = `<div class="dh-sub">数据面 · 逐项</div>` + files
         .slice()
         .sort((a, b) => usage(b) - usage(a))
         .map(f => {
@@ -1461,18 +1460,95 @@
             + `<span class="dh-state">${label}</span>`
             + `</div>`;
         }).join("");
+
+      // 体检以前在逐项里没有自己的一组：泳道只印得下最坏的那一条，WARN 的
+      // 全文没有任何地方读得到（窄屏还会被折成三行英文）。展开它就是那张单子。
+      const integrityRows = `<div class="dh-sub">体检 · 本次发现</div>`
+        + ((ig.top || []).length
+          ? (ig.top || []).map(t => {
+            const level = String(t.level || "").toUpperCase() || "INFO";
+            return `<div class="dh-row is-check is-${level === "ERROR" ? "missing" : level === "WARN" ? "late" : "ok"}">`
+              + `<span class="dh-name">${escapeHtml(level)}</span>`
+              + `<span class="dh-file">${escapeHtml(String(t.code || ""))}</span>`
+              + `<span class="dh-bar"></span>`
+              + `<span class="dh-detail">${escapeHtml(String(t.msg || ""))}</span>`
+              + `<span class="dh-state">${escapeHtml(level === "ERROR" ? "需处理" : "观察")}</span>`
+              + `</div>`;
+          }).join("")
+          : `<div class="dh-row is-check is-ok"><span class="dh-name">无异常</span>`
+            + `<span class="dh-file"></span><span class="dh-bar"></span>`
+            + `<span class="dh-detail">这一轮体检没有 ERROR 也没有 WARN</span>`
+            + `<span class="dh-state">正常</span></div>`);
+
+      const cronRows = cronScheduleRows(safe(DATA, "cron_schedule"));
+      // 一条泳道 = 一个展开器，明细就摊在它自己下面（组是泳道的兄弟节点，不是
+      // 卡片底部的一坨）。整块「逐项」在手机上是 34 行 2600px，读者要的不是
+      // 「全都展开」，是「点开我关心的那一条」。
+      const fill = (key, html) => {
+        const body = document.getElementById(`dh-group-${key}-body`);
+        if (body) body.innerHTML = html;
+      };
+      fill("files", fileRows);
+      fill("integrity", integrityRows);
+      fill("delivery", cronRows + deliveryRows);
+      const todoEl = document.getElementById("dh-todo");
+      if (todoEl) todoEl.innerHTML = todoRows;
+      // 收起的组仍在 DOM 里（折叠是 grid-rows 0fr 的动画），首帧也必须把它退出
+      // Tab 与读屏；这一步同时把展开状态原样留住 —— 刷新是每几分钟一次的事，
+      // 不能把读者刚展开的那一条合回去。
+      DH_LANES.forEach(key => {
+        const group = document.getElementById(`dh-group-${key}`);
+        setDataHealthGroup(key, !!(group && group.classList.contains("is-open")));
+      });
+      syncDataHealthToggle();
     }
 
+    DH_LANES.forEach(key => {
+      const lane = document.getElementById(`dh-lane-${key}`);
+      if (!lane || lane.dataset.wired === "1") return;
+      lane.dataset.wired = "1";
+      lane.addEventListener("click", () => {
+        setDataHealthGroup(key, lane.getAttribute("aria-expanded") !== "true");
+        syncDataHealthToggle();
+      });
+    });
     const toggle = document.getElementById("dh-toggle");
     if (toggle && toggle.dataset.wired !== "1") {
       toggle.dataset.wired = "1";
+      // 全局那颗按钮现在是「全部展开 / 全部收起」，不是唯一的入口。
       toggle.addEventListener("click", () => {
         const open = toggle.getAttribute("aria-expanded") !== "true";
-        toggle.setAttribute("aria-expanded", open ? "true" : "false");
-        toggle.textContent = open ? "收起" : "逐项";
-        if (filesEl) filesEl.hidden = !open;
+        DH_LANES.forEach(key => setDataHealthGroup(key, open));
+        syncDataHealthToggle();
       });
     }
+  }
+
+  const DH_LANES = ["files", "integrity", "delivery"];
+
+  // 展开一条泳道自己的那一组。收起时同时上 inert + aria-hidden：折叠是靠
+  // grid-template-rows 0fr 做的动画，元素还在，不设 inert 的话读屏和 Tab
+  // 仍然会走进一块看不见的清单。
+  function setDataHealthGroup(key, open) {
+    const group = document.getElementById(`dh-group-${key}`);
+    const lane = document.getElementById(`dh-lane-${key}`);
+    if (group) {
+      group.classList.toggle("is-open", !!open);
+      group.inert = !open;
+      group.setAttribute("aria-hidden", open ? "false" : "true");
+    }
+    if (lane) lane.setAttribute("aria-expanded", open ? "true" : "false");
+  }
+
+  function syncDataHealthToggle() {
+    const toggle = document.getElementById("dh-toggle");
+    if (!toggle) return;
+    const open = DH_LANES.every(key => {
+      const lane = document.getElementById(`dh-lane-${key}`);
+      return lane && lane.getAttribute("aria-expanded") === "true";
+    });
+    toggle.setAttribute("aria-expanded", open ? "true" : "false");
+    toggle.textContent = open ? "收起" : "逐项";
   }
 
   function flatHoldings() {

--- a/site/assets/js/dashboard.render.js
+++ b/site/assets/js/dashboard.render.js
@@ -1315,7 +1315,6 @@
     const verdictEl = document.getElementById("dh-verdict") || document.getElementById("dh-title");
     const metaEl = document.getElementById("dh-meta");
     const stripEl = document.getElementById("dh-strip");
-    const filesEl = document.getElementById("dh-files");
     const ig = bs.integrity || {};
     const wf = safe(DATA, "workflow_outcomes") || {};
     const wc = wf.counts || {};
@@ -1513,9 +1512,10 @@
         + "观察＝兜底已生效、成品到了，只记不动；已知不修＝已拍板不处理。";
     }
 
-    if (filesEl) {
-      // 逐项第一组是「处置清单」：只列 需处理 的那几条，每条带下一步该去
-      // 哪看。剩下两组（投递掉投 / 数据面逐项）是台账，不是待办。
+    {
+      // 「处置清单」不再藏在「逐项」后面：它是这块牌上唯一「你该动手」的
+      // 东西，藏在一次点击后面等于把答案放进抽屉。它自己一块（#dh-todo，
+      // 在判词底下），没有待办时是空的、整块不占位。
       const todo = [];
       late.forEach(f => todo.push({
         name: dataFileCn(f.name), where: f.name, why: detailOf(f),
@@ -1565,8 +1565,7 @@
             : "")
         : "";
 
-      const cronRows = cronScheduleRows(safe(DATA, "cron_schedule"));
-      filesEl.innerHTML = todoRows + cronRows + deliveryRows + `<div class="dh-sub">数据面</div>` + files
+      const fileRows = `<div class="dh-sub">数据面 · 逐项</div>` + files
         .slice()
         .sort((a, b) => usage(b) - usage(a))
         .map(f => {
@@ -1580,18 +1579,95 @@
             + `<span class="dh-state">${label}</span>`
             + `</div>`;
         }).join("");
+
+      // 体检以前在逐项里没有自己的一组：泳道只印得下最坏的那一条，WARN 的
+      // 全文没有任何地方读得到（窄屏还会被折成三行英文）。展开它就是那张单子。
+      const integrityRows = `<div class="dh-sub">体检 · 本次发现</div>`
+        + ((ig.top || []).length
+          ? (ig.top || []).map(t => {
+            const level = String(t.level || "").toUpperCase() || "INFO";
+            return `<div class="dh-row is-check is-${level === "ERROR" ? "missing" : level === "WARN" ? "late" : "ok"}">`
+              + `<span class="dh-name">${escapeHtml(level)}</span>`
+              + `<span class="dh-file">${escapeHtml(String(t.code || ""))}</span>`
+              + `<span class="dh-bar"></span>`
+              + `<span class="dh-detail">${escapeHtml(String(t.msg || ""))}</span>`
+              + `<span class="dh-state">${escapeHtml(level === "ERROR" ? "需处理" : "观察")}</span>`
+              + `</div>`;
+          }).join("")
+          : `<div class="dh-row is-check is-ok"><span class="dh-name">无异常</span>`
+            + `<span class="dh-file"></span><span class="dh-bar"></span>`
+            + `<span class="dh-detail">这一轮体检没有 ERROR 也没有 WARN</span>`
+            + `<span class="dh-state">正常</span></div>`);
+
+      const cronRows = cronScheduleRows(safe(DATA, "cron_schedule"));
+      // 一条泳道 = 一个展开器，明细就摊在它自己下面（组是泳道的兄弟节点，不是
+      // 卡片底部的一坨）。整块「逐项」在手机上是 34 行 2600px，读者要的不是
+      // 「全都展开」，是「点开我关心的那一条」。
+      const fill = (key, html) => {
+        const body = document.getElementById(`dh-group-${key}-body`);
+        if (body) body.innerHTML = html;
+      };
+      fill("files", fileRows);
+      fill("integrity", integrityRows);
+      fill("delivery", cronRows + deliveryRows);
+      const todoEl = document.getElementById("dh-todo");
+      if (todoEl) todoEl.innerHTML = todoRows;
+      // 收起的组仍在 DOM 里（折叠是 grid-rows 0fr 的动画），首帧也必须把它退出
+      // Tab 与读屏；这一步同时把展开状态原样留住 —— 刷新是每几分钟一次的事，
+      // 不能把读者刚展开的那一条合回去。
+      DH_LANES.forEach(key => {
+        const group = document.getElementById(`dh-group-${key}`);
+        setDataHealthGroup(key, !!(group && group.classList.contains("is-open")));
+      });
+      syncDataHealthToggle();
     }
 
+    DH_LANES.forEach(key => {
+      const lane = document.getElementById(`dh-lane-${key}`);
+      if (!lane || lane.dataset.wired === "1") return;
+      lane.dataset.wired = "1";
+      lane.addEventListener("click", () => {
+        setDataHealthGroup(key, lane.getAttribute("aria-expanded") !== "true");
+        syncDataHealthToggle();
+      });
+    });
     const toggle = document.getElementById("dh-toggle");
     if (toggle && toggle.dataset.wired !== "1") {
       toggle.dataset.wired = "1";
+      // 全局那颗按钮现在是「全部展开 / 全部收起」，不是唯一的入口。
       toggle.addEventListener("click", () => {
         const open = toggle.getAttribute("aria-expanded") !== "true";
-        toggle.setAttribute("aria-expanded", open ? "true" : "false");
-        toggle.textContent = open ? "收起" : "逐项";
-        if (filesEl) filesEl.hidden = !open;
+        DH_LANES.forEach(key => setDataHealthGroup(key, open));
+        syncDataHealthToggle();
       });
     }
+  }
+
+  const DH_LANES = ["files", "integrity", "delivery"];
+
+  // 展开一条泳道自己的那一组。收起时同时上 inert + aria-hidden：折叠是靠
+  // grid-template-rows 0fr 做的动画，元素还在，不设 inert 的话读屏和 Tab
+  // 仍然会走进一块看不见的清单。
+  function setDataHealthGroup(key, open) {
+    const group = document.getElementById(`dh-group-${key}`);
+    const lane = document.getElementById(`dh-lane-${key}`);
+    if (group) {
+      group.classList.toggle("is-open", !!open);
+      group.inert = !open;
+      group.setAttribute("aria-hidden", open ? "false" : "true");
+    }
+    if (lane) lane.setAttribute("aria-expanded", open ? "true" : "false");
+  }
+
+  function syncDataHealthToggle() {
+    const toggle = document.getElementById("dh-toggle");
+    if (!toggle) return;
+    const open = DH_LANES.every(key => {
+      const lane = document.getElementById(`dh-lane-${key}`);
+      return lane && lane.getAttribute("aria-expanded") === "true";
+    });
+    toggle.setAttribute("aria-expanded", open ? "true" : "false");
+    toggle.textContent = open ? "收起" : "逐项";
   }
 
   function renderDelta() {

--- a/site/assets/js/dashboard.render.js
+++ b/site/assets/js/dashboard.render.js
@@ -1224,6 +1224,22 @@
         + `${escapeHtml(CRON_STATES[k].cn)}</span>`).join("");
     }
 
+    // 窄屏把这张图收掉了（24 小时压进 ~217px 的轨、11 个名字全是省略号，
+    // 在手机上读不出任何东西；同一份「谁·几点·怎么了」在「逐项」里是逐行
+    // 的文字）。图不在的时候，「接下来轮到谁」必须仍然有一句话回答，否则
+    // 收图就等于删掉一个答案。CSS 只在窄档显示它。
+    const nextEl = document.getElementById("dh-rail-next");
+    if (nextEl) {
+      const hhmm = now
+        ? `${String(now.getHours()).padStart(2, "0")}:${String(now.getMinutes()).padStart(2, "0")}`
+        : "";
+      const next = cells.find(c => ["upcoming", "running"].includes(c.state)
+        && (!hhmm || c.at >= hhmm));
+      nextEl.textContent = next
+        ? `下一槽 ${next.at} · ${next.job}`
+        : "今天没有待跑的槽位了";
+    }
+
     // 轴刻度：每 3 小时一个数字、每小时一条细线（CSS 背景画），比原来只有
     // 00/06/12/18/24 四个地标精确得多；同一条轴下面每个 job 一行，行内的点
     // 用同一把尺子绝对定位，于是「谁、什么时候」不用悬停就读得出来。
@@ -1475,7 +1491,10 @@
       // Telegram 兜住了，它属于「已知不修」，位置就该在这条安静的行里。
       if (droppedTotal) bits.push(`微信掉投 ${droppedTotal} 档 · TG 已兜 · 已知不修`);
       if (bs.generated_at) bits.push(`构建 ${String(bs.generated_at).replace("T", " ").slice(0, 16)}`);
-      metaEl.textContent = bits.join(" · ");
+      // 每一段各自不折行：窄屏实测把「构建 2026-09-09 00:05」在「构建」后面
+      // 折开，一个时刻被读成两条信息。折行只准发生在分隔点上。
+      metaEl.innerHTML = bits.map(b => `<span class="dh-meta-bit">${escapeHtml(b)}</span>`)
+        .join(`<span class="dh-meta-sep"> · </span>`);
     }
 
     if (stripEl) {

--- a/site/index.html
+++ b/site/index.html
@@ -320,6 +320,9 @@ layout: null
           <div class="dh-rail-head">
             <span class="dh-rail-name" id="dh-rail-name">今天</span>
             <span class="dh-rail-keys" id="dh-rail-keys" aria-hidden="true"></span>
+            <!-- 窄档收掉下面那张图之后，「接下来轮到谁」的文字答案。宽档由
+                 图本身回答，CSS 把它藏起来。 -->
+            <span class="dh-rail-next" id="dh-rail-next"></span>
           </div>
           <div class="dh-rail-body">
             <div class="dh-rail-rows" id="dh-rail-rows" role="img"

--- a/site/index.html
+++ b/site/index.html
@@ -279,35 +279,64 @@ layout: null
             <h3 id="dh-title" class="hero-health-verdict">—</h3>
             <div class="hero-health-meta" id="dh-meta">—</div>
           </div>
-          <button class="dh-toggle" type="button" id="dh-toggle" aria-expanded="false" aria-controls="dh-files">逐项</button>
+          <button class="dh-toggle" type="button" id="dh-toggle" aria-expanded="false"
+                  aria-controls="dh-group-files dh-group-integrity dh-group-delivery">逐项</button>
         </div>
+        <!-- 「你该动手的事」不藏在任何一次点击后面。没有待办时它是空的，
+             整块不占位（CSS 用 :empty 收掉边线和外边距）。 -->
+        <div class="dh-todo-list" id="dh-todo"></div>
         <!-- 三条泳道，位置固定：读者每次都在同一个地方找同一件事。
              ①数据面＝页面上的数字新不新鲜 ②体检＝有没有报错
              ③投递＝今天的成品有没有送出去。每条各带一枚处置牌，
              因为「坏了」和「要不要动手」不是同一个判断（#771 的微信掉投
              永远坏着，但它是已知不修，不该占用注意力）。 -->
+        <!-- 每条泳道自己是一个展开器：点它就在它下面摊开它自己的那一组
+             （数据面逐项 / 体检发现 / 今天每槽 + 微信掉投）。整块「逐项」在
+             手机上是 34 行 2600px，读者要的不是「全都展开」。所以泳道是
+             <button>：整行都是点按面积，键盘可达，aria-expanded 说状态。 -->
         <div class="dh-lanes-shell"><div class="dh-lanes">
-          <div class="dh-lane" id="dh-lane-files" data-tone="ok">
+          <button type="button" class="dh-lane" id="dh-lane-files" data-tone="ok"
+                  aria-expanded="false" aria-controls="dh-group-files">
             <span class="dh-lane-name">数据面</span>
             <span class="dh-lane-stat" id="dh-files-stat">&mdash;</span>
-            <div class="dh-strip" id="dh-strip" role="img" aria-label="每个数据面的期限用量"></div>
+            <span class="dh-strip" id="dh-strip" role="img" aria-label="每个数据面的期限用量"></span>
             <span class="dh-lane-note" id="dh-files-note"></span>
             <span class="dh-chip" id="dh-files-chip"></span>
-          </div>
-          <div class="dh-lane" id="dh-lane-integrity" data-tone="ok">
+            <span class="dh-lane-chev" aria-hidden="true"></span>
+          </button>
+          <!-- 数据面那一组的明细，由它上面那条泳道开合（收起时 inert）。 -->
+          <section class="dh-group" id="dh-group-files" role="region"
+                   aria-labelledby="dh-lane-files" aria-hidden="true">
+            <div class="dh-group-inner"><div class="dh-group-body" id="dh-group-files-body"></div></div>
+          </section>
+          <button type="button" class="dh-lane" id="dh-lane-integrity" data-tone="ok"
+                  aria-expanded="false" aria-controls="dh-group-integrity">
             <span class="dh-lane-name">体检</span>
             <span class="dh-lane-stat" id="dh-integrity-stat">&mdash;</span>
-            <div class="dh-lane-shape" id="dh-integrity-shape" role="img" aria-label="体检结果构成"></div>
+            <span class="dh-lane-shape" id="dh-integrity-shape" role="img" aria-label="体检结果构成"></span>
             <span class="dh-lane-note" id="dh-integrity-note"></span>
             <span class="dh-chip" id="dh-integrity-chip"></span>
-          </div>
-          <div class="dh-lane" id="dh-lane-delivery" data-tone="ok">
+            <span class="dh-lane-chev" aria-hidden="true"></span>
+          </button>
+          <!-- 体检那一组的明细，由它上面那条泳道开合（收起时 inert）。 -->
+          <section class="dh-group" id="dh-group-integrity" role="region"
+                   aria-labelledby="dh-lane-integrity" aria-hidden="true">
+            <div class="dh-group-inner"><div class="dh-group-body" id="dh-group-integrity-body"></div></div>
+          </section>
+          <button type="button" class="dh-lane" id="dh-lane-delivery" data-tone="ok"
+                  aria-expanded="false" aria-controls="dh-group-delivery">
             <span class="dh-lane-name">投递</span>
             <span class="dh-lane-stat" id="dh-delivery-stat">&mdash;</span>
-            <div class="dh-lane-shape" id="dh-delivery-shape" role="img" aria-label="窗口内成品结果构成"></div>
+            <span class="dh-lane-shape" id="dh-delivery-shape" role="img" aria-label="窗口内成品结果构成"></span>
             <span class="dh-lane-note" id="dh-delivery-note"></span>
             <span class="dh-chip" id="dh-delivery-chip"></span>
-          </div>
+            <span class="dh-lane-chev" aria-hidden="true"></span>
+          </button>
+          <!-- 投递那一组的明细，由它上面那条泳道开合（收起时 inert）。 -->
+          <section class="dh-group" id="dh-group-delivery" role="region"
+                   aria-labelledby="dh-lane-delivery" aria-hidden="true">
+            <div class="dh-group-inner"><div class="dh-group-body" id="dh-group-delivery-body"></div></div>
+          </section>
         </div></div>
         <!-- 今天的槽位轨。投递泳道给的是 36 小时里成品落地的比例，这条给
              同一件事加上时间轴。它**没有自己的判词**——判词只在上面「处置 ·
@@ -335,7 +364,6 @@ layout: null
           </div>
         </div>
         <div class="dh-caption" id="dh-caption"></div>
-        <div class="dh-files" id="dh-files" hidden></div>
       </section>
 
 

--- a/tests/dashboard_tab_runtime.spec.js
+++ b/tests/dashboard_tab_runtime.spec.js
@@ -1533,6 +1533,81 @@ async function testMoversSayWhichSessionTheyAreFrom(browser, base) {
   }
 }
 
+// 窄档（≤767px）把槽位轨那张图收掉了：24 小时压进 ~217px 的轨道、11 个行名
+// 全是省略号，针脚和刻度线一样粗，在手机上读不出任何东西 —— 同一份「谁 ·
+// 几点 · 怎么了」在「逐项」里是逐行的文字。收图的前提是这块牌仍然答得出
+// 「接下来轮到谁」，否则那不是改版式，是删掉一个答案。
+// 这条闸同时钉住手机上另外三处几何：说明行不许被截断（nowrap+ellipsis 吃掉
+// 半句话是这块牌的老毛病）、逐项的状态词必须和名字同一行（它曾被自动排布挤
+// 成右对齐的孤行，每行白白高出 ~40px）、处置牌不许被顶出卡片。
+async function testDataHealthIsReadableOnAPhone(browser, base) {
+  const context = await browser.newContext({
+    viewport: { width: 390, height: 844 }, isMobile: true, hasTouch: true,
+  });
+  const page = await context.newPage();
+  await stubLiveOrigin(page, {
+    patch: (name, json) => {
+      if (name !== "overview.json" && name !== "dashboard.json") return null;
+      json.cron_schedule = {
+        date: "2026-09-03",
+        jobs: [
+          { job: "盘前深度简报", slots: [{ at: "00:01", state: "ok" }] },
+          { job: "美股盘中盯盘-overnight", slots: [{ at: "23:59", state: "upcoming" }] },
+        ],
+      };
+      return json;
+    },
+  });
+  await page.goto(base, { waitUntil: "networkidle" });
+  await waitForData(page);
+  await page.waitForSelector("#data-health:not(.is-pending)", { timeout: 5000 });
+
+  const head = await page.evaluate(() => {
+    const shown = el => getComputedStyle(el).display !== "none";
+    const card = document.getElementById("data-health");
+    const cardRight = card.getBoundingClientRect().right;
+    return {
+      railChart: shown(document.querySelector(".dh-rail-body")),
+      next: document.getElementById("dh-rail-next").textContent.trim(),
+      nextShown: shown(document.getElementById("dh-rail-next")),
+      clipped: [...card.querySelectorAll(".dh-lane-note, .dh-caption, .hero-health-meta")]
+        .filter(el => el.scrollWidth > el.clientWidth + 1)
+        .map(el => el.textContent.trim().slice(0, 40)),
+      overflow: card.scrollWidth - card.clientWidth,
+      toggleHeight: Math.round(document.getElementById("dh-toggle").getBoundingClientRect().height),
+      chipOverhang: Math.round(Math.max(...[...card.querySelectorAll(".dh-chip")]
+        .map(chip => chip.getBoundingClientRect().right - cardRight))),
+    };
+  });
+  assert.equal(head.railChart, false,
+    "the 24-hour cron chart is still drawn at 390px — it is unreadable at that width");
+  assert(head.nextShown && /^(下一槽|今天没有待跑)/.test(head.next),
+    `the phone card drops the chart without saying what runs next: ${head.next}`);
+  assert.deepEqual(head.clipped, [], "a data-health line is truncated at 390px");
+  assert(head.overflow <= 0,
+    `data-health overflows horizontally by ${head.overflow}px at 390px`);
+  assert(head.toggleHeight >= 32,
+    `逐项 is ${head.toggleHeight}px tall — too small a target for a thumb`);
+  assert(head.chipOverhang <= 0,
+    `a disposition chip sticks ${head.chipOverhang}px past the card edge`);
+
+  // 处置行（.is-todo）的末列是「下一步去哪看」，它本来就独占一行；台账行不是。
+  const orphans = await page.evaluate(async () => {
+    document.getElementById("dh-toggle").click();
+    await new Promise(resolve => setTimeout(resolve, 50));
+    return [...document.querySelectorAll("#dh-files .dh-row:not(.is-todo)")]
+      .filter(row => {
+        const name = row.querySelector(".dh-name").getBoundingClientRect();
+        const state = row.querySelector(".dh-state").getBoundingClientRect();
+        return state.top >= name.bottom - 1;
+      })
+      .map(row => row.querySelector(".dh-name").textContent.trim());
+  });
+  assert.deepEqual(orphans, [],
+    `逐项 rows put the status word on a line of its own: ${orphans.join(", ")}`);
+  await context.close();
+}
+
 async function main() {
   const server = serveWorkspace();
   await new Promise(resolve => server.listen(0, "127.0.0.1", resolve));
@@ -1553,6 +1628,7 @@ async function main() {
     await testHoldingsAndHeroNeverTruncate(browser, base);
     await testVerdictDeckFillsItsBoxAndRanksGatesBySeverity(browser, base);
     await testDataHealthNamesTheDegradedSlotAndWeChatDrops(browser, base);
+    await testDataHealthIsReadableOnAPhone(browser, base);
     await testAddSideCardExplainsWhyThereIsNoAdd(browser, base);
     await testAPanelSaysWhenItsDataDidNotLoad(browser, base);
     await testCronRailAccountsForEverySlotWithoutASecondVerdict(browser, base);

--- a/tests/dashboard_tab_runtime.spec.js
+++ b/tests/dashboard_tab_runtime.spec.js
@@ -1335,7 +1335,7 @@ async function testCronRailAccountsForEverySlotWithoutASecondVerdict(browser, ba
   const detail = await page.evaluate(async () => {
     document.getElementById("dh-toggle").click();
     await new Promise(r => setTimeout(r, 50));
-    const rows = [...document.querySelectorAll("#dh-files .dh-row.is-cron")];
+    const rows = [...document.querySelectorAll(".dh-group .dh-row.is-cron")];
     return rows.map(r => ({
       name: r.querySelector(".dh-name").textContent.trim(),
       detail: r.querySelector(".dh-detail").textContent.trim(),
@@ -1387,13 +1387,15 @@ async function testCronNeedsActionMergesIntoTheOneTodoListButWatchDoesNot(browse
   await waitForData(page);
   await page.waitForSelector("#data-health:not(.is-pending)", { timeout: 5000 });
 
-  const todo = await page.evaluate(async () => {
-    document.getElementById("dh-toggle").click();
-    await new Promise(r => setTimeout(r, 50));
-    return [...document.querySelectorAll("#dh-files .dh-row.is-todo")]
+  // 清单不再藏在「逐项」后面：它是这块牌上唯一「你该动手」的东西，所以这条
+  // 断言现在**不点任何东西**就要读得到它 —— 藏起来的待办和没有待办一样。
+  const todo = await page.evaluate(() =>
+    [...document.querySelectorAll("#dh-todo .dh-row.is-todo")]
       .map(r => ({ name: r.querySelector(".dh-name").textContent.trim(),
-                   why: r.querySelector(".dh-detail").textContent.trim() }));
-  });
+                   why: r.querySelector(".dh-detail").textContent.trim(),
+                   shown: r.getBoundingClientRect().height > 0 })));
+  assert.ok(todo.every(t => t.shown),
+    "the 需处理 list is in the DOM but collapsed — a hidden to-do is not a to-do");
 
   const needsAction = todo.find(t => t.name === "港股午后快报");
   assert.ok(needsAction, `needs_action cron slot never reached the 需处理 list: ${JSON.stringify(todo)}`);
@@ -1482,7 +1484,7 @@ async function testDataHealthNamesTheDegradedSlotAndWeChatDrops(browser, base) {
 
   await page.click("#dh-toggle");
   const rows = await page.evaluate(() =>
-    [...document.querySelectorAll("#dh-files .dh-row")].map(r => r.textContent.replace(/\s+/g, " ").trim()));
+    [...document.querySelectorAll(".dh-group .dh-row")].map(r => r.textContent.replace(/\s+/g, " ").trim()));
   const dropRows = rows.filter(t => t.includes("TG 已兜"));
   assert.equal(dropRows.length, 2,
     `expected both WeChat-dropped slots listed, got ${dropRows.length}: ${dropRows.join(" | ")}`);
@@ -1533,13 +1535,17 @@ async function testMoversSayWhichSessionTheyAreFrom(browser, base) {
   }
 }
 
-// 窄档（≤767px）把槽位轨那张图收掉了：24 小时压进 ~217px 的轨道、11 个行名
-// 全是省略号，针脚和刻度线一样粗，在手机上读不出任何东西 —— 同一份「谁 ·
-// 几点 · 怎么了」在「逐项」里是逐行的文字。收图的前提是这块牌仍然答得出
-// 「接下来轮到谁」，否则那不是改版式，是删掉一个答案。
-// 这条闸同时钉住手机上另外三处几何：说明行不许被截断（nowrap+ellipsis 吃掉
-// 半句话是这块牌的老毛病）、逐项的状态词必须和名字同一行（它曾被自动排布挤
-// 成右对齐的孤行，每行白白高出 ~40px）、处置牌不许被顶出卡片。
+// 手机上的数据健康牌：这块牌在 390px 上曾经是「一张读不出东西的 24 小时图
+// ＋ 一坨 2600px 的逐项」。现在的形状是：判词 → 需处理清单（不点任何东西就在）
+// → 三条泳道，每条自己是一个展开器，明细摊在它自己下面。这条闸钉住那个形状：
+//  1. 槽位轨那张图在窄档不画（24 小时压进 ~217px、11 个行名全是省略号），
+//     但收图的前提是同一块牌仍然答得出「接下来轮到谁」；
+//  2. 每条泳道都是可聚焦的按钮、有 aria-expanded、收起时它那一组是 inert
+//     （折叠是 grid-rows 动画，元素还在，不 inert 就还在 Tab 顺序里）；
+//  3. 点一条泳道只展开那一条，明细必须紧跟在它下面（不是卡片底部）；
+//  4. 说明行可以收成引子，但被收起来的那条泳道必须有一组明细接住全文；
+//  5. 逐项那一行的状态词必须和名字同一行（它曾被挤成右对齐的孤行）；
+//  6. 整块牌不横向溢出，处置牌不被顶出卡片，「逐项」有拇指够得着的高度。
 async function testDataHealthIsReadableOnAPhone(browser, base) {
   const context = await browser.newContext({
     viewport: { width: 390, height: 844 }, isMobile: true, hasTouch: true,
@@ -1570,13 +1576,26 @@ async function testDataHealthIsReadableOnAPhone(browser, base) {
       railChart: shown(document.querySelector(".dh-rail-body")),
       next: document.getElementById("dh-rail-next").textContent.trim(),
       nextShown: shown(document.getElementById("dh-rail-next")),
-      clipped: [...card.querySelectorAll(".dh-lane-note, .dh-caption, .hero-health-meta")]
+      clipped: [...card.querySelectorAll(".dh-caption, .hero-health-meta")]
         .filter(el => el.scrollWidth > el.clientWidth + 1)
         .map(el => el.textContent.trim().slice(0, 40)),
       overflow: card.scrollWidth - card.clientWidth,
       toggleHeight: Math.round(document.getElementById("dh-toggle").getBoundingClientRect().height),
       chipOverhang: Math.round(Math.max(...[...card.querySelectorAll(".dh-chip")]
         .map(chip => chip.getBoundingClientRect().right - cardRight))),
+      lanes: [...card.querySelectorAll(".dh-lane")].map(lane => ({
+        id: lane.id,
+        tag: lane.tagName,
+        expanded: lane.getAttribute("aria-expanded"),
+        height: Math.round(lane.getBoundingClientRect().height),
+        // 收起的那一组：0 高、inert，而且里面确实有东西可看（空的展开器是个
+        // 谎话——它会把「点开看全文」许诺给一块空面板）。
+        groupRows: (document.getElementById(lane.getAttribute("aria-controls")) || document.body)
+          .querySelectorAll(".dh-row").length,
+        groupInert: (document.getElementById(lane.getAttribute("aria-controls")) || {}).inert,
+        groupHeight: Math.round((document.getElementById(lane.getAttribute("aria-controls"))
+          || document.body).getBoundingClientRect().height),
+      })),
     };
   });
   assert.equal(head.railChart, false,
@@ -1590,12 +1609,47 @@ async function testDataHealthIsReadableOnAPhone(browser, base) {
     `逐项 is ${head.toggleHeight}px tall — too small a target for a thumb`);
   assert(head.chipOverhang <= 0,
     `a disposition chip sticks ${head.chipOverhang}px past the card edge`);
+  assert.equal(head.lanes.length, 3, "the three fixed lanes are gone");
+  head.lanes.forEach(lane => {
+    assert.equal(lane.tag, "BUTTON",
+      `${lane.id} is not a button — a row you are meant to tap has to be focusable`);
+    assert.equal(lane.expanded, "false", `${lane.id} starts expanded`);
+    assert(lane.groupRows > 0,
+      `${lane.id} promises detail but its panel is empty`);
+    assert.equal(lane.groupInert, true,
+      `${lane.id}'s collapsed panel is still in the tab order`);
+    assert.equal(lane.groupHeight, 0, `${lane.id}'s panel is not collapsed`);
+    assert(lane.height >= 44,
+      `${lane.id} is ${lane.height}px tall — below a thumb-sized row`);
+  });
+
+  // 点一条，只开那一条，而且开在它自己下面。
+  const opened = await page.evaluate(async () => {
+    document.getElementById("dh-lane-integrity").click();
+    await new Promise(resolve => setTimeout(resolve, 400));
+    const lane = document.getElementById("dh-lane-integrity");
+    const group = document.getElementById("dh-group-integrity");
+    return {
+      expanded: lane.getAttribute("aria-expanded"),
+      height: Math.round(group.getBoundingClientRect().height),
+      // 明细紧跟在这条泳道下面，不是卡片底部：它的顶边就是泳道的底边。
+      gap: Math.round(group.getBoundingClientRect().top - lane.getBoundingClientRect().bottom),
+      others: ["files", "delivery"].map(key =>
+        Math.round(document.getElementById(`dh-group-${key}`).getBoundingClientRect().height)),
+    };
+  });
+  assert.equal(opened.expanded, "true", "tapping a lane did not expand it");
+  assert(opened.height > 0, "the lane expanded but its panel stayed collapsed");
+  assert(Math.abs(opened.gap) <= 2,
+    `the panel opened ${opened.gap}px away from the lane that owns it`);
+  assert.deepEqual(opened.others, [0, 0],
+    "opening one lane expanded the others too — that is the 2600px 逐项 again");
 
   // 处置行（.is-todo）的末列是「下一步去哪看」，它本来就独占一行；台账行不是。
   const orphans = await page.evaluate(async () => {
     document.getElementById("dh-toggle").click();
-    await new Promise(resolve => setTimeout(resolve, 50));
-    return [...document.querySelectorAll("#dh-files .dh-row:not(.is-todo)")]
+    await new Promise(resolve => setTimeout(resolve, 400));
+    return [...document.querySelectorAll(".dh-group .dh-row:not(.is-todo)")]
       .filter(row => {
         const name = row.querySelector(".dh-name").getBoundingClientRect();
         const state = row.querySelector(".dh-state").getBoundingClientRect();


### PR DESCRIPTION
kcn：「数据健康那块现在对于 mobile 端体验还是比较奇怪…不仅仅是大小 还有交互 主要是展现形式」。

## 量出来的病（390px / 360px）

- 折叠态 **710px（390）/ 725px（360）**，其中 **243px 是那张 24 小时槽位轨**：24 小时压进 ~217px 的轨道、11 个行名全是省略号（`美股盘中盯盘-o…`）、3px 的针脚和「每小时一条」的刻度线一样粗。这张图在手机上读不出任何东西。
- **交互只有一个开关**：整块牌只有「逐项」，按下去是 **34 行 2600px** 的流水账；三条泳道自己不可点。想知道「投递到底怎么了」，得展开全部再往下翻。
- 逐项里 `.dh-bar` / `.dh-detail` 都是整行 span，自动排布把状态词挤到第四行、右对齐单独占一行，**每行 154px**。
- 「处置 · 需处理」——这块牌上唯一「你该动手」的东西——藏在那次点击后面。
- 体检那条泳道只印得下最坏的一条，**WARN 的全文在页面上没有任何地方读得到**；窄屏里它是三行英文，是折叠态最重的一坨。
- meta 在「构建」后面被折开，`构建 2026-09-09 00:05` 读成两条信息。

## 改法：形状先于尺寸

**一条泳道 = 一个展开器。** 泳道改成 `<button>`（整行都是点按面积、键盘可达、`aria-expanded` 说状态），明细摊在**它自己下面**（组是泳道的兄弟节点，不是卡片底部的一坨）。点 `投递` 只开「今天每槽 + 微信掉投」；点 `数据面` 只开 15 个数据面。收起时那一组 `inert` + `aria-hidden` —— 折叠是 `grid-template-rows: 0fr` 的动画，元素还在，不 inert 它就还在 Tab 顺序里。展开 240ms `ease-out`，`prefers-reduced-motion` 下直接落位。「逐项」保留，含义变成「全部展开」。

**「需处理」不再藏在一次点击后面**：它自己一块，在判词底下，没有待办时整块不占位。

**体检第一次有了自己的明细**：ERROR/WARN 逐条 + 处置词；折叠态的说明相应收成两行引子（全文一点就有）。

窄档仍然收掉槽位轨那张图，保留计数摘要 + `下一槽 HH:MM · job`；**≥768px 版式一字未动**，只多了三个 chevron。另外：状态词回到名字那一行、处置行三带（名字 / 位置+说明 / 下一步，位置不折不省略）、meta 分段不折行、说明行 10px→11px、期限带更宽不更高。

## 实测

| | 360 | 390 | 430 | 1280 |
|---|---|---|---|---|
| 折叠态 前 → 后 | 725 → **521** | 710 → **501** | 672 → **448** | 版式未变 |
| 只看投递 | — | **1720**（以前要 2600px 全展开才看得到同一段） | — | — |

深色模式、逾期 / ERROR / FAILED 的降级态都在 390px 上截图核过（处置清单那条路只有出事时才走，绿跑证明不了它）。

## 闸

- `testDataHealthIsReadableOnAPhone` 重写成钉**形状**：泳道必须是按钮、收起的组必须非空且 inert 且 0 高、点一条只开一条且开在它自己下面（顶边贴着泳道底边）、状态词和名字同行、不横向溢出、处置牌不出卡片、「逐项」够拇指点、图收掉了就必须答得出「接下来轮到谁」。
- `testCronNeedsActionMergesIntoTheOneTodoListButWatchDoesNot` 改成**不点任何东西**就要读到需处理清单（藏起来的待办 = 没有待办）。

`dashboard_tab_runtime.spec.js` 全绿；本地 pytest 全量 3608 passed。

> 顺带：这条分支第一次跑 CI 时 `validate` 是红的，**红在 master 自己身上**（decimap 抽屉的 focus trap，见 #1419，已单独修好合并）。

https://claude.ai/code/session_014rtreLEMvEJ1cCTGX84wT3