### PR TITLE
decimap: 抽屉打开时页头页脚还在 tab 顺序里（master 已红）

### DIFF
--- a/site/decimap/index.html
+++ b/site/decimap/index.html
@@ -585,14 +585,23 @@ permalink: /decimap/
   // by identity rather than by making the whole container inert.
   let drawerReturnFocus = null;
 
+  // Every ancestor level, not just #decimap: the page grew a shared header and
+  // footer (#1211) that live outside #decimap, so inerting only the drawer's
+  // siblings left nine real links in the tab order behind the scrim. It stayed
+  // green because the test's 12 tabs happened to be fewer than the drawer's own
+  // focusables — until a smaller payload (data commit 09f0b71c, no code change)
+  // made the drawer short enough for Tab to reach them. Walking up to <body> is
+  // the version that does not depend on how much is in the drawer.
   function setBackgroundInert(on) {
-    const root = el('decimap');
     const drawer = el('dm-drawer');
     const scrim = el('dm-scrim');
-    if (!root) return;
-    for (const child of root.children) {
-      if (child === drawer || child === scrim) continue;
-      child.inert = on;
+    if (!drawer) return;
+    for (let node = drawer; node && node.parentElement && node !== document.body;
+         node = node.parentElement) {
+      for (const sibling of node.parentElement.children) {
+        if (sibling === node || sibling === scrim) continue;
+        sibling.inert = on;
+      }
     }
   }
 

--- a/tests/decimap_board.spec.js
+++ b/tests/decimap_board.spec.js
@@ -180,6 +180,22 @@ async function theDrawerTrapsFocusAndGivesItBack(browser, base) {
   assert.deepEqual(outside, [],
     `these siblings stayed reachable behind the open drawer: ${outside.join(", ")}`);
 
+  // 12 tabs only proves the trap holds while the drawer is long enough to
+  // absorb them — that is exactly how this contract went green on a page whose
+  // header links were never inerted (a smaller payload, no code change, later
+  // made Tab reach them). Enumerate instead: nothing focusable anywhere on the
+  // page may be reachable while the drawer is open.
+  const reachable = await page.evaluate(() => {
+    const drawer = document.getElementById("dm-drawer");
+    const FOCUSABLE = "a[href], button, input, select, textarea, [tabindex]";
+    return [...document.querySelectorAll(FOCUSABLE)]
+      .filter(el => !drawer.contains(el) && !el.closest("[inert]") && !el.inert
+        && el.offsetParent !== null)
+      .map(el => el.id || `${el.tagName}.${el.className}`);
+  });
+  assert.deepEqual(reachable, [],
+    `these controls stayed in the tab order behind the open drawer: ${reachable.join(", ")}`);
+
   for (let i = 0; i < 12; i++) await page.keyboard.press("Tab");
   const stillInside = await page.evaluate(() =>
     document.getElementById("dm-drawer").contains(document.activeElement));


### PR DESCRIPTION
`validate` 在 **master 上就是红的**，挡住所有 PR。

## 不是谁的 diff

`git bisect` 指到 **09f0b71c**：一次纯数据提交（`memory: daily deep brief 2026-09-07`，`decision_map.json` 变小），**代码一行没改**。master 的推送不跑浏览器契约（data-only 提交把 `changes.code` 判成 false，那几步 `skipped`），所以红了两天没人看见 —— 又一次「master 的 CI 绿 ≠ master 绿」。

## 真因

`setBackgroundInert` 只把 `#decimap` 的兄弟节点设成 `inert`，而这个页面在 #1211 之后长出了 `#decimap` **之外**的共享页头/页脚。实测抽屉打开时仍有 **9 个链接**（brand + 5 条 nav + 3 条 footer）留在 tab 顺序里。这条契约一直靠「抽屉里的可聚焦元素比 12 个 Tab 多」蒙混过关；payload 一变小，Tab 就走出去了 —— 数据只是把一个一直存在的 a11y 缺陷暴露出来。

## 改法

- 从抽屉往上走到 `<body>`，每一层都把兄弟节点 inert 掉；不再依赖抽屉里有多少东西。
- 闸加一条**枚举**断言：抽屉打开时，页面上任何可聚焦元素都不许留在 tab 顺序里。撤掉 fix 它会点名那 9 个链接（已验）。12 个 Tab 那条留着，但不再是唯一证据。

https://claude.ai/code/session_014rtreLEMvEJ1cCTGX84wT3