### PR TITLE
ops: master 自己是红的，这件事没有读者

### DIFF
--- a/.github/workflows/cron-health.yml
+++ b/.github/workflows/cron-health.yml
@@ -117,6 +117,33 @@ jobs:
         if: always()
         run: python3 ops/ci/schedule_punctuality.py --strict
 
+      # Nothing was reading master's OWN CI conclusion. On 2026-09-09
+      # `validate` went red at 19:20Z and stayed red through five consecutive
+      # master pushes over eighteen hours — all pure data commits, no code
+      # changed (#1425). Every other watcher is structurally blind to it:
+      # `workflow_health.py` below filters to `event == "schedule"`, so
+      # `ci.yml`'s master pushes are outside it by construction; the host's
+      # `system_check` knows only the local workspace; and a PR opened against
+      # a red master goes red too, which its author reads as their own diff —
+      # PR #1418 needed a `git bisect` to disprove exactly that.
+      #
+      # `system_check` now reads the same module from the live checkout, so a
+      # red is visible within minutes there. This step is the other half: once
+      # a day, the question is asked whether or not anybody pushed.
+      #
+      # `--strict` reddens only a DETERMINED red, exactly like the backstop
+      # rehearsal above: an unreachable `gh`, a rate limit, or a newest run
+      # still in progress all exit 0. A gate that reddened on a network hiccup
+      # would be one more line its reader learns to skip.
+      - name: Is master itself red?
+        # `always()` for the same reason as the steps above: the health check
+        # exits non-zero on any miss, which would skip this on the days it
+        # matters most.
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: python3 ops/ci/master_ci_state.py --strict
+
       - name: Fold Actions-side failures into the daily summary
         # cron_health_check only sees host-side products; a scheduled workflow
         # that fails (or stops firing) on the Actions side was previously

