### PR TITLE
dashboard: 数据健康的泳道展开之后，把「今天没事」的那些行折起来

### DIFF
--- a/site/assets/css/dashboard.css
+++ b/site/assets/css/dashboard.css
@@ -2914,6 +2914,25 @@
     font: 500 var(--fs-xs)/1.35 var(--mono); font-variant-numeric: tabular-nums;
   }
   .dh-row:last-child { border-bottom: 0; }
+  /* 「今天没事的那些」折起来：展开一条泳道之后不该还是一坨流水账。行本身
+     一个字没改，只是排在一个展开器后面。 */
+  .dh-fold {
+    display: flex; align-items: center; gap: 8px; width: 100%;
+    background: none; border: 0; border-bottom: 1px solid var(--border-subtle);
+    padding: 9px 0; margin: 0; cursor: pointer; text-align: left;
+    color: var(--text-tertiary);
+    font: 600 var(--fs-xs)/1.35 var(--mono); font-variant-numeric: tabular-nums;
+  }
+  .dh-fold i {
+    width: 9px; height: 9px; border-right: 1.5px solid currentColor;
+    border-bottom: 1.5px solid currentColor; transform: rotate(-45deg);
+    transition: transform .16s ease; flex: 0 0 auto; margin: -3px 2px 0 3px;
+  }
+  .dh-fold[aria-expanded="true"] i { transform: rotate(45deg); margin-top: -6px; }
+  .dh-fold:hover { color: var(--text-secondary); }
+  .dh-fold:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+  @media (prefers-reduced-motion: reduce) { .dh-fold i { transition: none; } }
+  @media (pointer: coarse) { .dh-fold { padding: 13px 0; } }
   /* 逐项里的分组标题（投递 / 数据面）：两组读的是两件事，中间要有个界。 */
   .dh-sub {
     padding: 10px 0 4px; color: var(--text-tertiary);

--- a/site/assets/js/dashboard.hero.js
+++ b/site/assets/js/dashboard.hero.js
@@ -1151,13 +1151,31 @@
     return { cells, byDisposition };
   }
 
