### PR TITLE
dashboard: 辩论留痕改成一场一行，点开看全文

### DIFF
--- a/site/assets/css/dashboard.css
+++ b/site/assets/css/dashboard.css
@@ -1622,8 +1622,52 @@
     background: var(--card-2); border-left: 3px solid color-mix(in srgb, var(--accent) 50%, transparent);
   }
   .dbt-head {
-    display: flex; align-items: baseline; gap: 8px; flex-wrap: wrap; margin-bottom: 6px;
+    display: flex; align-items: baseline; gap: 8px; flex-wrap: wrap;
   }
+  /* 一场辩论 = 一行，点开看全文。30 场全文摊开在 390px 上是 8908px —— 一张
+     卡里十个屏幕的墙，没人从头读到尾。 */
+  .dbt-toggle {
+    display: flex; align-items: baseline; gap: 8px; flex-wrap: wrap; width: 100%;
+    background: none; border: 0; padding: 0; margin: 0; cursor: pointer;
+    color: inherit; font: inherit; text-align: left;
+  }
+  .dbt-toggle > i {
+    flex: 0 0 auto; width: 7px; height: 7px; border-right: 1.5px solid var(--text-dim);
+    border-bottom: 1.5px solid var(--text-dim); transform: rotate(-45deg);
+    transition: transform .16s ease; align-self: center;
+  }
+  .dbt-toggle[aria-expanded="true"] > i { transform: rotate(45deg); }
+  .dbt-toggle .dbt-head { flex: 0 1 auto; margin: 0; }
+  /* 摘要那半截只占一行：它是「这场辩论判了什么」的引子，不是判词全文
+     （全文在展开后的 Judge 那一行，一个字没删）。 */
+  .dbt-gist {
+    flex: 1 1 100%; min-width: 0; overflow: hidden; text-overflow: ellipsis;
+    white-space: nowrap; font-size: var(--fs-sm); color: var(--text-dim);
+  }
+  /* 展开之后引子就该让位：Judge 的全文就在下面两行处，留着摘要等于把同一
+     句话印两遍。 */
+  .dbt-toggle[aria-expanded="true"] .dbt-gist { display: none; }
+  .dbt-body { margin-top: 8px; }
+  .dbt-more {
+    display: flex; align-items: center; gap: 8px; width: 100%;
+    background: none; border: 0; padding: 8px 2px; margin: 0 0 8px; cursor: pointer;
+    color: var(--text-tertiary); text-align: left;
+    font: 600 var(--fs-xs)/1.35 var(--mono);
+  }
+  .dbt-more > i {
+    width: 7px; height: 7px; border-right: 1.5px solid currentColor;
+    border-bottom: 1.5px solid currentColor; transform: rotate(-45deg);
+    transition: transform .16s ease; flex: 0 0 auto; margin-left: 3px;
+  }
+  .dbt-more[aria-expanded="true"] > i { transform: rotate(45deg); }
+  .dbt-more:hover, .dbt-toggle:hover .dbt-gist { color: var(--text-secondary); }
+  .dbt-toggle:focus-visible, .dbt-more:focus-visible {
+    outline: 2px solid var(--accent); outline-offset: 3px;
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .dbt-toggle > i, .dbt-more > i { transition: none; }
+  }
+  @media (pointer: coarse) { .dbt-toggle { padding: 3px 0; } .dbt-more { padding: 11px 2px; } }
   .dbt-tk { font-weight: 700; font-family: var(--mono); font-size: var(--fs-md); }
   .dbt-side { display: flex; gap: 8px; align-items: flex-start; margin-top: 4px; }
   .dbt-lbl {

--- a/site/assets/js/dashboard.render.js
+++ b/site/assets/js/dashboard.render.js
@@ -3853,7 +3853,7 @@
       cut: "砍", trim_on_rebound: "反弹减", hold_and_watch: "持有观察",
       add_only_on_trigger: "触发才加", watch: "观察",
     };