--- a/ops/ci/master_ci_state.py
+++ b/ops/ci/master_ci_state.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""Is master itself red right now — and for how long?
+
+Nothing measured this until 2026-09-10, and it had already cost two incidents.
+`validate` went red on 09-09 at 19:20Z and stayed red through **five consecutive
+master pushes over eighteen hours**, every one of them a pure data commit with
+no code changed. The cause was a test naming today's holdings (#1425). The
+reason nobody saw it is that master's CI conclusion had no reader at all:
+
+  * `ops/system_check.py` says so in its own docstring — it "only knows the
+    local workspace";
+  * `ops/ci/workflow_health.py` filters to `event == "schedule"`, so `ci.yml`'s
+    master pushes are outside it by construction;
+  * `cron-health.yml` reads the day's git artefacts and heartbeats;
+  * a pull request *does* go red — and its author reads it as their own diff.
+    Not hypothetical: PR #1418 opened red on 09-09 and it took a `git bisect`
+    to prove the break came from a data commit.
+
+**A red master is a state, not an event.** The push that broke it is one line in
+one log nobody opens; "the last finished run on master failed" is still true on
+the next run, which is what makes it reportable at all.
+
+One module, two readers, so the two cannot drift into disagreeing about the same
+fact: `system_check` calls `read_state()` from the live checkout every time
+anything runs it, and `cron-health.yml` calls this file's CLI once a day so the
+day cannot pass without somebody having asked.
+
+`unknown` is not `red`. An unreachable `gh`, a rate limit, an unfinished newest
+run — none of those are evidence about master, and a check that reddened on them
+would train its reader to skip the line that matters. Same rule, and the same
+reason, as `backstop_rehearsal.py`.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+#: How many master runs to walk back looking for one that finished. The newest
+#: is often still in progress, and master's CI is path-filtered, so a data-only
+#: commit starts no run at all — ten is several days of code pushes on a quiet
+#: week and still one `gh` call.
+SCAN_LIMIT = 10
+#: Seconds before the lookup gives up. It also runs inside `pre-push`; a hung
+#: network must cost the push a moment, not the push.
+TIMEOUT = 8
+WORKFLOW = "ci.yml"
+BRANCH = "master"
+
+#: `system_check` runs inside `.githooks/pre-push`, once per push ATTEMPT, and
+#: `safe_push.sh` attempts up to three times — so an unconditional `gh` call
+#: (1.4s measured) is paid three times against a 9.3s budget that
+#: `test_system_check_reads_without_spawning` exists to defend. The run list is
+#: cached on disk for this long instead. Only the LIST is cached: the age and
+#: the stack on top are recomputed from local git every read, so a cache hit
+#: still reports the red getting older.
+CACHE_TTL = 300
+_CACHE = Path(tempfile.gettempdir()) / "clawock_master_ci_runs.json"
+
+
+@dataclass(frozen=True)
+class State:
+    """What the last *finished* run on master concluded, and what it cost."""
+
+    state: str  # 'green' | 'red' | 'unknown'
+    conclusion: str | None = None
+    sha: str | None = None
+    run_id: int | None = None
+    hours: float | None = None
+    stacked: int | None = None  # commits pushed on top of that sha since
+    reason: str | None = None  # only set when state == 'unknown'
+
+    @property
+    def short_sha(self) -> str:
+        return (self.sha or "")[:8]
+
+    def summary(self) -> str:
+        if self.state == "unknown":
+            return f"master CI state unknown: {self.reason or 'no reason given'}"
+        if self.state == "green":
+            return f"last finished run on master passed ({self.short_sha})"
+        parts = [f"{self.conclusion or 'unknown'} on {self.short_sha}"]
+        if self.hours is not None:
+            parts.append(f"{self.hours:.1f}h ago")
+        if self.stacked:
+            parts.append(f"{self.stacked} commit(s) pushed on top since")
+        return (", ".join(parts) + " — master is red and every PR opened "
+                f"against it inherits the red; run {self.run_id}")
+
+
+def _sh(argv, timeout=TIMEOUT):
+    return subprocess.run(argv, capture_output=True, text=True, timeout=timeout)
+
+
+def _cached_runs(now: float) -> list[dict] | None:
+    try:
+        blob = json.loads(_CACHE.read_text(encoding="utf-8"))
+        if now - float(blob["at"]) > CACHE_TTL:
+            return None
+        runs = blob["runs"]
+    except Exception:
+        return None
+    return runs if isinstance(runs, list) else None
+
+
+def _store_runs(runs: list[dict], now: float) -> None:
+    # Atomic, because three push attempts can be in flight at once and a
+    # half-written cache reads as `unknown` — which would be reported as
+    # silence, the one outcome this whole module exists to avoid.
+    try:
+        tmp = _CACHE.with_suffix(f".{os.getpid()}.tmp")
+        tmp.write_text(json.dumps({"at": now, "runs": runs}), encoding="utf-8")
+        tmp.replace(_CACHE)
+    except OSError:
+        pass
+
+
+def fetch_runs(runner=_sh, use_cache=True) -> list[dict] | None:
+    """Master's recent `ci.yml` runs, newest first. `None` means "could not ask"."""
+    now = time.time()
+    if use_cache:
+        cached = _cached_runs(now)
+        if cached is not None:
+            return cached
+    if not shutil.which("gh"):
+        return None
+    try:
+        proc = runner([
+            "gh", "run", "list", "--workflow", WORKFLOW, "--branch", BRANCH,
+            "--limit", str(SCAN_LIMIT), "--json",
+            "conclusion,status,databaseId,headSha,createdAt",
+        ])
+    except Exception:
+        return None
+    if getattr(proc, "returncode", 1) != 0:
+        return None
+    try:
+        runs = json.loads(proc.stdout or "[]")
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(runs, list):
+        return None
+    if use_cache:
+        _store_runs(runs, now)
+    return runs
+
+
+def _stacked_since(sha: str, runner=_sh) -> int | None:
+    """Commits pushed on top of `sha` since. The number that turns a stale red
+    into "and we kept building on it"."""
+    try:
+        proc = runner(["git", "rev-list", "--count", f"{sha}..origin/{BRANCH}"])
+        if proc.returncode != 0:
+            # A CI checkout has no `origin/master` ref for a master build; the
+            # local branch is the same tip there.
+            proc = runner(["git", "rev-list", "--count", f"{sha}..HEAD"])
+        if proc.returncode != 0:
+            return None
+        return int((proc.stdout or "0").strip() or 0)
+    except Exception:
+        return None
+
+
+def read_state(runs=None, runner=_sh, now=None, use_cache=True) -> State:
+    if runs is None:
+        runs = fetch_runs(runner=runner, use_cache=use_cache)
+    if runs is None:
+        return State("unknown", reason="gh could not be asked")
+    # Newest first. An unfinished run is not a verdict — walk to the first one
+    # that reached a conclusion.
+    finished = [r for r in runs if (r or {}).get("status") == "completed"]
+    if not finished:
+        return State("unknown", reason="no finished run on master in the last "
+                                       f"{SCAN_LIMIT}")
+    latest = finished[0]
+    sha = str(latest.get("headSha") or "")
+    conclusion = latest.get("conclusion")
+    run_id = latest.get("databaseId")
+    if conclusion == "success":
+        return State("green", conclusion=conclusion, sha=sha, run_id=run_id)
+    hours = None
+    try:
+        started = datetime.fromisoformat(
+            str(latest["createdAt"]).replace("Z", "+00:00"))
+        moment = now or datetime.now(timezone.utc)
+        hours = (moment - started).total_seconds() / 3600
+    except Exception:
+        pass
+    return State("red", conclusion=conclusion, sha=sha, run_id=run_id,
+                 hours=hours, stacked=_stacked_since(sha, runner=runner) if sha
+                 else None)
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--strict", action="store_true",
+        help="exit non-zero when master is DETERMINED red; `unknown` still "
+             "exits 0, because a gh hiccup is not evidence about master")
+    args = parser.parse_args(argv)
+
+    # The daily gate asks for itself. A cache is a pre-push economy, and this
+    # step runs once a day on a fresh runner where there is nothing to save.
+    state = read_state(use_cache=False)
+    line = state.summary()
+    print(line)
+    summary = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary:
+        icon = {"green": "✅", "red": "🔴", "unknown": "➖"}[state.state]
+        try:
+            with open(summary, "a", encoding="utf-8") as handle:
+                handle.write(f"\n### master CI\n\n{icon} {line}\n")
+        except OSError:
+            pass
+    return 1 if (args.strict and state.state == "red") else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ops/system_check.py
+++ b/ops/system_check.py
@@ -129,6 +129,7 @@ class Result:
 BACKLOG_WARN_COMMITS = 3
 BACKLOG_WARN_HOURS = 2.0
 