+  // 一组明细里「今天没事」的那些行折起来。#1418 把每条泳道做成了自己的展开
+  // 器，但展开之后仍然是一坨流水账：投递那组在 390px 上是 1200px，11 个 job
+  // 里 9 个写着「正常」——读者要滚到底才敢说今天没事。有事的排在前面、一直
+  // 摊开；没事的收进一个展开器，点开还是同一批行。收起时用 hidden，元素直接
+  // 退出 Tab 与读屏（这里不做 0fr 动画，所以不需要另外再上 inert）。
+  function foldQuiet(id, rows, label) {
+    const loud = rows.filter(r => !r.quiet).map(r => r.html).join("");
+    const quiet = rows.filter(r => r.quiet);
+    if (!quiet.length) return loud;
+    return loud
+      + `<button type="button" class="dh-fold" data-fold="${id}"`
+      + ` aria-expanded="false" aria-controls="dh-fold-${id}">`
+      + `<i></i>${escapeHtml(label(quiet.length))}</button>`
+      + `<div class="dh-foldbody" id="dh-fold-${id}" hidden>`
+      + quiet.map(r => r.html).join("")
+      + `</div>`;
+  }
+
   // 逐项里的一组：沿用这张牌已有的 .dh-row 五列语法（名/位置/条/说明/状态），
   // 灯放进 .dh-bar 那一列——说明列现在印的是那一句「为什么」，不是裸时刻表。
   function cronScheduleRows(cs) {
     const jobs = (cs && cs.jobs) || [];
     if (!jobs.length) return "";
     const RANK = { needs_action: 0, known_not_fixed: 1, watch: 2 };
-    return `<div class="dh-sub">定时任务 · 今天每槽</div>` + jobs.map(j => {
+    const rows = jobs.map(j => {
       const slots = (j.slots || []).map(s => ({ ...s, state: cronState(s.state) }));
       const noted = slots.filter(s => s.note)
         .sort((a, b) => (RANK[a.note.disposition] ?? 9) - (RANK[b.note.disposition] ?? 9));
@@ -1178,13 +1196,16 @@
       }).join("");
       const rowTone = j.unmonitored ? "idle"
         : worst ? (worst.note.disposition === "needs_action" ? "bad" : "warn") : "ok";
-      return `<div class="dh-row is-cron" data-tone="${rowTone}">`
+      // 「按时」和「待跑」都是今天没事；「账本看不到」不是——那一行留在上面。
+      return { quiet: rowTone === "ok", html: `<div class="dh-row is-cron" data-tone="${rowTone}">`
         + `<span class="dh-name">${escapeHtml(j.job)}</span>`
         + `<span class="dh-file">${escapeHtml(slots.length > 1 ? `${slots.length} 槽` : slots[0] ? slots[0].at : "")}</span>`
         + `<span class="dh-bar is-lamps">${lamps}</span>`
         + `<span class="dh-detail">${escapeHtml(why)}</span>`
-        + `<span class="dh-state">${escapeHtml(state)}</span></div>`;
-    }).join("");
+        + `<span class="dh-state">${escapeHtml(state)}</span></div>` };
+    });
+    return `<div class="dh-sub">定时任务 · 今天每槽</div>`
+      + foldQuiet("cron", rows, count => `其余 ${count} 个 job 今天按时或待跑`);
   }
   function renderDataHealth() {
     const root = document.getElementById("data-health");
@@ -1428,38 +1449,45 @@
         : "";
 
       const unnamed = Math.max(0, droppedTotal - dropped.length);
+      // 微信掉投整族是「已拍板不修」的台账（#771），一条都不需要动手 ⇒ 整族
+      // 折起来，标题那行仍然说清楚是几档、谁兜的。
+      const deliveryLedger = dropped.map(r => ({ quiet: true,
+        html: `<div class="dh-row is-delivery">`
+          + `<span class="dh-name">${escapeHtml(r.job || "未具名任务")}</span>`
+          + `<span class="dh-file">${escapeHtml(String(r.slot || "").slice(0, 16).replace("T", " "))}</span>`
+          + `<span class="dh-bar"></span>`
+          + `<span class="dh-detail">微信 sendMessage ret=-2 prepare failed</span>`
+          + `<span class="dh-state">TG 已兜</span></div>` }));
+      // 名单有上限，超出的那几档必须说出来 —— 否则「掉投 9 档」配 8 行
+      // 会读成列全了。
+      if (unnamed) {
+        deliveryLedger.push({ quiet: true,
+          html: `<div class="dh-row is-delivery"><span class="dh-name muted">另有 ${unnamed} 档</span>`
+            + `<span class="dh-file"></span><span class="dh-bar"></span>`
+            + `<span class="dh-detail">更早的槽位见 workflow-outcomes.json</span>`
+            + `<span class="dh-state"></span></div>` });
+      }
       const deliveryRows = dropped.length
         ? `<div class="dh-sub">投递 · 微信掉投（上游 ret=-2，已知不修）</div>`
-          + dropped.map(r => `<div class="dh-row is-delivery">`
-            + `<span class="dh-name">${escapeHtml(r.job || "未具名任务")}</span>`
-            + `<span class="dh-file">${escapeHtml(String(r.slot || "").slice(0, 16).replace("T", " "))}</span>`
-            + `<span class="dh-bar"></span>`
-            + `<span class="dh-detail">微信 sendMessage ret=-2 prepare failed</span>`
-            + `<span class="dh-state">TG 已兜</span></div>`).join("")
-          // 名单有上限，超出的那几档必须说出来 —— 否则「掉投 9 档」配 8 行
-          // 会读成列全了。
-          + (unnamed
-            ? `<div class="dh-row is-delivery"><span class="dh-name muted">另有 ${unnamed} 档</span>`
-              + `<span class="dh-file"></span><span class="dh-bar"></span>`
-              + `<span class="dh-detail">更早的槽位见 workflow-outcomes.json</span>`
-              + `<span class="dh-state"></span></div>`
-            : "")
+          + foldQuiet("wechat", deliveryLedger, count => `${count} 档掉投的台账`)
         : "";
 
-      const fileRows = `<div class="dh-sub">数据面 · 逐项</div>` + files
+      const fileList = files
         .slice()
         .sort((a, b) => usage(b) - usage(a))
         .map(f => {
           const st = stateOf(f);
           const label = st === "missing" ? "缺失" : st === "late" ? "逾期" : "在期";
-          return `<div class="dh-row is-${st}">`
+          return { quiet: st === "ok", html: `<div class="dh-row is-${st}">`
             + `<span class="dh-name">${escapeHtml(dataFileCn(f.name))}</span>`
             + `<span class="dh-file">${escapeHtml(f.name)}</span>`
             + `<span class="dh-bar"><i style="width:${Math.round(usage(f) * 100)}%"></i></span>`
             + `<span class="dh-detail">${escapeHtml(detailOf(f))}</span>`
             + `<span class="dh-state">${label}</span>`
-            + `</div>`;
-        }).join("");
+            + `</div>` };
+        });
+      const fileRows = `<div class="dh-sub">数据面 · 逐项</div>`
+        + foldQuiet("files", fileList, count => `在期的 ${count} 个数据面`);
 
       // 体检以前在逐项里没有自己的一组：泳道只印得下最坏的那一条，WARN 的
       // 全文没有任何地方读得到（窄屏还会被折成三行英文）。展开它就是那张单子。