-    document.getElementById("debate-body").innerHTML = rows.map(r => {
+    const cases = rows.map((r, index) => {
       const side = (label, cls, text) => text
         ? `<div class="dbt-side ${cls}"><span class="dbt-lbl">${label}</span>`
           + `<span class="dbt-text">${escLLM(text)}</span></div>`
@@ -3872,21 +3872,59 @@
       const frames = chips.length
         ? `<div class="dbt-frames">${chips.join("")}</div>` : "";
       const conf = r.confidence == null ? "" : ` · 置信 ${Math.round(r.confidence * 100)}%`;
+      // 摘要行印 Judge 的判词——那是这场辩论的结论。没有 Judge 的（早期几条）
+      // 退到被攻击的那条共识；两个都没有就不印，宁可空着也不拿多方陈述冒充
+      // 结论。全文一个字不改，都在下面的 .dbt-body 里。
+      const gist = r.judge ? `Judge：${r.judge}`
+        : r.attacked_consensus ? `攻击：${r.attacked_consensus}` : "";
       return `<div class="dbt-case">
-        <div class="dbt-head">
-          <span class="dbt-tk">${escLLM(r.ticker)}</span>
-          <span class="muted">${escLLM(r.date)} · ${escLLM(ACTION_ZH[r.action] || r.action)}${conf}</span>
-        </div>
+        <button type="button" class="dbt-toggle" aria-expanded="false"
+          aria-controls="dbt-case-${index}">
+          <i></i>
+          <span class="dbt-head">
+            <span class="dbt-tk">${escLLM(r.ticker)}</span>
+            <span class="muted">${escLLM(r.date)} · ${escLLM(ACTION_ZH[r.action] || r.action)}${conf}</span>
+          </span>
+          <span class="dbt-gist">${escLLM(gist)}</span>
+        </button>
+        <div class="dbt-body" id="dbt-case-${index}" hidden>
         ${side("多", "dbt-bull", r.bull)}
         ${side("空", "dbt-bear", r.bear)}
         ${line("被攻击的共识", r.attacked_consensus)}
         ${line("Judge", r.judge)}
         ${frames}
+        </div>
       </div>`;
-    }).join("");
+    });
+    // 30 场辩论全文摊开是 8908px（390px 实测），一张卡里十个屏幕的墙。一场
+    // 辩论是读者心里的一个单位 ⇒ 一场一行，点开看全文；最近 6 场排在外面，
+    // 更早的收进一个展开器（收起用 hidden，元素直接退出 Tab 与读屏）。
+    const HEAD = 6;
+    const tail = cases.length - HEAD;
+    document.getElementById("debate-body").innerHTML = cases.slice(0, HEAD).join("")
+      + (tail > 0
+        ? `<button type="button" class="dbt-more" aria-expanded="false"`
+          + ` aria-controls="dbt-more-body"><i></i>更早的 ${tail} 场辩论</button>`
+          + `<div class="dbt-morebody" id="dbt-more-body" hidden>`
+          + cases.slice(HEAD).join("") + `</div>`
+        : "");
     const total = rows.length;
     document.getElementById("debate-src").textContent =
       `最近 ${total} 条带辩论记录的决策（窗口上限 ${block.limit || total}）`;