+
 #: How far back to look for a hop that cannot recover. Wide enough to survive a
 #: quiet stretch, short enough that a fixed hop stops being reported the same day.
 RUN_SCAN_LIMIT = 40
@@ -1072,6 +1073,44 @@ def _last_meaningful_line(path):
         tail = fh.read().decode('utf-8', 'replace')
     lines = [line.strip() for line in tail.splitlines() if line.strip()]
     return lines[-1] if lines else None
+
+
+
+def check_master_ci_conclusion(r):
+    """Is master itself red right now? (#1425 fallout.)
+
+    The fact, the incident it exists for, and why `unknown` is not `red` all
+    live in `ops/ci/master_ci_state`, which `cron-health.yml` reads once a day
+    through its CLI. One module, two readers, so the daily gate and this hook
+    cannot drift into disagreeing about the same fact.
+
+    What is local to this reader:
+
+    * **Only on master, only outside Actions.** A task branch has its own PR to
+      read, and judging the runs from inside one is circular.
+    * **WARN, never CRITICAL** — identical reasoning to `check_publish_backlog`
+      below: this runs inside `pre-push`, and a CRITICAL would refuse the very
+      push that carries the fix.
+    * **`unknown` is silence.** A dropped connection says nothing about master,
+      and a line that cried red on one would teach its reader to skip it.
+    """
+    if os.environ.get('GITHUB_ACTIONS'):
+        return
+    try:
+        branch = subprocess.run(
+            ['git', 'rev-parse', '--abbrev-ref', 'HEAD'],
+            capture_output=True, text=True, timeout=10)
+        if branch.returncode != 0 or branch.stdout.strip() != 'master':
+            return
+        sys.path.insert(0, str(_REPO_ROOT / 'ops' / 'ci'))
+        import master_ci_state  # noqa: PLC0415 - lazily, like cron_runs below
+        state = master_ci_state.read_state()
+    except Exception:
+        return
+    if state.state == 'green':
+        r.add('master CI', OK, state.summary())
+    elif state.state == 'red':
+        r.add('master CI', WARNING, state.summary())
 
 
 def check_publish_backlog(r):