@@ -1484,6 +1512,10 @@
       // 一条泳道 = 一个展开器，明细就摊在它自己下面（组是泳道的兄弟节点，不是
       // 卡片底部的一坨）。整块「逐项」在手机上是 34 行 2600px，读者要的不是
       // 「全都展开」，是「点开我关心的那一条」。
+      // 刷新是每几分钟一次的事：读者刚点开的那一折不能被合回去。
+      const openFolds = [...document.querySelectorAll("#data-health .dh-fold")]
+        .filter(button => button.getAttribute("aria-expanded") === "true")
+        .map(button => button.dataset.fold);
       const fill = (key, html) => {
         const body = document.getElementById(`dh-group-${key}-body`);
         if (body) body.innerHTML = html;
@@ -1491,6 +1523,13 @@
       fill("files", fileRows);
       fill("integrity", integrityRows);
       fill("delivery", cronRows + deliveryRows);
+      openFolds.forEach(id => {
+        const button = document.querySelector(`#data-health .dh-fold[data-fold="${id}"]`);
+        const body = document.getElementById(`dh-fold-${id}`);
+        if (!button || !body) return;
+        button.setAttribute("aria-expanded", "true");
+        body.hidden = false;
+      });
       const todoEl = document.getElementById("dh-todo");
       if (todoEl) todoEl.innerHTML = todoRows;
       // 收起的组仍在 DOM 里（折叠是 grid-rows 0fr 的动画），首帧也必须把它退出
@@ -1512,6 +1551,20 @@
         syncDataHealthToggle();
       });
     });
+    // 折叠器是每次刷新重新写进 innerHTML 的，所以监听挂在卡片上（一次），
+    // 不挂在按钮上。
+    if (root.dataset.foldWired !== "1") {
+      root.dataset.foldWired = "1";
+      root.addEventListener("click", event => {
+        const button = event.target.closest(".dh-fold");
+        if (!button) return;
+        const body = document.getElementById(`dh-fold-${button.dataset.fold}`);
+        if (!body) return;
+        const open = button.getAttribute("aria-expanded") !== "true";
+        button.setAttribute("aria-expanded", open ? "true" : "false");
+        body.hidden = !open;
+      });
+    }
     const toggle = document.getElementById("dh-toggle");
     if (toggle && toggle.dataset.wired !== "1") {
       toggle.dataset.wired = "1";

--- a/site/assets/js/dashboard.render.js
+++ b/site/assets/js/dashboard.render.js
@@ -1271,13 +1271,31 @@
     return { cells, byDisposition };
   }
 
