### PR TITLE
tests: 板块暴露断言别再点名今天持有谁（master 红了 18 小时）

### DIFF
--- a/tests/test_instrument_registry.py
+++ b/tests/test_instrument_registry.py
@@ -123,9 +123,18 @@ def test_live_dashboard_exposure_has_no_other_and_matches_risk_leverage():
     portfolio = _portfolio()
     sectors = build_dashboard.compute_sector_exposure(portfolio)
     assert all(row["sector"] != "Other" for leg in sectors.values() for row in leg)
-    assert {"SPCX", "SPCH", "SKHY"} <= {
-        ticker for row in sectors["us"] for ticker in row["tickers"]
-    }
+    # Naming today's holdings here made the test a timebomb: SKHY was pinned by
+    # name and went red the morning after it was closed, with no code change.
+    # `compute_sector_exposure` swallows exceptions and returns the legs it got
+    # through, so the property worth pinning is that every active holding came
+    # out the other side — that still fails closed on a partial result, and it
+    # keeps holding whoever the book holds.
+    for leg, bucket in (("us", "us_stocks"), ("hk", "hk_stocks")):
+        assert {ticker for row in sectors[leg] for ticker in row["tickers"]} == {
+            h["ticker"]
+            for h in portfolio["portfolios"][bucket]["holdings"]
+            if h.get("shares", 0) > 0
+        }
 
     leveraged = build_dashboard.compute_leveraged_etf_exposure(portfolio, fx_rate=7.84)
     # us_pct is a share of live market value, so pinning today's quote (it was


### PR DESCRIPTION
## 症状

master 的 `validate` 从 2026-09-09T19:20Z 起**连红五次、约 18 小时**，无人发现：

| run | 提交 | 性质 |
|---|---|---|
| 34394458108 | `455aba24 memory: dreaming 促进自动提交` | 纯数据 |
| 34398972972 | `b5d19d01 portfolio: 美股收盘价格更新` | 纯数据 |
| 34420097166 | `6eb6fc52 memory: daily deep brief` | 纯数据 |
| 34426024710 | `70394cc4 portfolio: 港股开盘价格更新` | 纯数据 |
| 34435789236 | `58a2c373 portfolio: 港股午盘价格更新` | 纯数据 |

```
FAILED tests/test_instrument_registry.py::test_live_dashboard_exposure_has_no_other_and_matches_risk_leverage
  assert {'SKHY', 'SPCH', 'SPCX'} <= {'CRCL', 'RKL...SPCH', 'SPCX'}
  Extra items in the left set: 'SKHY'
```

## 真因

断言把**今天的持仓代码**写死了。SKHY 在 09-09 已 197.35 清仓（`4aa15d06`），
`shares: 0` ⇒ 不再进 `compute_sector_exposure` 的 active 过滤 ⇒ 清仓当晚测试自己红。
代码一行没改。

同一个测试的下半部分在 2026-08 已经学过这课（*"pinning today's quote goes red at
the next close for no reason. Pin the derivation instead"*），上半部分没跟着改。

## 改法

`compute_sector_exposure` 吞异常并返回它走通的那几条腿，所以这里值得钉的性质是
**「每个活跃持仓都从另一头出来了」**——部分结果照样红，而且书里持有谁它就跟到谁。

## 判别力：比旧断言强，不是弱

旧断言只看 `us` 腿。把 hk 腿整条静默丢掉（`current_value` 归零 ⇒ `total_value<=0`
走 `continue`，正是 fail-open 的真实形状）：

- 旧断言 `{"SPCX","SPCH"} <= us_tickers` → **仍然绿**
- 新断言 → **点名 hk 腿**

已实测（见 commit body）。

## 验证

`tests/test_instrument_registry.py` 10 passed、`tests/test_build_dashboard.py` 90 passed。
全量走本 PR 的 `validate`。

https://claude.ai/code/session_01RC61NsgyH4o1xZAyBY2spw