@@ -2029,6 +2068,7 @@ def main():
         check_host_crontab_targets,
         check_host_cron_logs,
         check_publish_backlog,
+        check_master_ci_conclusion,
         check_delivered_but_unarchived,
         check_fallback_chain_shape,
         check_model_chain_health,

--- a/tests/test_master_ci_is_a_state.py
+++ b/tests/test_master_ci_is_a_state.py
@@ -1,0 +1,306 @@
+"""master's own CI conclusion had no reader (#1425 fallout).
+
+On 2026-09-09 `validate` went red at 19:20Z and stayed red across **five
+consecutive master pushes over eighteen hours**, every one of them a pure data
+commit. `system_check` knew only the local workspace, `workflow_health.py`
+filters to `event == "schedule"`, and the pull requests that did go red were
+read by their authors as their own diff. Nothing measured master itself.
+
+Everything here is driven through fakes, because the branches worth pinning are
+the ones only a bad day reaches — a red master, an unfinished newest run, an
+unreachable `gh`. A green live run exercises none of them, which is the same
+reason the incident lasted eighteen hours.
+"""
+import importlib.util
+import json
+import subprocess
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+# Bare, not `from ops.ci import …`: conftest puts `ops/ci` on the path and
+# `system_check` imports it by that name too, so this is the same module object
+# it will reach. Two copies would make every monkeypatch below a no-op.
+import master_ci_state as mcs
+
+ROOT = Path(__file__).resolve().parents[1]
+NOW = datetime(2026, 9, 10, 13, 20, tzinfo=timezone.utc)
+
+
+@pytest.fixture(scope="module")
+def system_check():
+    for path in (ROOT, ROOT / "src"):
+        if str(path) not in sys.path:
+            sys.path.insert(0, str(path))
+    spec = importlib.util.spec_from_file_location(
+        "kcnyu_system_check_master_ci", ROOT / "ops" / "system_check.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _run(conclusion, status="completed", sha="3a81d86b26ca", hours_ago=1.0,
+         run_id=34440620504):
+    started = NOW - timedelta(hours=hours_ago)
+    return {
+        "conclusion": conclusion,
+        "status": status,
+        "databaseId": run_id,
+        "headSha": sha,
+        "createdAt": started.isoformat().replace("+00:00", "Z"),
+    }
+
+
+def _runner(runs, gh_rc=0, stacked="0", raises=None, stdout=None):
+    """A fake `gh`/`git` answering only the questions the module asks."""
+
+    def run(argv, **kwargs):
+        if argv[:2] == ["gh", "run"]:
+            if raises is not None:
+                raise raises
+            body = json.dumps(runs) if stdout is None else stdout
+            return subprocess.CompletedProcess(argv, gh_rc, body, "")
+        if argv[:3] == ["git", "rev-list", "--count"]:
+            return subprocess.CompletedProcess(argv, 0, stacked + "\n", "")
+        raise AssertionError(f"unexpected command {argv}")
+
+    return run
+
+
+def _state(monkeypatch, runs, **kwargs):
+    monkeypatch.setattr(mcs.shutil, "which", lambda _: "/usr/bin/gh")
+    return mcs.read_state(runner=_runner(runs, **kwargs), now=NOW,
+                          use_cache=False)
+
+
+# ---------------------------------------------------------------- the fact
+
+
+def test_a_green_master_says_so(monkeypatch):
+    state = _state(monkeypatch, [_run("success")])
+    assert state.state == "green"
+    assert "3a81d86b" in state.summary()
+
+
+def test_the_incident_shape_carries_both_numbers(monkeypatch):
+    """2026-09-09/10, exactly. The hours and the stack are what turn "master is
+    red" into something somebody acts on."""
+    state = _state(monkeypatch, [_run("failure", sha="455aba24beef",
+                                      hours_ago=18.0)], stacked="5")
+    assert state.state == "red"
+    assert (state.hours, state.stacked) == (18.0, 5)
+    message = state.summary()
+    assert "failure" in message and "455aba24" in message
+    assert "18.0h ago" in message
+    assert "5 commit(s) pushed on top since" in message
+    assert "34440620504" in message
+
+
+def test_an_unfinished_newest_run_is_not_a_verdict(monkeypatch):
+    """master's newest run is usually still going; the answer is the one below
+    it, not `unknown` and not the unfinished one's absent conclusion."""
+    state = _state(monkeypatch, [
+        _run(None, status="in_progress", sha="ffffffffffff"),
+        _run("failure", sha="455aba24beef", hours_ago=3.0),
+    ], stacked="2")
+    assert (state.state, state.short_sha) == ("red", "455aba24")
+
+
+# ------------------------------------------------- `unknown` is not `red`
+
+
+@pytest.mark.parametrize("kwargs", [
+    {"gh_rc": 1},
+    {"raises": subprocess.TimeoutExpired("gh", 8)},
+    {"stdout": "not json at all"},
+])
+def test_an_unreachable_gh_is_unknown_not_red(monkeypatch, kwargs):
+    """A dropped connection, a rate limit and a garbled body are not evidence
+    about master. A verdict here would teach its readers to skip the line."""
+    assert _state(monkeypatch, [], **kwargs).state == "unknown"
+
+
+def test_nothing_finished_yet_is_unknown(monkeypatch):
+    assert _state(monkeypatch, [_run(None, status="in_progress")]).state == "unknown"
+
+
+def test_no_gh_binary_is_unknown(monkeypatch):
+    monkeypatch.setattr(mcs.shutil, "which", lambda _: None)
+    assert mcs.read_state(runner=_runner([]), now=NOW,
+                          use_cache=False).state == "unknown"
+
+
+# ------------------------------------------------------------- the cache
+
+
+def _counting_runner(runs, calls):
+    inner = _runner(runs)
+
+    def run(argv, **kwargs):
+        if argv[:2] == ["gh", "run"]:
+            calls.append(argv)
+        return inner(argv, **kwargs)
+
+    return run
+
+
+def test_three_push_attempts_pay_for_one_gh_call(monkeypatch, tmp_path):
+    """`safe_push.sh` attempts up to three times and each attempt is a fresh
+    process, so an in-process memo would buy nothing. Measured: the `gh` call is
+    1.4s against a 9.3s budget that `test_system_check_reads_without_spawning`
+    exists to defend."""
+    monkeypatch.setattr(mcs, "_CACHE", tmp_path / "runs.json")
+    monkeypatch.setattr(mcs.shutil, "which", lambda _: "/usr/bin/gh")
+    calls = []
+    runner = _counting_runner([_run("failure", hours_ago=18.0)], calls)
+    for _ in range(3):
+        assert mcs.read_state(runner=runner, now=NOW).state == "red"
+    assert len(calls) == 1
+
+
+def test_a_cache_hit_still_reports_the_red_getting_older(monkeypatch, tmp_path):
+    """Only the run LIST is cached. Age and the stack on top are recomputed from
+    local git, or a stale red would keep claiming the hour it was first seen."""
+    monkeypatch.setattr(mcs, "_CACHE", tmp_path / "runs.json")
+    monkeypatch.setattr(mcs.shutil, "which", lambda _: "/usr/bin/gh")
+    runner = _runner([_run("failure", hours_ago=1.0)], stacked="1")
+    assert mcs.read_state(runner=runner, now=NOW).hours == pytest.approx(1.0)
+    later = mcs.read_state(runner=_runner([], stacked="4"),
+                           now=NOW + timedelta(hours=4))
+    assert later.state == "red"
+    assert later.hours == pytest.approx(5.0)
+    assert later.stacked == 4
+
+
+def test_an_expired_cache_asks_again(monkeypatch, tmp_path):
+    monkeypatch.setattr(mcs, "_CACHE", tmp_path / "runs.json")
+    monkeypatch.setattr(mcs.shutil, "which", lambda _: "/usr/bin/gh")
+    calls = []
+    runner = _counting_runner([_run("success")], calls)
+    mcs.read_state(runner=runner, now=NOW)
+    real_time = mcs.time.time
+    monkeypatch.setattr(mcs.time, "time",
+                        lambda: real_time() + mcs.CACHE_TTL + 1)
+    mcs.read_state(runner=runner, now=NOW)
+    assert len(calls) == 2
+
+
+def test_a_corrupt_cache_is_not_a_verdict(monkeypatch, tmp_path):
+    """A half-written cache must read as "ask again", never as `unknown` — an
+    `unknown` is reported as silence, which is the outcome this module exists
+    to avoid."""
+    cache = tmp_path / "runs.json"
+    cache.write_text('{"at": 99999999999, "runs": ')
+    monkeypatch.setattr(mcs, "_CACHE", cache)
+    monkeypatch.setattr(mcs.shutil, "which", lambda _: "/usr/bin/gh")
+    assert mcs.read_state(runner=_runner([_run("success")]),
+                          now=NOW).state == "green"
+
+
+def test_the_daily_gate_does_not_read_the_hosts_cache(monkeypatch, tmp_path):
+    """The cache is a pre-push economy. The once-a-day ask is the whole point of
+    the daily gate; letting it answer from a saved list would make the day pass
+    without anybody having asked."""
+    seen = {}
+    monkeypatch.setattr(mcs, "read_state",
+                        lambda **kw: seen.update(kw) or mcs.State("green"))
+    mcs.main([])
+    assert seen == {"use_cache": False}
+
+
+# ------------------------------------------------------ reader 1: the CLI
+
+
+def test_strict_reddens_only_a_determined_red(monkeypatch, capsys):
+    monkeypatch.setattr(mcs, "read_state", lambda **kw: mcs.State("red", "failure"))
+    assert mcs.main(["--strict"]) == 1
+    monkeypatch.setattr(mcs, "read_state",
+                        lambda **kw: mcs.State("unknown", reason="gh down"))
+    assert mcs.main(["--strict"]) == 0
+    monkeypatch.setattr(mcs, "read_state", lambda **kw: mcs.State("green"))
+    assert mcs.main(["--strict"]) == 0
+
+
+def test_without_strict_it_only_reports(monkeypatch):
+    monkeypatch.setattr(mcs, "read_state", lambda **kw: mcs.State("red", "failure"))
+    assert mcs.main([]) == 0
+
+
+def test_the_daily_gate_actually_runs_it():
+    """A gate nobody wired in is the failure this whole change is about.
+
+    Parsed, not grepped: the step above it exits non-zero on any missed slot
+    (5 of its last 6 runs), so without `if: always()` this one is skipped on
+    exactly the days it matters — the same trap the two steps before it carry a
+    comment about."""
+    yaml = pytest.importorskip("yaml")
+    workflow = yaml.safe_load(
+        (ROOT / ".github" / "workflows" / "cron-health.yml").read_text())
+    steps = workflow["jobs"]["check"]["steps"]
+    gate = [s for s in steps if "master_ci_state.py" in (s.get("run") or "")]
+    assert len(gate) == 1, "the daily master-CI gate is not wired in"
+    assert "--strict" in gate[0]["run"]
+    assert gate[0].get("if") == "always()"
+    assert "GH_TOKEN" in (gate[0].get("env") or {})
+
+
+# --------------------------------------------- reader 2: the pre-push hook
+
+
+def _check(system_check, monkeypatch, state, branch="master"):
+    monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
+    monkeypatch.setattr(mcs, "read_state", lambda **kw: state)
+
+    def run(argv, **kwargs):
+        assert argv[:3] == ["git", "rev-parse", "--abbrev-ref"]
+        return subprocess.CompletedProcess(argv, 0, branch + "\n", "")
+
+    monkeypatch.setattr(subprocess, "run", run)
+    result = system_check.Result()
+    system_check.check_master_ci_conclusion(result)
+    return result.checks
+
+
+def test_the_hook_warns_on_red_and_never_blocks_the_fix(system_check, monkeypatch):
+    """CRITICAL would refuse the very push that turns master green — the same
+    reasoning that keeps `check_publish_backlog` at WARNING."""
+    state = mcs.State("red", "failure", sha="455aba24beef",
+                      run_id=1, hours=18.0, stacked=5)
+    (name, severity, message), = _check(system_check, monkeypatch, state)
+    assert (name, severity) == ("master CI", system_check.WARNING)
+    assert severity != system_check.CRITICAL
+    assert "18.0h ago" in message
+
+
+def test_the_hook_reports_green(system_check, monkeypatch):
+    (name, severity, _), = _check(system_check, monkeypatch,
+                                  mcs.State("green", sha="3a81d86b26ca"))
+    assert (name, severity) == ("master CI", system_check.OK)
+
+
+def test_the_hook_is_silent_on_unknown(system_check, monkeypatch):
+    assert _check(system_check, monkeypatch,
+                  mcs.State("unknown", reason="gh down")) == []
+
+
+def test_a_task_branch_judges_its_own_pr_not_master(system_check, monkeypatch):
+    assert _check(system_check, monkeypatch, mcs.State("red", "failure"),
+                  branch="claude/some-task") == []
+
+
+def test_inside_actions_the_hook_does_not_judge_its_own_runs(
+        system_check, monkeypatch):
+    monkeypatch.setenv("GITHUB_ACTIONS", "true")
+    monkeypatch.setattr(mcs, "read_state", lambda **kw: mcs.State("red", "failure"))
+    result = system_check.Result()
+    system_check.check_master_ci_conclusion(result)
+    assert result.checks == []
+
+
+def test_it_is_registered_in_the_check_list(system_check):
+    """A check nothing calls is a check nobody reads — the whole failure this
+    one exists for."""
+    body = (ROOT / "ops" / "system_check.py").read_text().split("def main(")[1]
+    assert "check_master_ci_conclusion," in body