+  // 一组明细里「今天没事」的那些行折起来。#1418 把每条泳道做成了自己的展开
+  // 器，但展开之后仍然是一坨流水账：投递那组在 390px 上是 1200px，11 个 job
+  // 里 9 个写着「正常」——读者要滚到底才敢说今天没事。有事的排在前面、一直
+  // 摊开；没事的收进一个展开器，点开还是同一批行。收起时用 hidden，元素直接
+  // 退出 Tab 与读屏（这里不做 0fr 动画，所以不需要另外再上 inert）。
+  function foldQuiet(id, rows, label) {
+    const loud = rows.filter(r => !r.quiet).map(r => r.html).join("");
+    const quiet = rows.filter(r => r.quiet);
+    if (!quiet.length) return loud;
+    return loud
+      + `<button type="button" class="dh-fold" data-fold="${id}"`
+      + ` aria-expanded="false" aria-controls="dh-fold-${id}">`
+      + `<i></i>${escapeHtml(label(quiet.length))}</button>`
+      + `<div class="dh-foldbody" id="dh-fold-${id}" hidden>`
+      + quiet.map(r => r.html).join("")
+      + `</div>`;
+  }
+
   // 逐项里的一组：沿用这张牌已有的 .dh-row 五列语法（名/位置/条/说明/状态），
   // 灯放进 .dh-bar 那一列——说明列现在印的是那一句「为什么」，不是裸时刻表。
   function cronScheduleRows(cs) {
     const jobs = (cs && cs.jobs) || [];
     if (!jobs.length) return "";
     const RANK = { needs_action: 0, known_not_fixed: 1, watch: 2 };
-    return `<div class="dh-sub">定时任务 · 今天每槽</div>` + jobs.map(j => {
+    const rows = jobs.map(j => {
       const slots = (j.slots || []).map(s => ({ ...s, state: cronState(s.state) }));
       const noted = slots.filter(s => s.note)
         .sort((a, b) => (RANK[a.note.disposition] ?? 9) - (RANK[b.note.disposition] ?? 9));
@@ -1298,13 +1316,16 @@
       }).join("");
       const rowTone = j.unmonitored ? "idle"
         : worst ? (worst.note.disposition === "needs_action" ? "bad" : "warn") : "ok";
-      return `<div class="dh-row is-cron" data-tone="${rowTone}">`
+      // 「按时」和「待跑」都是今天没事；「账本看不到」不是——那一行留在上面。
+      return { quiet: rowTone === "ok", html: `<div class="dh-row is-cron" data-tone="${rowTone}">`
         + `<span class="dh-name">${escapeHtml(j.job)}</span>`
         + `<span class="dh-file">${escapeHtml(slots.length > 1 ? `${slots.length} 槽` : slots[0] ? slots[0].at : "")}</span>`
         + `<span class="dh-bar is-lamps">${lamps}</span>`
         + `<span class="dh-detail">${escapeHtml(why)}</span>`
-        + `<span class="dh-state">${escapeHtml(state)}</span></div>`;
-    }).join("");
+        + `<span class="dh-state">${escapeHtml(state)}</span></div>` };
+    });
+    return `<div class="dh-sub">定时任务 · 今天每槽</div>`
+      + foldQuiet("cron", rows, count => `其余 ${count} 个 job 今天按时或待跑`);
   }
   function renderDataHealth() {
     const root = document.getElementById("data-health");
@@ -1548,38 +1569,45 @@
         : "";
 
       const unnamed = Math.max(0, droppedTotal - dropped.length);
+      // 微信掉投整族是「已拍板不修」的台账（#771），一条都不需要动手 ⇒ 整族
+      // 折起来，标题那行仍然说清楚是几档、谁兜的。
+      const deliveryLedger = dropped.map(r => ({ quiet: true,
+        html: `<div class="dh-row is-delivery">`
+          + `<span class="dh-name">${escapeHtml(r.job || "未具名任务")}</span>`
+          + `<span class="dh-file">${escapeHtml(String(r.slot || "").slice(0, 16).replace("T", " "))}</span>`
+          + `<span class="dh-bar"></span>`
+          + `<span class="dh-detail">微信 sendMessage ret=-2 prepare failed</span>`
+          + `<span class="dh-state">TG 已兜</span></div>` }));
+      // 名单有上限，超出的那几档必须说出来 —— 否则「掉投 9 档」配 8 行
+      // 会读成列全了。
+      if (unnamed) {
+        deliveryLedger.push({ quiet: true,
+          html: `<div class="dh-row is-delivery"><span class="dh-name muted">另有 ${unnamed} 档</span>`
+            + `<span class="dh-file"></span><span class="dh-bar"></span>`
+            + `<span class="dh-detail">更早的槽位见 workflow-outcomes.json</span>`
+            + `<span class="dh-state"></span></div>` });
+      }
       const deliveryRows = dropped.length
         ? `<div class="dh-sub">投递 · 微信掉投（上游 ret=-2，已知不修）</div>`
-          + dropped.map(r => `<div class="dh-row is-delivery">`
-            + `<span class="dh-name">${escapeHtml(r.job || "未具名任务")}</span>`
-            + `<span class="dh-file">${escapeHtml(String(r.slot || "").slice(0, 16).replace("T", " "))}</span>`
-            + `<span class="dh-bar"></span>`
-            + `<span class="dh-detail">微信 sendMessage ret=-2 prepare failed</span>`
-            + `<span class="dh-state">TG 已兜</span></div>`).join("")
-          // 名单有上限，超出的那几档必须说出来 —— 否则「掉投 9 档」配 8 行
-          // 会读成列全了。
-          + (unnamed
-            ? `<div class="dh-row is-delivery"><span class="dh-name muted">另有 ${unnamed} 档</span>`
-              + `<span class="dh-file"></span><span class="dh-bar"></span>`
-              + `<span class="dh-detail">更早的槽位见 workflow-outcomes.json</span>`
-              + `<span class="dh-state"></span></div>`
-            : "")
+          + foldQuiet("wechat", deliveryLedger, count => `${count} 档掉投的台账`)
         : "";
 
-      const fileRows = `<div class="dh-sub">数据面 · 逐项</div>` + files
+      const fileList = files
         .slice()
         .sort((a, b) => usage(b) - usage(a))
         .map(f => {
           const st = stateOf(f);
           const label = st === "missing" ? "缺失" : st === "late" ? "逾期" : "在期";
-          return `<div class="dh-row is-${st}">`
+          return { quiet: st === "ok", html: `<div class="dh-row is-${st}">`
             + `<span class="dh-name">${escapeHtml(dataFileCn(f.name))}</span>`
             + `<span class="dh-file">${escapeHtml(f.name)}</span>`
             + `<span class="dh-bar"><i style="width:${Math.round(usage(f) * 100)}%"></i></span>`
             + `<span class="dh-detail">${escapeHtml(detailOf(f))}</span>`
             + `<span class="dh-state">${label}</span>`
-            + `</div>`;
-        }).join("");
+            + `</div>` };
+        });
+      const fileRows = `<div class="dh-sub">数据面 · 逐项</div>`
+        + foldQuiet("files", fileList, count => `在期的 ${count} 个数据面`);
 
       // 体检以前在逐项里没有自己的一组：泳道只印得下最坏的那一条，WARN 的
       // 全文没有任何地方读得到（窄屏还会被折成三行英文）。展开它就是那张单子。
