### PR TITLE
dashboard: Plan Timeline 的理由夹成两行，更早的收起来

### DIFF
--- a/site/assets/css/dashboard.css
+++ b/site/assets/css/dashboard.css
@@ -1648,26 +1648,26 @@
      句话印两遍。 */
   .dbt-toggle[aria-expanded="true"] .dbt-gist { display: none; }
   .dbt-body { margin-top: 8px; }
-  .dbt-more {
+  .dbt-more, .pt-fold {
     display: flex; align-items: center; gap: 8px; width: 100%;
     background: none; border: 0; padding: 8px 2px; margin: 0 0 8px; cursor: pointer;
     color: var(--text-tertiary); text-align: left;
     font: 600 var(--fs-xs)/1.35 var(--mono);
   }
-  .dbt-more > i {
+  .dbt-more > i, .pt-fold > i {
     width: 7px; height: 7px; border-right: 1.5px solid currentColor;
     border-bottom: 1.5px solid currentColor; transform: rotate(-45deg);
     transition: transform .16s ease; flex: 0 0 auto; margin-left: 3px;
   }
-  .dbt-more[aria-expanded="true"] > i { transform: rotate(45deg); }
-  .dbt-more:hover, .dbt-toggle:hover .dbt-gist { color: var(--text-secondary); }
-  .dbt-toggle:focus-visible, .dbt-more:focus-visible {
+  .dbt-more[aria-expanded="true"] > i, .pt-fold[aria-expanded="true"] > i { transform: rotate(45deg); }
+  .dbt-more:hover, .pt-fold:hover, .dbt-toggle:hover .dbt-gist { color: var(--text-secondary); }
+  .dbt-toggle:focus-visible, .dbt-more:focus-visible, .pt-fold:focus-visible {
     outline: 2px solid var(--accent); outline-offset: 3px;
   }
   @media (prefers-reduced-motion: reduce) {
-    .dbt-toggle > i, .dbt-more > i { transition: none; }
+    .dbt-toggle > i, .dbt-more > i, .pt-fold > i { transition: none; }
   }
-  @media (pointer: coarse) { .dbt-toggle { padding: 3px 0; } .dbt-more { padding: 11px 2px; } }
+  @media (pointer: coarse) { .dbt-toggle { padding: 3px 0; } .dbt-more, .pt-fold { padding: 11px 2px; } }
   .dbt-tk { font-weight: 700; font-family: var(--mono); font-size: var(--fs-md); }
   .dbt-side { display: flex; gap: 8px; align-items: flex-start; margin-top: 4px; }
   .dbt-lbl {
@@ -1866,6 +1866,19 @@
     line-height: 1.5;
     overflow-wrap: anywhere;
   }
+  /* 理由默认夹两行：15 条决策的理由全文摊开在 390px 上是 4515px，一张卡
+     五个屏幕。第一行往往就是那句话的要点，所以夹而不是藏。 */
+  .pt-row .pt-rationale.is-clamped {
+    display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+  .pt-expand {
+    background: none; border: 0; padding: 4px 0; margin: 0; cursor: pointer;
+    color: var(--text-tertiary); font: 600 var(--fs-micro)/1.3 var(--mono);
+  }
+  .pt-expand:hover { color: var(--text-secondary); }
+  .pt-expand:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+  @media (pointer: coarse) { .pt-expand { padding: 9px 0; } }
   .pt-row .pt-side { display: flex; flex-direction: column; align-items: flex-end; gap: 4px; }
   .pt-row .pt-conf {
     font-size: var(--fs-xs); padding: 2px 8px; border-radius: 999px;

--- a/site/assets/js/dashboard.render.js
+++ b/site/assets/js/dashboard.render.js
@@ -4394,13 +4394,25 @@
       const s = p >= 0 ? "+" : "";
       return `<div class="pt-pnl ${cls}" title="对下一个快照报价的方向分：正值表示这条建议的方向对了。报价时点不稳定，不等于 T+1 收益">方向分 ${s}${p.toFixed(2)}%</div>`;
     };
-    wrap.innerHTML = list.map(a => {
+    const cards = list.map((a, index) => {
       const oc = a.outcome || "pending";
       const followed = (a.execution || "unknown").toLowerCase();
       const c = a.condition || {};
       const trig = `${c.type || ""}${fmtTriggerPrice(c.price)}${fmtSize(a)}`;
       const cond = c.note ? `<div class="pt-trigger" title="${escapeHtml(c.note)}">${escapeHtml(c.note)}</div>` : "";
-      const rationale = a.rationale ? `<div class="pt-rationale">${escapeHtml(a.rationale)}</div>` : "";
+      // 理由是这张卡最长的一段（实测 390px：一条 209-369px，15 条 = 4515px）。
+      // 默认夹成两行，长到会被夹住的才给一个展开器 —— 短理由配一个什么都不
+      // 展开的按钮是噪音。阈值按字数不按版式：量版式要等面板排完，而这块牌
+      // 是 tab 激活时才排的，那之前量出来是 0。
+      const long = String(a.rationale || "").length > 120;
+      const rationale = a.rationale
+        ? `<div class="pt-rationale${long ? " is-clamped" : ""}" id="pt-why-${index}">`
+          + `${escapeHtml(a.rationale)}</div>`
+          + (long
+            ? `<button type="button" class="pt-expand" aria-expanded="false"`
+              + ` aria-controls="pt-why-${index}">展开理由</button>`
+            : "")
+        : "";
       const region = /^\d/.test(a.ticker) ? "HK" : "US";
       const followedTag = followed === "true"
         ? `<div class="pt-followed-true">✓ followed</div>`
@@ -4427,7 +4439,34 @@
             ${fmtPnl(a.benefit_t1_pct)}
           </div>
         </div>`;
-    }).join("");
+    });
+    // 15 条全文摊开在 390px 上是 4515px。最近 6 条排在外面，更早的收进一个
+    // 展开器（收起用 hidden，元素直接退出 Tab 与读屏）。
+    const HEAD = 6;
+    const tail = cards.length - HEAD;
+    wrap.innerHTML = cards.slice(0, HEAD).join("")
+      + (tail > 0
+        ? `<button type="button" class="pt-fold" aria-expanded="false"`
+          + ` aria-controls="pt-older"><i></i>更早的 ${tail} 条</button>`
+          + `<div id="pt-older" hidden>${cards.slice(HEAD).join("")}</div>`
+        : "");
+    // 监听挂在容器上一次：每次刷新都会把这些按钮重新写进 innerHTML。
+    if (wrap.dataset.wired !== "1") {
+      wrap.dataset.wired = "1";
+      wrap.addEventListener("click", event => {
+        const button = event.target.closest(".pt-expand, .pt-fold");
+        if (!button) return;
+        const target = document.getElementById(button.getAttribute("aria-controls"));
+        if (!target) return;
+        const open = button.getAttribute("aria-expanded") !== "true";
+        button.setAttribute("aria-expanded", open ? "true" : "false");
+        if (button.classList.contains("pt-fold")) target.hidden = !open;
+        else {
+          target.classList.toggle("is-clamped", !open);
+          button.textContent = open ? "收起理由" : "展开理由";
+        }
+      });
+    }
   }
 
   // =========================================================

--- a/tests/dashboard_tab_runtime.spec.js
+++ b/tests/dashboard_tab_runtime.spec.js
@@ -1782,6 +1782,110 @@ async function testDataHealthIsReadableOnAPhone(browser, base) {
 // payload 是这个用例自己造的：`decision_audit.json` 不进仓库，CI 上根本没有
 // 这份文件，靠当日数据的断言在那里等于没跑。造的是**输入的形状**（多少场、
 // 每场多长），量的仍然是浏览器真排出来的高度与可达性。
+// Plan Timeline：先扫得动，再读得下去。
+//
+// 2026-09-09 实测线上 390px：15 条决策卡把 rationale 全文一次全摊开 =
+// **4615px**（一条 209-369px），一张卡五个屏幕。理由的第一行往往就是那句话的
+// 要点，所以是**夹**（两行 + 展开）而不是藏；卡的尾巴照例折起来。
+async function testThePlanTimelineClampsItsRationales(browser, base) {
+  const total = 15, head = 6;
+  const long = "这条是为了让理由确实超过两行而写的长文：" + "因为".repeat(120);
+  const plan = [];
+  for (let i = 0; i < total; i++) {
+    plan.push({
+      date: "2026-09-0" + (i % 9 + 1), ticker: `T${1000 + i}`, action: "hold_and_watch",
+      strategy_id: "core_position", condition: { type: "manual" }, confidence: 0.5,
+      outcome: "pending", execution: "unknown",
+      // 最后一条故意是短理由：短理由不该配一个什么都不展开的按钮。
+      rationale: i === total - 1 ? "一句话就说完了。" : `第 ${i + 1} 条：${long}`,
+    });
+  }
+  const context = await browser.newContext({
+    viewport: { width: 390, height: 844 }, isMobile: true, hasTouch: true,
+  });
+  const page = await context.newPage();
+  await stubLiveOrigin(page, {
+    patch: (name, json) => {
+      if (name !== "dashboard.json") return null;
+      json.plan_timeline = plan;
+      return json;
+    },
+  });
+  await page.goto(base, { waitUntil: "networkidle" });
+  await waitForData(page);
+  await page.click('.tab-btn[data-tab="plan"]');
+  await waitForTab(page, "plan");
+  await page.waitForFunction(() => document.querySelectorAll("#plan-timeline .pt-row").length > 0,
+    null, { timeout: 15000 })
+    .catch(() => { throw new Error("the plan timeline never rendered") });
+
+  const shape = await page.evaluate(() => {
+    const wrap = document.getElementById("plan-timeline");
+    const rows = [...wrap.querySelectorAll(".pt-row")];
+    const fold = wrap.querySelector(".pt-fold");
+    const clamped = [...wrap.querySelectorAll(".pt-rationale.is-clamped")];
+    return {
+      rows: rows.length,
+      onScreen: rows.filter(row => row.getBoundingClientRect().height > 0).length,
+      cardHeight: Math.round(wrap.closest(".card").getBoundingClientRect().height),
+      rowHeights: rows.slice(0, 4).map(r => Math.round(r.getBoundingClientRect().height)),
+      clamped: clamped.length,
+      // 夹住的那一段必须真的比它显示出来的高——否则 is-clamped 只是个类名。
+      trulyClipped: clamped.filter(el => el.scrollHeight > el.clientHeight + 4).length,
+      expands: wrap.querySelectorAll(".pt-expand").length,
+      controls: [...wrap.querySelectorAll(".pt-expand")]
+        .filter(b => document.getElementById(b.getAttribute("aria-controls"))).length,
+      fold: fold ? fold.textContent.trim() : null,
+    };
+  });
+  assert.equal(shape.rows, total, `the timeline rendered ${shape.rows} of ${total} actions`);
+  assert.equal(shape.onScreen, head,
+    `${shape.onScreen} actions are on screen before any tap — the newest ${head} are the list`);
+  assert.equal(shape.clamped, total - 1,
+    `${shape.clamped} rationales are clamped; the short one must not be`);
+  assert.equal(shape.expands, total - 1,
+    "a short rationale was given an expander that opens nothing");
+  assert.equal(shape.controls, shape.expands,
+    "an expander does not point at the rationale it opens");
+  assert(shape.trulyClipped >= 3,
+    `only ${shape.trulyClipped} clamped rationales are actually cut off — `
+    + "is-clamped is decorating text that already fits");
+  assert(shape.rowHeights.every(h => h > 0 && h <= 260),
+    `a clamped row is ${shape.rowHeights.join("/")}px tall`);
+  // 不夹不折是 4600px 起。这条断言是这次改动的全部理由。
+  assert(shape.cardHeight <= 1600,
+    `the plan timeline is ${shape.cardHeight}px on a phone — five screens of one card`);
+  assert(shape.fold && shape.fold.includes(String(total - head)),
+    `the tail does not say how many actions it is holding: ${shape.fold}`);
+
+  const opened = await page.evaluate(async () => {
+    const wrap = document.getElementById("plan-timeline");
+    wrap.querySelector(".pt-expand").click();
+    await new Promise(resolve => setTimeout(resolve, 150));
+    const first = wrap.querySelector(".pt-rationale");
+    return {
+      clampedLeft: wrap.querySelectorAll(".pt-rationale.is-clamped").length,
+      label: wrap.querySelector(".pt-expand").textContent.trim(),
+      expanded: wrap.querySelector(".pt-expand").getAttribute("aria-expanded"),
+      grew: first.scrollHeight <= first.clientHeight + 4,
+    };
+  });
+  assert.equal(opened.clampedLeft, total - 2, "expanding one rationale unclamped the others");
+  assert.equal(opened.expanded, "true", "the expander did not report itself as open");
+  assert(opened.grew, "the rationale is still cut off after being expanded");
+  assert(opened.label.includes("收起"),
+    `the expander still says "${opened.label}" after opening`);
+
+  const tail = await page.evaluate(async () => {
+    document.querySelector("#plan-timeline .pt-fold").click();
+    await new Promise(resolve => setTimeout(resolve, 150));
+    return [...document.querySelectorAll("#plan-timeline .pt-row")]
+      .filter(row => row.getBoundingClientRect().height > 0).length;
+  });
+  assert.equal(tail, total, `opening the tail showed ${tail} of ${total} actions`);
+  await context.close();
+}
+
 async function testTheDebateTrailIsAListOfCasesNotAWallOfText(browser, base) {
   const total = 12, head = 6;
   const long = "这一段是为了让每一场辩论在展开时确实很高而写的长文：" + "论据".repeat(60);
@@ -1935,6 +2039,7 @@ async function main() {
     await testAQuietLaneFoldsItsLedgerInsteadOfScrolling(browser, base);
     await testASidecarStillReachesItsCardWhenThePagerIsStillSettling(browser, base);
     await testTheDebateTrailIsAListOfCasesNotAWallOfText(browser, base);
+    await testThePlanTimelineClampsItsRationales(browser, base);
     await testAddSideCardExplainsWhyThereIsNoAdd(browser, base);
     await testAPanelSaysWhenItsDataDidNotLoad(browser, base);
     await testCronRailAccountsForEverySlotWithoutASecondVerdict(browser, base);


### PR DESCRIPTION
dashboard 优化 loop 第 2 轮。重新扫了一遍（六个 tab × 390/1280 量 `.card` 高度），#1423 之后最高的一张是这个。

## 病灶（线上实测）

| | 390px | 1280px |
|---|---|---|
| Plan Timeline 整卡 | **4615px**（≈5 个屏幕） | 1472px |
| 单条决策卡 | 209–369px | 130px |

15 条决策把 `rationale` 全文一次全摊开。要看「今天做了什么」得滚过五屏的理由。

## 终态

- **理由夹两行**（`-webkit-line-clamp: 2`）+ 「展开理由 / 收起理由」。第一行往往就是那句话的要点，所以是**夹**不是藏。
- **长到会被夹住的才给展开器**。阈值按**字数**不按版式：量版式要等面板排完，而这块牌是 tab 激活时才排的，那之前量出来是 0。短理由不配一个什么都不展开的按钮。
- 尾巴照例折起来：最近 6 条在外面，更早的 9 条进「更早的 9 条」，收起用 `hidden`（元素直接退出 Tab 与读屏）。
- 折叠器样式与 #1423 的辩论留痕共用一套（`.dbt-more, .pt-fold`），不发明第二种外观。

| | 之前 | 现在 |
|---|---|---|
| 整卡 390 / 1280 | 4615 / 1472 | **1327 / 531** |
| 单条 390 / 1280 | 209–369 / 130 | **188 / 130** |
| 首屏能看见几条决策 | 2–3 条 | 6 条（都带一行理由引子） |

## 闸

`testThePlanTimelineClampsItsRationales`，fixture 15 条、最后一条**故意是短理由**：外面只有 6 条、14 条被夹住而短的那条没有、每个展开器都指得到它要展开的那段、**被夹住的那段必须真的比显示出来的高**（`scrollHeight > clientHeight`——否则 `is-clamped` 只是个类名，一条永远绿的断言）、单条 ≤260px、整卡 **≤1600px**、尾巴要说出还压着几条；点一个只展开一个且**真的不再被切**，点尾巴其余的才出现。**撤掉修复它就红**（实测：`15 actions are on screen before any tap`）。

本地：`dashboard_tab_runtime` 全绿（`verdict deck` 那条除外——master 上用同一份数据也红，只在机器有负载时红，是量测时机的问题），pytest **3608 passed**。

https://claude.ai/code/session_01GABq2rC4WbpZWLF2h1S5Qd