### PR DESCRIPTION
接 #1425。那次红了 **18 小时、连续五次 master push** 都没人看见——这个 PR 修的是「没人看见」那一半。

## 为什么没有读者

| 谁 | 为什么看不到 |
|---|---|
| `ops/system_check.py` | 自己的 docstring 就写着 "only knows the local workspace"；隔壁 `check_publish_backlog` 读的是上次 fetch 留下的 `origin/master`，从不读 run |
| `ops/ci/workflow_health.py` | 过滤 `event == "schedule"`，`ci.yml` 的 master push 按构造在视野外 |
| `cron-health.yml` | 读当天的 git 产物和 heartbeat |
| PR 上的红 | **确实**会红——然后作者读成自己 diff 的锅。09-09 的 PR #1418 就是这样，靠 `git bisect` 才洗清 |

**红的 master 是 state，不是 event。** 把它弄红的那次 push 是某个没人打开的日志里的一行；「master 上最后一次跑完的 run 失败了」在下一次跑时仍然为真——这才是它可被报告的原因。跟 `check_publish_backlog` 同一条判据。

## 一个模块，两个读者

`ops/ci/master_ci_state.py` 是那个事实本身，免得两处对同一件事各说各话：

- **`system_check`** 从 live checkout 读它，任何东西调 system_check 都会报一次 ⇒ 红在几分钟内可见；
- **`cron-health.yml`** 每天调它的 CLI 一次（`--strict`）⇒ 没人 push 的那天也照样问一遍。