@@ -1604,6 +1632,10 @@
       // 一条泳道 = 一个展开器，明细就摊在它自己下面（组是泳道的兄弟节点，不是
       // 卡片底部的一坨）。整块「逐项」在手机上是 34 行 2600px，读者要的不是
       // 「全都展开」，是「点开我关心的那一条」。
+      // 刷新是每几分钟一次的事：读者刚点开的那一折不能被合回去。
+      const openFolds = [...document.querySelectorAll("#data-health .dh-fold")]
+        .filter(button => button.getAttribute("aria-expanded") === "true")
+        .map(button => button.dataset.fold);
       const fill = (key, html) => {
         const body = document.getElementById(`dh-group-${key}-body`);
         if (body) body.innerHTML = html;
@@ -1611,6 +1643,13 @@
       fill("files", fileRows);
       fill("integrity", integrityRows);
       fill("delivery", cronRows + deliveryRows);
+      openFolds.forEach(id => {
+        const button = document.querySelector(`#data-health .dh-fold[data-fold="${id}"]`);
+        const body = document.getElementById(`dh-fold-${id}`);
+        if (!button || !body) return;
+        button.setAttribute("aria-expanded", "true");
+        body.hidden = false;
+      });
       const todoEl = document.getElementById("dh-todo");
       if (todoEl) todoEl.innerHTML = todoRows;
       // 收起的组仍在 DOM 里（折叠是 grid-rows 0fr 的动画），首帧也必须把它退出
@@ -1632,6 +1671,20 @@
         syncDataHealthToggle();
       });
     });
+    // 折叠器是每次刷新重新写进 innerHTML 的，所以监听挂在卡片上（一次），
+    // 不挂在按钮上。
+    if (root.dataset.foldWired !== "1") {
+      root.dataset.foldWired = "1";
+      root.addEventListener("click", event => {
+        const button = event.target.closest(".dh-fold");
+        if (!button) return;
+        const body = document.getElementById(`dh-fold-${button.dataset.fold}`);
+        if (!body) return;
+        const open = button.getAttribute("aria-expanded") !== "true";
+        button.setAttribute("aria-expanded", open ? "true" : "false");
+        body.hidden = !open;
+      });
+    }
     const toggle = document.getElementById("dh-toggle");
     if (toggle && toggle.dataset.wired !== "1") {
       toggle.dataset.wired = "1";

--- a/tests/dashboard_tab_runtime.spec.js
+++ b/tests/dashboard_tab_runtime.spec.js
@@ -1339,11 +1339,19 @@ async function testCronRailAccountsForEverySlotWithoutASecondVerdict(browser, ba
     return rows.map(r => ({
       name: r.querySelector(".dh-name").textContent.trim(),
       detail: r.querySelector(".dh-detail").textContent.trim(),
+      folded: !!r.closest(".dh-foldbody"),
     }));
   });
