### PR TITLE
dashboard: 决策地图在手机上一次只画一类动作

### DIFF
--- a/site/assets/css/dashboard.css
+++ b/site/assets/css/dashboard.css
@@ -3000,6 +3000,12 @@
   .dm-seg button + button { border-left: 1px solid var(--border); }
   .dm-seg button[aria-pressed="true"] { background: var(--accent); color: #fff; }
 
+  /* 动作切换条：只在窄档存在（宽档八列本来就都在屏幕上）。见
+     dashboard.decimap.js 的 visibleActions()。 */
+  .dm-actionbar { display: none; }
+  .dm-actionnote { display: none; }
+  .dm-onlynarrow { display: none; }
+
   /* the board — horizontal scroll lives here and only here: the page itself
      must never scroll sideways. */
   .dm-board-wrap { overflow-x: auto; border: 1px solid var(--border);
@@ -3141,6 +3147,31 @@
        opened on two columns of names and no data at all. Narrow both until at
        least three action columns are on screen before the first scroll. */
     .dm-board { min-width: 640px; }
+    /* 窄档的板只画一类动作 ⇒ 它必须**装得下**，不是「滚得动」。 */
+    .dm-board.is-single { min-width: 0; }
+    /* 单列模式省下来的宽度，一半给信号名（`bar.corwin_schultz_spread_pct`
+       在窄档要折行），但仍然是**上限**：去掉上限它会长到 265px，把板重新
+       顶出屏幕（实测 390px 展开后横滚 118px）。 */
+    .dm-board.is-single .dm-src { max-width: 156px; }
+    .dm-board.is-single .dm-cov { width: 92px; }
+    .dm-board.is-single .dm-ic { width: 62px; min-width: 56px; }
+    .dm-board.is-single .dm-whisker { display: none; }
+
+    .dm-actionbar { display: flex; flex-wrap: wrap; align-items: center; gap: 6px; }
+    .dm-barlabel { color: var(--text-dim); font-family: var(--mono);
+      font-size: 10.5px; letter-spacing: .04em; }
+    .dm-actionbar button { display: inline-flex; align-items: center; gap: 5px;
+      border: 1px solid var(--border); border-radius: 999px; background: var(--card);
+      color: var(--text); font: inherit; font-size: 12px; padding: 6px 10px;
+      cursor: pointer; }
+    .dm-actionbar button em { font-style: normal; font-family: var(--mono);
+      font-size: 11px; color: var(--text-dim); }
+    .dm-actionbar button[aria-pressed="true"] { background: var(--accent);
+      border-color: var(--accent); color: #fff; }
+    .dm-actionbar button[aria-pressed="true"] em { color: rgba(255,255,255,.85); }
+    .dm-actionnote { display: block; margin: 2px 0 0; }
+    .dm-onlywide { display: none; }
+    .dm-onlynarrow { display: inline; }
     /* Let a long signal name wrap instead of forcing the sticky column as wide
        as `quant.stop_distance_pct`, which alone was half a phone. */
     .dm-board .dm-src { min-width: 104px; max-width: 118px;
@@ -3165,6 +3196,15 @@
       transform: translateY(100%);
     }
     .dm-drawer .dm-close { font-size: 24px; padding: 4px 8px; top: 8px; right: 8px; }
+  }
+
+  /* 320px（SE / 折叠机外屏）：展开信号行之后 IC 那一列回来，四列刚好比屏幕
+     宽（实测 15px）。省下来的宽度全在三列固定宽度和名字的上限上。 */
+  @media (max-width: 360px) {
+    .dm-board.is-single .dm-src { max-width: 124px; }
+    .dm-board.is-single .dm-cov { width: 76px; }
+    .dm-board.is-single .dm-ic { width: 52px; min-width: 48px; }
+    .dm-board.is-single .dm-cell { min-width: 48px; }
   }
 
   /* Touch, not hover. The timeline dot is 9px across — under a finger that is a

--- a/site/assets/js/dashboard.decimap.js
+++ b/site/assets/js/dashboard.decimap.js
@@ -32,7 +32,13 @@
     quant: '量化', setup: '形态',
   };
   function kindCn(kind) { return KIND_CN[kind] || kind; }
-  var state = { data: null, horizon: 't5', ticker: '', open: {}, scale: 1 };
+  var state = { data: null, horizon: 't5', ticker: '', open: {}, scale: 1, action: '' };
+  // 窄档一次只画一类动作。八列 × 66px 是 649px 的表塞进 324px 的卡：手机上
+  // 看得见三列半，右边还有什么没有任何提示，而其中两类动作在这段窗口里一条
+  // 决策都没有。读者心里的单位是「哪类动作旁边站着谁」——那就让他一次选一类，
+  // 板不横向滚。≥641px 一字不动（那里八列本来就都在屏幕上）。
+  var NARROW = window.matchMedia('(max-width: 640px)');
+  function narrow() { return NARROW.matches; }
 
   function el(id) { return document.getElementById(id); }
   // Every string interpolated into innerHTML below goes through this. Ticker
@@ -168,18 +174,84 @@
     return '<td class="dm-ic" title="' + esc(title) + '">' + value + whisker + '</td>';
   }
 
+  // 每类动作的总条数，按信息源族的汇总取（不加信号行，那是同一批决策的重复
+  // 计数）。0 条的那几类在窄档不列成 chip —— 但要说出来是哪几类，一个安静
+  // 消失的列读起来像「这类动作没发生过」和「这类动作我们不给看」不分。
+  function actionTotals() {
+    var totals = {};
+    (state.data.actions || []).forEach(function (action) { totals[action] = 0; });
+    (state.data.source_kind_cards || []).forEach(function (card) {
+      Object.keys(card.by_action || {}).forEach(function (action) {
+        if (totals[action] === undefined) totals[action] = 0;
+        totals[action] += card.by_action[action].count || 0;
+      });
+    });
+    return totals;
+  }
+
+  function liveActions() {
+    var totals = actionTotals();
+    return (state.data.actions || []).filter(function (action) {
+      return totals[action] > 0;
+    }).sort(function (a, b) { return totals[b] - totals[a]; });
+  }
+
+  // The columns this render draws. Wide: every action the payload declares.
+  // Narrow: exactly the one the reader picked, defaulting to the busiest.
+  function visibleActions() {
+    var actions = state.data.actions || [];
+    if (!narrow()) return actions;
+    var live = liveActions();
+    if (!live.length) return actions.slice(0, 1);
+    if (live.indexOf(state.action) < 0) state.action = live[0];
+    return [state.action];
+  }
+
+  function renderActionBar() {
+    var bar = el('dm-actions'), note = el('dm-actionnote');
+    if (!bar) return;
+    if (!narrow()) { bar.hidden = true; if (note) note.hidden = true; return; }
+    var totals = actionTotals(), live = liveActions();
+    visibleActions();   // 归一化 state.action
+    bar.innerHTML = '<span class="dm-barlabel">动作</span>' + live.map(function (action) {
+      return '<button type="button" data-action="' + esc(action) + '"'
+        + ' title="' + esc(action) + '"'
+        + ' aria-pressed="' + (action === state.action ? 'true' : 'false') + '">'
+        + esc(actionCn(action)) + ' <em>' + totals[action] + '</em></button>';
+    }).join('');
+    bar.hidden = false;
+    if (note) {
+      var quiet = (state.data.actions || []).filter(function (action) {
+        return !totals[action];
+      });
+      note.textContent = '手机上一次看一类动作。'
+        + (quiet.length
+            ? quiet.map(actionCn).join('、') + ' 在这段窗口里 0 条决策，没有列出来。'
+            : '');
+      note.hidden = false;
+    }
+  }
+
   function renderBoard() {
     var d = state.data, horizon = state.horizon;
-    var actions = d.actions || [];
+    var actions = visibleActions();
     var rows = boardRows();
+    // 满色阈值仍然按**所有**动作算：切一类动作不该让同一个格换个颜色。
     state.scale = fillScale(horizon);
+    el('dm-board').classList.toggle('is-single', narrow());
+
+    // IC 按信息源族汇总没有定义 ⇒ 板刚打开时那一列整列是「·」。宽档它只是
+    // 一列留白，窄档它是 62px 的屏幕。展开任意一个族（IC 有值的那些行）它
+    // 就回来。
+    var showIc = !narrow() || rows.some(function (row) { return !row.kind; });
 
     var head = '<thead><tr><th class="dm-src">信息源</th>'
       + '<th class="dm-covh">覆盖</th>';
     actions.forEach(function (action) {
       head += '<th title="' + esc(action) + '">' + esc(actionCn(action)) + '</th>';
     });
-    head += '<th>IC ' + esc(horizon) + '</th></tr></thead><tbody>';
+    head += (showIc ? '<th>IC ' + esc(horizon) + '</th>' : '')
+      + '</tr></thead><tbody>';
 
     var body = '';
     rows.forEach(function (row) {
@@ -202,7 +274,7 @@
         + '<span class="dm-covtext">' + card.decision_coverage_pct.toFixed(1) + '% · '
         + card.decisions_joined + '</span></td>';
       actions.forEach(function (action) { body += cellHtml(row, action, horizon); });
-      body += icHtml(row, horizon) + '</tr>';
+      body += (showIc ? icHtml(row, horizon) : '') + '</tr>';
     });
 
     el('dm-board').innerHTML = head + body + '</tbody>';
@@ -483,7 +555,7 @@
     drawerReturnFocus = null;
   }
 
-  function renderAll() { renderKpi(); renderBoard(); renderTimeline(); }
+  function renderAll() { renderKpi(); renderActionBar(); renderBoard(); renderTimeline(); }
 
   // 面板每次刷新都会拿到一份新的 payload；事件只绑一次，展开/横期/选票这些
   // 读者自己的状态因此不会被一次后台刷新重置。
@@ -512,7 +584,7 @@
       renderBoard();
     });
     el('dm-reset').addEventListener('click', function () {
-      state.horizon = 't5'; state.ticker = ''; state.open = {};
+      state.horizon = 't5'; state.ticker = ''; state.open = {}; state.action = '';
       el('dm-ticker').value = '';
       el('dm-expand').textContent = '展开全部';
       [].forEach.call(el('dm-horizon').querySelectorAll('button'), function (button) {
@@ -520,6 +592,18 @@
       });
       renderAll();
     });
+    el('dm-actions').addEventListener('click', function (event) {
+      var button = event.target.closest('button[data-action]');
+      if (!button) return;
+      state.action = button.dataset.action;
+      renderActionBar();
+      renderBoard();
+    });
+    // 转屏/换窗宽会跨过 640px：板的形态是媒体查询决定的，重画一次，否则窄档
+    // 留着八列（横向滚回来了）或宽档只剩一列。
+    var onWidth = function () { if (state.data) { renderActionBar(); renderBoard(); } };
+    if (NARROW.addEventListener) NARROW.addEventListener('change', onWidth);
+    else if (NARROW.addListener) NARROW.addListener(onWidth);
     el('dm-board').addEventListener('click', function (event) {
       var twist = event.target.closest('.dm-twist');
       if (twist) {

--- a/site/index.html
+++ b/site/index.html
@@ -975,7 +975,8 @@ layout: null
           <button type="button" data-h="t20" aria-pressed="false">t20</button>
         </span>
       </div>
-      <p class="chart-hint">行是<b>信息源</b>（点开成它的信号），列是<b>当时实际采取的动作</b>，
+      <p class="chart-hint">行是<b>信息源</b>（点开成它的信号），<span class="dm-onlywide">列是<b>当时实际采取的动作</b></span><span
+        class="dm-onlynarrow">列是你选的那类<b>动作</b></span>，
         格是「这个源站在那类动作旁边多少次 · 之后的中位收益」。</p>
       <div class="decimap" id="decimap">
         <div class="dm-kpi" id="dm-kpi">载入中…</div>
@@ -983,6 +984,8 @@ layout: null
           <button type="button" id="dm-expand">展开全部</button>
           <button type="button" id="dm-reset">重置</button>
         </div>
+        <div class="dm-actionbar" id="dm-actions" role="group" aria-label="动作" hidden></div>
+        <p class="dm-sub dm-actionnote" id="dm-actionnote" hidden></p>
         <div class="dm-board-wrap"><table class="dm-board" id="dm-board"></table></div>
         <div class="dm-scalenote" id="dm-scale"></div>
         <details class="chart-note">

--- a/tests/decimap_board.spec.js
+++ b/tests/decimap_board.spec.js
@@ -228,28 +228,126 @@ async function theDrawerTrapsFocusAndGivesItBack(browser, base) {
 }
 
 
-async function thePageNeverScrollsSidewaysButTheBoardDoes(browser, base) {
-  for (const width of [320, 390, 1280]) {
-    const { context, page } = await open(browser, base, width);
-    const measured = await page.evaluate(() => {
+// 手机上这块板一次只画一类动作。
+//
+// 2026-09-09 实测（真 payload，8 类动作）：宽档的板是 649px，塞进 390px 手机上
+// 的一张 324px 的卡里 —— 看得见三列半，右边还有五列没有任何提示，而其中两类
+// 动作（否决 / 只做 T 之一）在这段窗口里一条决策都没有。横向滚动不是交互：
+// 读者心里的单位是「哪类动作旁边站着谁」，所以窄档给他一个动作切换条，板
+// 必须**装得下**。宽档八列本来就都在屏幕上，一字不动。
+async function theBoardFitsAPhoneOneActionAtATime(browser, base, payload) {
+  const declared = payload.actions || [];
+  const totals = {};
+  declared.forEach(action => { totals[action] = 0; });
+  (payload.source_kind_cards || []).forEach(card => {
+    Object.keys(card.by_action || {}).forEach(action => {
+      totals[action] = (totals[action] || 0) + (card.by_action[action].count || 0);
+    });
+  });
+  const busiest = declared.slice().sort((a, b) => totals[b] - totals[a])[0];
+  const quiet = declared.filter(action => !totals[action]);
+
+  for (const width of [320, 390]) {
+    const { context, page, errors } = await open(browser, base, width);
+    const shape = await page.evaluate(() => {
       const wrap = document.querySelector(".dm-board-wrap");
-      const source = document.querySelector("#dm-board .dm-src");
+      const bar = document.getElementById("dm-actions");
       return {
         page: document.documentElement.scrollWidth - document.documentElement.clientWidth,
         board: wrap.scrollWidth - wrap.clientWidth,
-        sticky: getComputedStyle(source).position,
+        sticky: getComputedStyle(document.querySelector("#dm-board .dm-src")).position,
+        barShown: !bar.hidden && bar.getBoundingClientRect().height > 0,
+        chips: [...bar.querySelectorAll("button")].map(button => button.dataset.action),
+        pressed: [...bar.querySelectorAll('button[aria-pressed="true"]')]
+          .map(button => button.dataset.action),
+        columns: [...document.querySelectorAll("#dm-board thead th")]
+          .map(th => th.getAttribute("title")).filter(Boolean),
+        note: (document.getElementById("dm-actionnote") || {}).textContent || "",
       };
     });
-    assert(measured.page <= 1,
-      `${width}px: the document scrolls sideways by ${measured.page}px`);
-    assert.equal(measured.sticky, "sticky",
-      `${width}px: the source column must stay put while the actions scroll`);
-    if (width < 600) {
-      assert(measured.board > 0,
-        `${width}px: a nine-column board that needs no scroll is suspicious`);
+    assert.deepEqual(errors, [], `${width}px: page errors: ${errors.join(" | ")}`);
+    assert(shape.page <= 1, `${width}px: the document scrolls sideways by ${shape.page}px`);
+    assert.equal(shape.board, 0,
+      `${width}px: the board still needs ${shape.board}px of sideways scroll — `
+      + "a phone cannot read a column it has no idea is there");
+    assert.equal(shape.sticky, "sticky",
+      `${width}px: the source column must stay put`);
+    assert(shape.barShown, `${width}px: the action switcher is not on screen`);
+    assert(shape.chips.length >= 2,
+      `${width}px: ${shape.chips.length} action chip(s) — nothing to switch between`);
+    assert.deepEqual(shape.pressed, [busiest],
+      `${width}px: the board opens on ${shape.pressed} instead of the busiest action `
+      + `(${busiest}, ${totals[busiest]} decisions)`);
+    assert.deepEqual(shape.columns, [busiest],
+      `${width}px: the board drew ${shape.columns.length} action columns, not one`);
+    // 0 条的动作不列成 chip —— 但要说出来是哪几类：一个安静消失的列读起来跟
+    // 「这类动作没发生过」不分。
+    for (const action of quiet) {
+      assert(!shape.chips.includes(action),
+        `${width}px: ${action} has no decisions in this window and is still a chip`);
+      assert(shape.note.length > 0,
+        `${width}px: ${action} was dropped from the switcher without a word`);
     }
+    assert.deepEqual(shape.chips.filter(action => !totals[action]), [],
+      `${width}px: a chip offers an action with no decisions behind it`);
+
+    // 换一类动作，格子里的数必须跟着换 —— 否则这个开关是个装饰。
+    const before = await page.textContent("#dm-board .dm-cell");
+    const other = shape.chips.find(action => action !== busiest);
+    await page.click(`#dm-actions button[data-action="${other}"]`);
+    await page.waitForTimeout(150);
+    const after = await page.evaluate(() => ({
+      columns: [...document.querySelectorAll("#dm-board thead th")]
+        .map(th => th.getAttribute("title")).filter(Boolean),
+      cell: document.querySelector("#dm-board .dm-cell").textContent,
+      board: (() => {
+        const wrap = document.querySelector(".dm-board-wrap");
+        return wrap.scrollWidth - wrap.clientWidth;
+      })(),
+    }));
+    assert.deepEqual(after.columns, [other],
+      `${width}px: tapping ${other} did not swap the column`);
+    assert.notEqual(after.cell, before,
+      `${width}px: the board prints the same numbers for ${busiest} and ${other}`);
+
+    // 展开信号行会把 IC 那一列带回来（族的 IC 没有定义，整列是「·」）。
+    // 那是这块板最宽的状态，也必须装得下。
+    await page.click("#dm-expand");
+    await page.waitForTimeout(200);
+    const expanded = await page.evaluate(() => {
+      const wrap = document.querySelector(".dm-board-wrap");
+      return {
+        board: wrap.scrollWidth - wrap.clientWidth,
+        rows: document.querySelectorAll("#dm-board tbody tr").length,
+        ic: document.querySelectorAll("#dm-board .dm-ic").length,
+      };
+    });
+    assert(expanded.rows > 6, `${width}px: expanding revealed no signal rows`);
+    assert(expanded.ic > 0,
+      `${width}px: the IC column never comes back for the rows that have an IC`);
+    assert.equal(expanded.board, 0,
+      `${width}px: expanded, the board needs ${expanded.board}px of sideways scroll`);
     await context.close();
   }
+
+  // ≥641px：八列全在，切换条不存在。
+  const { context, page } = await open(browser, base, 1280);
+  const wide = await page.evaluate(() => ({
+    columns: [...document.querySelectorAll("#dm-board thead th")]
+      .map(th => th.getAttribute("title")).filter(Boolean),
+    bar: (() => {
+      const bar = document.getElementById("dm-actions");
+      return !bar.hidden && bar.getBoundingClientRect().height > 0;
+    })(),
+    page: document.documentElement.scrollWidth - document.documentElement.clientWidth,
+    sticky: getComputedStyle(document.querySelector("#dm-board .dm-src")).position,
+  }));
+  assert.deepEqual(wide.columns, declared,
+    "the wide board must still carry every action the payload declares");
+  assert(!wide.bar, "the action switcher is a narrow-only shape; it is showing at 1280px");
+  assert(wide.page <= 1, `1280px: the document scrolls sideways by ${wide.page}px`);
+  assert.equal(wide.sticky, "sticky", "1280px: the source column must stay put");
+  await context.close();
 }
 
 async function theKpiStripPrintsWhatThePayloadHolds(browser, base, payload) {
@@ -370,7 +468,7 @@ async function main() {
     await noCellUsesColourAsItsOnlyChannel(browser, base);
     await aCellOpensTheDecisionsItCounts(browser, base);
     await theDrawerTrapsFocusAndGivesItBack(browser, base);
-    await thePageNeverScrollsSidewaysButTheBoardDoes(browser, base);
+    await theBoardFitsAPhoneOneActionAtATime(browser, base, payload);
     await theTimelineSpreadsRealDatesAcrossItsAxis(browser, base);
     await theKpiStripPrintsWhatThePayloadHolds(browser, base, payload);
     await theCaveatReportsWhatSurvivedItsPlacebo(browser, base, payload);


### PR DESCRIPTION
kcn：「决策地图在 mobile 展现要注意」。前情：#1420 刚把它从 `/decimap/` 搬进 Reflect 的一张卡。

## 病灶（实测，390px + 真 payload）

板是 **649px 的表塞进 324px 的卡**：看得见三列半，右边还有五列没有任何提示（首列是 sticky 的，但没人知道要往右滑）。而这段窗口里 `reject` 一条决策都没有，那一列照样占着 66px。**横向滚动不是交互**——读者心里的单位是「哪类动作旁边站着谁」。

## 窄档（≤640px）：一次一类动作

- 板上方一条**动作切换条**：中文名 + 该动作的总条数（`持有观察 1412` / `砍仓 368` / …），按条数排序，默认选最忙的那类。
- 板只画 **信息源 / 覆盖 / 选中的那一类动作**，`.dm-board-wrap` **0 横滚**。
- **0 条的动作不列成 chip**，但在条下面点名：「手机上一次看一类动作。否决 在这段窗口里 0 条决策，没有列出来。」——一个安静消失的列，跟「这类动作没发生过」读起来不分。
- **IC 那一列**在信息源族的汇总上没有定义（整列是「·」），窄档先不占那 62px，展开信号行（IC 有值的那些行）它就回来。
- 满色阈值仍按**所有**动作算：切一类动作不该让同一个格换个颜色。
- 转屏跨过 640px 会重画（`matchMedia` 的 change），否则窄档留着八列、宽档只剩一列。

**≥641px 一字未动**（那里八列本来就都在屏幕上）。

| | 之前 | 现在 |
|---|---|---|
| 390px 板宽 / 卡宽 | 649 / 324 ⇒ 横滚 325px | 322 / 322 ⇒ **0** |
| 屏幕上的动作列 | 3.5 列，其余无提示 | 1 列 + 6 个可点的 chip |
| 0 条决策的动作 | 占一列 | 不列，但点名 |

## 闸

`decimap_board.spec.js` 里「板必须横滚」那条（`thePageNeverScrollsSidewaysButTheBoardDoes`）换成 `theBoardFitsAPhoneOneActionAtATime`，跑**真 payload**量 320/390 两档：收起 / 切一类动作 / 展开全部三个状态下 `.dm-board-wrap` 都必须是 0 横滚；chip 里不许出现 0 条的动作，被丢掉的动作必须在页面上被点名；默认必须是条数最多的那类；点另一个 chip 必须真的换掉列头**和格子里的数**（否则这个开关是装饰）；1280px 仍然是八列、且切换条不存在。

## 两个量出来的坑

- 单列模式给信号名放开 `max-width` ⇒ 那一列长到 265px，板重新顶出屏幕 118px。改成 156px 上限（320px 档 124px）。
- 给 320px 加的媒体块一开始插在 `max-width: 640px` 块**中间**，把后面所有窄档规则（含抽屉的底部弹层）一起关进了 `max-width: 360px`——症状是 390px 上源列回到 176px 的桌面 `min-width`。

本地：`decimap_board` / `site_layout_mobile` / `dashboard_tab_runtime` 三条浏览器契约全绿，pytest **3608 passed**。（`dashboard_tab_runtime` 的 verdict deck 那条在 **master 上用同一份今日数据也红**：「-3px of dead air」，与本 PR 无关，已另记。）

https://claude.ai/code/session_01PpjWJSMQKwiiQ5anRmTqtf