## 三条本地判据

- **`unknown` 不是 `red`。** gh 不可达、限流、JSON 坏了、最新那条还在跑——都不是关于 master 的证据。在这里报红等于教会读者跳过这一行。跟 `backstop_rehearsal.py --strict` 同一条规矩。
- **WARN，绝不 CRITICAL。** 它跑在 `pre-push` 里，CRITICAL 会拦住**带着修复的那次 push**。
- **两个数字都是推导来的。** 红了多久、之上又叠了几个 commit。「红了 18 小时、叠了 5 个」才是让人动起来的那半句。

## 缓存（`test_system_check_reads_without_spawning` 的预算）

`safe_push.sh` 最多三次尝试、每次一个新进程 ⇒ 进程内 memo 买不到东西。实测 gh 调用 **1.4s**，而那份契约守的预算是 **9.3s**。所以 run 列表落盘缓存 300s（原子替换，三次尝试可能同时在飞）：

- **只缓存列表**——年龄和叠加数每次从本地 git 重算，缓存命中时那条红仍然在变老（有闸）；
- 每天那次 gate 显式 `use_cache=False`——缓存是 pre-push 的经济学，而「今天有没有人问过」正是 gate 存在的理由（有闸）。

实测 cold 1.07s → warm 0.00s。

## 验证

- 撤掉修复各点名一次：去掉 step 的 `if: always()` → `test_the_daily_gate_actually_runs_it` 红；把 check 从 `main()` 的 list 删掉 → `test_it_is_registered_in_the_check_list` 红。
- 真 `gh` 端到端跑通：`last finished run on master passed (3a81d86b)`。
- 全量 **3630 passed**。

https://claude.ai/code/session_01RC61NsgyH4o1xZAyBY2spw