+    // 监听挂在容器上一次：每次刷新都会把这些按钮重新写进 innerHTML。
+    const body = document.getElementById("debate-body");
+    if (body.dataset.wired !== "1") {
+      body.dataset.wired = "1";
+      body.addEventListener("click", event => {
+        const button = event.target.closest(".dbt-toggle, .dbt-more");
+        if (!button) return;
+        const panel = document.getElementById(button.getAttribute("aria-controls"));
+        if (!panel) return;
+        const open = button.getAttribute("aria-expanded") !== "true";
+        button.setAttribute("aria-expanded", open ? "true" : "false");
+        panel.hidden = !open;
+      });
+    }
   }
 
   function renderBearCases() {

--- a/tests/dashboard_tab_runtime.spec.js
+++ b/tests/dashboard_tab_runtime.spec.js
@@ -1773,6 +1773,114 @@ async function testDataHealthIsReadableOnAPhone(browser, base) {
 // 于是抓回来的 sidecar 从来没被写进 DATA。之后每次再进这个 tab 都走「什么都
 // 不缺」的快路径（sidecar 确实 ready 了），而那条路径也不写 DATA —— 于是那张
 // 卡在这一整个会话里都是空的，只有整页刷新能救。桌面宽度不复现（没有 pager）。
+// 辩论留痕：一场辩论一行，点开看全文。
+//
+// 2026-09-09 实测线上 390px：30 场辩论的全文一次全摊开 = **8908px** 的一块，
+// 自评卡整张 12287px（十四个屏幕）。一场辩论是读者心里的一个单位，所以摘要
+// 行印「谁 · 哪天 · 判了什么 · Judge 的一句话」，全文在展开后一个字不改。
+//
+// payload 是这个用例自己造的：`decision_audit.json` 不进仓库，CI 上根本没有
+// 这份文件，靠当日数据的断言在那里等于没跑。造的是**输入的形状**（多少场、
+// 每场多长），量的仍然是浏览器真排出来的高度与可达性。
+async function testTheDebateTrailIsAListOfCasesNotAWallOfText(browser, base) {
+  const total = 12, head = 6;
+  const long = "这一段是为了让每一场辩论在展开时确实很高而写的长文：" + "论据".repeat(60);
+  const rows = [];
+  for (let i = 0; i < total; i++) {
+    rows.push({
+      ticker: `T${1000 + i}`, date: "2026-09-0" + (i % 9 + 1), action: "hold_and_watch",
+      confidence: 0.5, bull: long, bear: long, attacked_consensus: long,
+      judge: `第 ${i + 1} 场的判词：` + long, frames: ["mean_reversion"],
+    });
+  }
+  const context = await browser.newContext({
+    viewport: { width: 390, height: 844 }, isMobile: true, hasTouch: true,
+  });
+  const page = await context.newPage();
+  await stubLiveOrigin(page);
+  // stubLiveOrigin 之后注册：playwright 后注册的路由先匹配，反过来的话这份
+  // 造出来的 payload 会被真实文件盖掉（实测：断言拿到的是当日的 30 场）。
+  await page.route("**/decision_audit.json*", route => route.fulfill({
+    status: 200,
+    headers: { "content-type": "application/json; charset=utf-8",
+               "access-control-allow-origin": "*" },
+    body: JSON.stringify({ debates: { rows, limit: total } }),
+  }));
+  await page.goto(base, { waitUntil: "networkidle" });
+  await waitForData(page);
+  await page.click('.tab-btn[data-tab="reflect"]');
+  await waitForTab(page, "reflect");
+  await page.waitForFunction(() => document.querySelectorAll(".dbt-case").length > 0,
+    null, { timeout: 15000 })
+    .catch(() => { throw new Error("the debate trail never rendered") });
+
+  const shape = await page.evaluate(() => {
+    const cases = [...document.querySelectorAll(".dbt-case")];
+    const block = document.getElementById("debate-body");
+    const more = document.querySelector(".dbt-more");
+    return {
+      cases: cases.length,
+      onScreen: cases.filter(c => c.getBoundingClientRect().height > 0).length,
+      openBodies: [...document.querySelectorAll(".dbt-body")]
+        .filter(body => !body.hidden).length,
+      rowHeights: cases.slice(0, 3).map(c => Math.round(c.getBoundingClientRect().height)),
+      blockHeight: Math.round(block.getBoundingClientRect().height),
+      toggles: document.querySelectorAll(".dbt-toggle").length,
+      gists: [...document.querySelectorAll(".dbt-gist")]
+        .map(g => g.textContent.trim()).filter(Boolean).length,
+      firstGist: (document.querySelector(".dbt-gist") || {}).textContent || "",
+      more: more ? more.textContent.trim() : null,
+      moreExpanded: more ? more.getAttribute("aria-expanded") : null,
+    };
+  });
+
+  assert.equal(shape.cases, total, `the trail rendered ${shape.cases} of ${total} debates`);
+  assert.equal(shape.onScreen, head,
+    `${shape.onScreen} debates are on screen before any tap — the newest ${head} are the list`);
+  assert.equal(shape.openBodies, 0, "a debate starts with its full text open");
+  assert.equal(shape.toggles, total, "a debate case is not a button you can open");
+  assert.equal(shape.gists, total,
+    "a collapsed case does not say what the debate concluded");
+  assert(shape.firstGist.startsWith("Judge"),
+    `the summary line must carry the Judge's verdict, got "${shape.firstGist.slice(0, 30)}"`);
+  assert(shape.rowHeights.every(h => h > 0 && h <= 110),
+    `a collapsed case is ${shape.rowHeights.join("/")}px tall — that is not one row`);
+  // 不折是 3000px 起（每场 250-420px）。这条断言是这次改动的全部理由。
+  assert(shape.blockHeight <= 900,
+    `the debate trail is ${shape.blockHeight}px on a phone — it is a wall again`);
+  assert(shape.more && shape.more.includes(String(total - head)),
+    `the tail does not say how many debates it is holding: ${shape.more}`);
+  assert.equal(shape.moreExpanded, "false", "the older debates start unfolded");
+
+  // 点一场，只开那一场；再点尾巴，其余的才出来。
+  const opened = await page.evaluate(async () => {
+    document.querySelector(".dbt-toggle").click();
+    await new Promise(resolve => setTimeout(resolve, 150));
+    const first = document.querySelector(".dbt-case");
+    return {
+      open: [...document.querySelectorAll(".dbt-body")].filter(b => !b.hidden).length,
+      expanded: first.querySelector(".dbt-toggle").getAttribute("aria-expanded"),
+      height: Math.round(first.getBoundingClientRect().height),
+      hasBull: !!first.querySelector(".dbt-bull .dbt-text"),
+      judgeInFull: (first.querySelector(".dbt-body") || {}).textContent.includes("第 1 场的判词"),
+    };
+  });
+  assert.equal(opened.open, 1, `tapping one case opened ${opened.open} of them`);
+  assert.equal(opened.expanded, "true", "the case did not report itself as open");
+  assert(opened.height > 150, `the opened case is only ${opened.height}px — nothing came out`);
+  assert(opened.hasBull && opened.judgeInFull,
+    "the opened case is missing the argument it was hiding");
+
+  const tail = await page.evaluate(async () => {
+    document.querySelector(".dbt-more").click();
+    await new Promise(resolve => setTimeout(resolve, 150));
+    return [...document.querySelectorAll(".dbt-case")]
+      .filter(c => c.getBoundingClientRect().height > 0).length;
+  });
+  assert.equal(tail, total, `opening the tail showed ${tail} of ${total} debates`);
+  await context.close();
+}
+
 async function testASidecarStillReachesItsCardWhenThePagerIsStillSettling(browser, base) {
   const context = await browser.newContext({
     viewport: { width: 390, height: 844 }, isMobile: true, hasTouch: true,
@@ -1826,6 +1934,7 @@ async function main() {
     await testDataHealthIsReadableOnAPhone(browser, base);
     await testAQuietLaneFoldsItsLedgerInsteadOfScrolling(browser, base);
     await testASidecarStillReachesItsCardWhenThePagerIsStillSettling(browser, base);
+    await testTheDebateTrailIsAListOfCasesNotAWallOfText(browser, base);
     await testAddSideCardExplainsWhyThereIsNoAdd(browser, base);
     await testAPanelSaysWhenItsDataDidNotLoad(browser, base);
     await testCronRailAccountsForEverySlotWithoutASecondVerdict(browser, base);


### PR DESCRIPTION
dashboard 优化 loop 第 1 轮。全站扫了一遍（六个 tab × 390/1280），最高的一处是这个。

## 病灶（线上实测）

| | 390px | 1280px |
|---|---|---|
| 「辩论留痕」那一块 | **8908px** | 5521px |
| 整张自评卡 | **12287px**（≈14 个屏幕） | 7946px |

30 场辩论的 Bull / Bear / 被攻击的共识 / Judge **全文一次全摊开**。没有人从头读到尾，而要找某一场只能滚。

## 终态：一场一行

- 摘要行 = 「票 · 日期 · 动作 · 置信」+ **Judge 的判词一行**（截断在一行）。没有 Judge 的（早期几条）退到「被攻击的共识」；两个都没有就不印——不拿多方陈述冒充结论。
- 全文**一个字不改**，收在展开后的 `.dbt-body`；收起用 `hidden`，元素直接退出 Tab 与读屏。
- 最近 6 场排在外面，更早的收进「更早的 N 场辩论」。
- 展开之后摘要让位（Judge 全文就在两行之下，留着等于同一句印两遍）。

| | 之前 | 现在 |
|---|---|---|
| 辩论块 390 / 1280 | 8908 / 5521 | **676 / 588** |
| 自评卡 390 / 1280 | 12287 / 7946 | **4045 / 3003** |
| 首屏能看见几场 | 1 场（其余靠滚） | 6 场的结论 |

## 闸

`testTheDebateTrailIsAListOfCasesNotAWallOfText`：外面只有 6 场、没有一场是展开的、每场都是可点的按钮、每场都说得出结论、折叠行 ≤110px、**整块 ≤900px**、尾巴要说出还压着几场；点一场只开一场且全文确实出来（`.dbt-bull` + Judge 全文），点尾巴其余的才出现。**撤掉修复它就红**（实测：`12 debates are on screen before any tap`）。

payload 是用例自己造的：`decision_audit.json` 不进仓库，**CI 上根本没有这份文件**，靠当日数据的断言在那里等于没跑。造的是*输入的形状*（12 场、每场很长），量的仍然是浏览器真排出来的高度与可达性。

一个测量上的坑记在注释里：`page.route` **后注册的先匹配**，把造的 payload 挂在 `stubLiveOrigin` 之前会被真实文件盖掉（实测断言拿到的是当日那 30 场）。

本地：`dashboard_tab_runtime` 全绿（`verdict deck` 那条除外——**master 上用同一份数据也红**，且只在机器有负载时红，是量测时机的问题，另记），pytest **3608 passed**。

https://claude.ai/code/session_01GABq2rC4WbpZWLF2h1S5Qd