-  assert.deepEqual(detail.map(r => r.name),
-    ["盘前深度简报", "盘中盯盘", "Memory Dreaming Promotion"],
+  assert.deepEqual(detail.map(r => r.name).slice().sort(),
+    ["Memory Dreaming Promotion", "盘中盯盘", "盘前深度简报"].sort(),
     `逐项 is missing the per-job timetable rows: ${detail.map(r => r.name).join(", ")}`);
+  // 顺序不再是 payload 的顺序：有事的（降级 / 账本看不到）排在前面且一直摊
+  // 开，今天按时的那些折进「其余 N 个」——展开一条泳道不该是一坨流水账。
+  assert.deepEqual(detail.filter(r => !r.folded).map(r => r.name),
+    ["盘中盯盘", "Memory Dreaming Promotion"],
+    `these rows should stay out of the fold: ${detail.filter(r => !r.folded).map(r => r.name).join(", ")}`);
+  assert.deepEqual(detail.filter(r => r.folded).map(r => r.name), ["盘前深度简报"],
+    `a job with nothing to do today should fold away: ${detail.filter(r => r.folded).map(r => r.name).join(", ")}`);
   // 逐项里印的是那句「为什么」，不是裸时刻表——读者不用去猜黄点是什么意思。
   const cronRow = detail.find(r => r.name === "盘中盯盘");
   assert.ok(cronRow && cronRow.detail.includes("仪表盘发布还在排队"),
@@ -1546,6 +1554,90 @@ async function testMoversSayWhichSessionTheyAreFrom(browser, base) {
 //  4. 说明行可以收成引子，但被收起来的那条泳道必须有一组明细接住全文；
 //  5. 逐项那一行的状态词必须和名字同一行（它曾被挤成右对齐的孤行）；
 //  6. 整块牌不横向溢出，处置牌不被顶出卡片，「逐项」有拇指够得着的高度。
+// 展开一条泳道之后，「今天没事」的那些行折起来。
+//
+// #1418 把每条泳道做成了自己的展开器，但展开之后仍然是一坨流水账：2026-09-09
+// 实测线上 390px，点开「投递」得到 1200px 的组，11 个 job 里 9 个写着「正常」，
+// 读者要滚到底才敢说今天没事。有事的那一条必须**不用再点一下**就看得见；没事
+// 的收进一个展开器，点开还是同一批行。
+async function testAQuietLaneFoldsItsLedgerInsteadOfScrolling(browser, base) {
+  const quietJobs = 11;
+  const context = await browser.newContext({
+    viewport: { width: 390, height: 844 }, isMobile: true, hasTouch: true,
+  });
+  const page = await context.newPage();
+  await stubLiveOrigin(page, {
+    patch: (name, json) => {
+      if (name !== "overview.json" && name !== "dashboard.json") return null;
+      const jobs = [{ job: "无 harness 的任务", unmonitored: true,
+                      slots: [{ at: "03:00", state: "ok" }] }];
+      for (let i = 0; i < quietJobs; i++) {
+        jobs.push({ job: `按时的任务 ${i + 1}`, slots: [{ at: "0" + (i % 10) + ":03", state: "ok" }] });
+      }
+      json.cron_schedule = { date: "2026-09-09", jobs };
+      return json;
+    },
+  });
+  await page.goto(base, { waitUntil: "networkidle" });
+  await waitForData(page);
+  await page.waitForSelector("#data-health:not(.is-pending)", { timeout: 5000 });
+
+  const folded = await page.evaluate(async () => {
+    document.getElementById("dh-lane-delivery").click();
+    await new Promise(resolve => setTimeout(resolve, 400));
+    const group = document.getElementById("dh-group-delivery");
+    const rows = [...group.querySelectorAll(".dh-row")];
+    const fold = group.querySelector('.dh-fold[data-fold="cron"]');
+    const body = document.getElementById("dh-fold-cron");
+    return {
+      height: Math.round(group.getBoundingClientRect().height),
+      shown: rows.filter(row => row.getBoundingClientRect().height > 0)
+        .map(row => row.querySelector(".dh-name").textContent.trim()),
+      foldText: fold ? fold.textContent.trim() : null,
+      foldTag: fold ? fold.tagName : null,
+      foldHeight: fold ? Math.round(fold.getBoundingClientRect().height) : 0,
+      expanded: fold ? fold.getAttribute("aria-expanded") : null,
+      controls: fold ? fold.getAttribute("aria-controls") : null,
+      hidden: body ? body.hidden : null,
+      buried: body ? body.querySelectorAll(".dh-row").length : 0,
+    };
+  });
+
+  assert(folded.foldTag === "BUTTON",
+    "the quiet rows are not behind a button — a fold you cannot tap is a fold that is not there");
+  assert.equal(folded.expanded, "false", "the quiet ledger starts open");
+  assert.equal(folded.hidden, true,
+    "the folded rows are still in the tab order and the accessibility tree");
+  assert.equal(folded.controls, "dh-fold-cron",
+    "the fold does not point at the panel it opens");
+  assert.equal(folded.buried, quietJobs,
+    `the fold hides ${folded.buried} rows, not the ${quietJobs} quiet ones`);
+  assert(folded.foldText.includes(String(quietJobs)),
+    `the fold does not say how many it is hiding: "${folded.foldText}"`);
+  assert(folded.foldHeight >= 40,
+    `the fold is ${folded.foldHeight}px tall — below a thumb-sized row`);
+  // 有事的那一条不进折叠：藏起来的待办和没有待办一样。
+  assert(folded.shown.includes("无 harness 的任务"),
+    `the job the ledger cannot see is not on screen without a second tap: ${folded.shown.join(", ")}`);
+  assert(folded.height <= 420,
+    `the expanded lane is ${folded.height}px on a 844px-tall phone — that is the ledger again`);
+
+  const opened = await page.evaluate(async () => {
+    document.querySelector('#dh-group-delivery .dh-fold[data-fold="cron"]').click();
+    await new Promise(resolve => setTimeout(resolve, 200));
+    const group = document.getElementById("dh-group-delivery");
+    return {
+      expanded: group.querySelector('.dh-fold[data-fold="cron"]').getAttribute("aria-expanded"),
+      shown: [...group.querySelectorAll(".dh-row")]
+        .filter(row => row.getBoundingClientRect().height > 0).length,
+    };
+  });
+  assert.equal(opened.expanded, "true", "tapping the fold did not open it");
+  assert(opened.shown >= quietJobs + 1,
+    `opening the fold showed ${opened.shown} rows, not the ${quietJobs + 1} the lane holds`);
+  await context.close();
+}
+
 async function testDataHealthIsReadableOnAPhone(browser, base) {
   const context = await browser.newContext({
     viewport: { width: 390, height: 844 }, isMobile: true, hasTouch: true,
@@ -1646,19 +1738,31 @@ async function testDataHealthIsReadableOnAPhone(browser, base) {
     "opening one lane expanded the others too — that is the 2600px 逐项 again");
 
   // 处置行（.is-todo）的末列是「下一步去哪看」，它本来就独占一行；台账行不是。
-  const orphans = await page.evaluate(async () => {
+  const rows = await page.evaluate(async () => {
     document.getElementById("dh-toggle").click();
     await new Promise(resolve => setTimeout(resolve, 400));
-    return [...document.querySelectorAll(".dh-group .dh-row:not(.is-todo)")]
-      .filter(row => {
-        const name = row.querySelector(".dh-name").getBoundingClientRect();
-        const state = row.querySelector(".dh-state").getBoundingClientRect();
-        return state.top >= name.bottom - 1;
-      })
-      .map(row => row.querySelector(".dh-name").textContent.trim());
+    // 这条断言问的是「一行的版式」，所以先把「今天没事」的那几折也打开——
+    // 折起来的行是 hidden，每个矩形都是 0，量它等于给自己发一张假红。数出
+    // 量了几行，免得这个过滤把断言悄悄变成一个什么都不测的测试。
+    document.querySelectorAll("#data-health .dh-fold").forEach(fold => fold.click());
+    await new Promise(resolve => setTimeout(resolve, 200));
+    const measurable = [...document.querySelectorAll(".dh-group .dh-row:not(.is-todo)")]
+      .filter(row => row.getBoundingClientRect().height > 0);
+    return {
+      measured: measurable.length,
+      orphans: measurable
+        .filter(row => {
+          const name = row.querySelector(".dh-name").getBoundingClientRect();
+          const state = row.querySelector(".dh-state").getBoundingClientRect();
+          return state.top >= name.bottom - 1;
+        })
+        .map(row => row.querySelector(".dh-name").textContent.trim()),
+    };
   });
-  assert.deepEqual(orphans, [],
-    `逐项 rows put the status word on a line of its own: ${orphans.join(", ")}`);
+  assert(rows.measured >= 3,
+    `only ${rows.measured} 逐项 row(s) were laid out — this assertion is measuring nothing`);
+  assert.deepEqual(rows.orphans, [],
+    `逐项 rows put the status word on a line of its own: ${rows.orphans.join(", ")}`);
   await context.close();
 }
 
@@ -1720,6 +1824,7 @@ async function main() {
     await testVerdictDeckFillsItsBoxAndRanksGatesBySeverity(browser, base);
     await testDataHealthNamesTheDegradedSlotAndWeChatDrops(browser, base);
     await testDataHealthIsReadableOnAPhone(browser, base);
+    await testAQuietLaneFoldsItsLedgerInsteadOfScrolling(browser, base);
     await testASidecarStillReachesItsCardWhenThePagerIsStillSettling(browser, base);
     await testAddSideCardExplainsWhyThereIsNoAdd(browser, base);
     await testAPanelSaysWhenItsDataDidNotLoad(browser, base);


### PR DESCRIPTION
kcn：「还有数据健康的重构」。前情：#1270（三泳道 + 处置牌）、#1418（一条泳道 = 一个展开器）。

## 病灶（实测，线上 390px）

#1418 把每条泳道做成了自己的展开器，**但展开之后仍然是一坨流水账**：点开「投递」得到 **1200px 的组**，11 个 job 里 9 个写着「正常」，1 个「账本看不到」的夹在中间。读者要滚到底才敢说今天没事，而唯一那条要看的被埋在里面。

⇒ **判据：一条泳道展开之后，屏幕上先出现的必须是「有事的那几条」。** 没事的台账收进一个展开器，点开还是同一批行，一个字不改。

## 终态

- `foldQuiet(id, rows, label)`：有事的排前面、一直摊开；没事的进 `<button class="dh-fold">` + `<div class="dh-foldbody" hidden>`。收起用 `hidden` —— 元素直接退出 Tab 与读屏，不需要再上 `inert`（泳道那层是 `0fr` 动画，元素还在，才需要）。
- 三处用上它：
  - **定时任务**：按时 / 待跑的折成「其余 N 个 job 今天按时或待跑」；**「账本看不到」不折**（它不是「没事」）。
  - **微信掉投**：整族台账折成「N 档掉投的台账」——#771 已拍板不修，一条都不用动手，标题那行已经说清是几档、谁兜的。
  - **数据面逐项**：在期的折成「在期的 N 个数据面」，逾期 / 缺失留在上面。
- 刷新（每几分钟一次）**不把读者刚点开的那一折合回去**。
- 监听挂在卡片上一次，不挂在按钮上——折叠器每次刷新都被重写进 `innerHTML`。

| | 之前 | 现在 |
|---|---|---|
| 390px 点开「投递」 | 1200px | **216px** |
| 390px 整张卡（投递展开） | 1682px | **699px** |
| 1280px 三条泳道全展开 | 1600+px | **758px** |
| 展开后第一眼看到的 | 第 2 条起才是有事的 | 有事的那一条 |

## 闸

- 新增 `testAQuietLaneFoldsItsLedgerInsteadOfScrolling`（390px，fixture = 11 个按时的 job + 1 个账本看不到的）：有事的那条**不点第二下**就要在屏幕上、折叠体必须 `hidden` 且正好藏住那 11 行、`aria-controls` 指对、折叠器 ≥40px 高、组高 **≤420px**（不折是 1100+）、点开要真的出来。
- `testCronRailAccountsForEverySlotWithoutASecondVerdict` 的行序断言改成新规则：有事的（降级 / 账本看不到）在前且不在折叠里，今天按时的那个在折叠里。
- `testDataHealthIsReadableOnAPhone` 的「状态词不许独占一行」先把折叠全打开再量，**并数出量了几行**——一个 `hidden` 元素的矩形全是 0，量它等于给自己发一张假红；而只把它们过滤掉，又会让这条断言在全都折起来的那天变成什么都不测（实测过滤后只剩 1 行）。

`renderDataHealth` 仍是 `hero.js` / `render.js` 手工双份，两份同改，`test_dashboard_bundle_parity` 绿。

本地：`dashboard_tab_runtime` 全绿（`verdict deck` 那条除外——它在 **master 上用同一份今日数据也红**：「-3px of dead air」，与本 PR 无关），pytest **3608 passed**。

https://claude.ai/code/session_01GABq2rC4WbpZWLF2h1S5Qd