### PR TITLE
debate 引用：context 给了两个名字，模型抄了外面那个

### DIFF
--- a/skills/daily-deep-brief/SKILL.md
+++ b/skills/daily-deep-brief/SKILL.md
@@ -760,10 +760,12 @@ postflight 严格 schema 校验：
   - `frames`：`Judge — strategy frames` 表里为这条 action 选的 1–3 个 frame，逐字照抄枚举值。
   - `judge`：Judge 的合成判词一句话（不是 Bull/Bear 的复述）。
   - `evidence_ids`（≤6 条，选填）：这场辩论**站在**哪几条 context 证据上（#1141）。只认三个能被解析的命名空间，postflight 逐条对着本次 context 核，**核不上的直接丢掉并记一条 degradation**（不会让流水线变红，但会被数出来）：
-    - `news:<event_id>` —— `context.news_evidence_graph.events[].event_id`
+    - `news:…` —— **照抄那一条事件的 `evidence_id` 字段**。`context.news_evidence_graph.events` 每一行都自带一条，形如 `news:evt_3ffdc891b1dd9eb52b84`；你不需要拼，也不要拼。
+      - 2026-09-10 这里被拼成了 `news:00100-humain-m3-2026-09-04` 和 `news:02208-h1-report-2026-09-08`——`<票>-<主题>-<日期>`，一个人会取的名字，而真 id 是一串不透明的 `evt_` 十六进制。**不透明的 token 只能抄，抄不了就别引。**跟下面 `risk:` 同一条纪律。
     - `risk:…` —— **照抄那一行的 `evidence_id` 字段**。`context.risk_guardrail` 的 breach / hard_stop_watch / concentration_review 每一行都自带一条，形如 `risk:single_name_review:00100`；你不需要拼，也不要拼。
       - 这条规则以前是一段语法（命名空间 + `<type>` 全集 + ticker 形还是 leg 形 + 「别自己起名」），2026-09-08 仍然被拼成 `risk:single_name:00100` 去指一行 `type` 是 `single_name_review` 的记录——票是对的，名字取了另一行合法拥有的那一半。所以现在只有一条：**那一行写着什么就抄什么**。
       - 想引整条腿的闸（`leveraged_exposure`、`beta` 这种 `ticker` 为 null 的行）同理，它的 `evidence_id` 已经是 `:<leg>` 形。
+      - resolver 另外接受**那一行所在 list 的键名**作为同一行的别名（`risk:hard_stop_watch:RKLX` == `risk:leveraged_hard_stop:RKLX`），**仅限该 list 里所有行 type 相同时**——`breaches` 装着四种 type，拿它当名字说不清指的是哪一行，照样被丢。这是给「抄了外层键名」兜底的，不是第二种写法：**照抄 `evidence_id` 仍然是唯一该做的事。**
     - `quant:<ticker>:<field>` —— `context.quant_signals.rows[<ticker>]` 上一个非空字段（如 `quant:SPCH:dist_ma200_pct`）。**只有 `rows` 里真有的 ticker 能引**：杠杆 ETF 通常没有自己的行（07226 没有，它的底层 HSTECH 有），要引就引你真正读的那一行
     **没有可引的证据就不填**，别为了填而造 id：造出来的引用比不引更糟，它看起来像证据。portable workflow lane 早就要求每个 case 带 `evidence_ids`（`workflows/validators.py`），这里是把同一条纪律接到日报这条 lane 上。
   - **不会因为格式错误让 08:00 流水线变红**：postflight 的 normalizer 会裁剪超长文本、丢弃未知键与不在枚举内的 frame，整块为空则记为「没写」。但缺席是被数出来的——dashboard 的 `debate_coverage.bear_case_pct` 就是这条纪律的实测曲线，别用空块凑覆盖率。

--- a/src/clawock/decision/risk.py
+++ b/src/clawock/decision/risk.py
@@ -448,6 +448,36 @@ def evidence_ref(row: dict) -> str:
     return f"risk:{kind}"
 
 
+def news_evidence_ref(event: dict) -> str:
+    """The debate citation that resolves to this exact news event.
+
+    Same reason as `evidence_ref` above, one namespace over. A real event id is
+    `evt_3ffdc891b1dd9eb52b84` — opaque, and nothing in it says which story it
+    is. On 2026-09-10 the model cited `news:00100-humain-m3-2026-09-04` and
+    `news:02208-h1-report-2026-09-08`: `<ticker>-<topic>-<date>`, a format it
+    invented because it is the one a human would have chosen. Both resolved to
+    nothing. Asking a model to carry an opaque token it cannot check is asking
+    it to prefer a plausible one; hand it the finished string instead.
+    """
+    event_id = str((event or {}).get("event_id") or "").strip()
+    return f"news:{event_id}" if event_id else ""
+
+
+def attach_event_ids(events: list) -> list:
+    """Return a copy of the projected events, each advertising its citation."""
+    out = []
+    for event in events or []:
+        if not isinstance(event, dict):
+            out.append(event)
+            continue
+        row = dict(event)
+        ref = news_evidence_ref(row)
+        if ref:
+            row["evidence_id"] = ref
+        out.append(row)
+    return out
+
+
 def attach_breach_ids(guardrail: dict) -> dict:
     """Return a context copy whose current detector rows carry stable IDs."""
     out = copy.deepcopy(guardrail)

--- a/src/clawock/harness/brief_postflight.py
+++ b/src/clawock/harness/brief_postflight.py
@@ -230,13 +230,35 @@ def _citable_refs(context) -> set[str]:
 
     graph = context.get('news_evidence_graph') or {}
     for event in graph.get('events') or []:
+        # The one the row advertises first, for the same reason as the
+        # guardrail rows below: it is the string the model was handed.
+        advertised = str((event or {}).get('evidence_id') or '').strip()
+        if advertised:
+            refs.add(advertised)
         event_id = str((event or {}).get('event_id') or '').strip()
         if event_id:
             refs.add(f'news:{event_id}')
 
     guardrail = context.get('risk_guardrail') or {}
     for key in risk_discipline.GUARDRAIL_ROW_KEYS:
-        for row in guardrail.get(key) or []:
+        rows = guardrail.get(key) or []
+        # A list whose rows all share one `type` has an unambiguous second
+        # name: the key it is filed under. `hard_stop_watch` holds only
+        # `leveraged_hard_stop` rows, so `risk:hard_stop_watch:RKLX` and
+        # `risk:leveraged_hard_stop:RKLX` are the same row — and the context
+        # hands the model BOTH names, the key wrapping the row and the type
+        # inside it. On 2026-09-10 it took the outer one twice.
+        #
+        # Only for a homogeneous list, and that is computed, not listed:
+        # `breaches` carries four different types, so `risk:breaches:07226`
+        # would name a row without saying which, and a citation that vague is
+        # the thing this resolver exists to refuse. Accepting the alias is not
+        # a loosening — every alias still resolves to a row that is really
+        # there, and the invented ones are dropped exactly as before.
+        kinds = {str((row or {}).get('type') or '').strip() for row in rows}
+        kinds.discard('')
+        alias = key if len(kinds) == 1 else None
+        for row in rows:
             # The one the row itself advertises. Reading the same field the
             # context hands the model is what makes "copy this" true — a
             # second spelling of the grammar here is a second thing to drift.
@@ -246,10 +268,13 @@ def _citable_refs(context) -> set[str]:
             kind = str((row or {}).get('type') or '').strip()
             if not kind:
                 continue
-            refs.add(f'risk:{kind}')
+            names = [kind] + ([alias] if alias and alias != kind else [])
+            for name in names:
+                refs.add(f'risk:{name}')
             ticker = str((row or {}).get('ticker') or '').strip()
             if ticker:
-                refs.add(f'risk:{kind}:{ticker}')
+                for name in names:
+                    refs.add(f'risk:{name}:{ticker}')
             # A leg-level breach (`leveraged_exposure`, `beta`) carries no
             # ticker: the cap is on the book, not on a name. Without a scoped
             # form for those rows the only way to point at "the HK one" is to
@@ -257,7 +282,8 @@ def _citable_refs(context) -> set[str]:
             # nothing — measured, 8 of 28 dropped refs did exactly that.
             leg = str((row or {}).get('leg') or '').strip()
             if leg:
-                refs.add(f'risk:{kind}:{leg}')
+                for name in names:
+                    refs.add(f'risk:{name}:{leg}')
 
     rows = ((context.get('quant_signals') or {}).get('rows')) or {}
     if isinstance(rows, dict):

--- a/src/clawock/harness/brief_preflight.py
+++ b/src/clawock/harness/brief_preflight.py
@@ -1526,10 +1526,14 @@ def news_evidence_node():
             news_evidence_ctx = {
                 'as_of': graph.get('as_of'),
                 'summary': graph.get('summary'),
-                'events': [
+                # `attach_event_ids` for the same reason `attach_breach_ids`
+                # exists next to the guardrail: the model should copy an id,
+                # not compose one. Applied to the PROJECTION, not the source —
+                # what the model can cite is exactly what it was handed.
+                'events': risk_discipline.attach_event_ids([
                     {key: event.get(key) for key in decision_fields}
                     for event in current_events[:40]
-                ],
+                ]),
                 'actionable_events': graph.get('actionable_events') or [],
                 'information_overlay': graph.get('information_overlay') or {},
                 'tavily_resolution_queue': (

--- a/tests/test_debate_evidence_citations.py
+++ b/tests/test_debate_evidence_citations.py
@@ -293,3 +293,123 @@ def test_one_hard_stop_has_one_name_across_every_surface_that_shows_it():
 
     citable = brief_postflight._citable_refs({'risk_guardrail': guardrail})
     assert f'risk:{name}:{ticker}' in citable
+
+
+def test_the_key_a_row_is_filed_under_resolves_to_that_row():
+    """`hard_stop_watch` is the list; `leveraged_hard_stop` is the row's type.
+
+    The context hands the model both names — the key wrapping the row and the
+    type inside it — and on 2026-09-10 it copied the outer one twice
+    (`risk:hard_stop_watch:RKLX`, `risk:hard_stop_watch:SPCH`), two of that
+    morning's nine dropped citations. The row those name is unambiguous, so the
+    resolver now accepts the key as an alias for it.
+    """
+    from clawock.decision import risk as discipline
+    from clawock.harness import brief_postflight
+
+    guardrail = discipline.attach_breach_ids(_guardrail_from_the_real_producer())
+    citable = brief_postflight._citable_refs({'risk_guardrail': guardrail})
+
+    stops = guardrail.get('hard_stop_watch') or []
+    assert stops, 'the fixture stopped tripping a hard stop — it proves nothing'
+    for stop in stops:
+        canonical = f"risk:{stop['type']}:{stop['ticker']}"
+        alias = f"risk:hard_stop_watch:{stop['ticker']}"
+        assert canonical in citable
+        assert alias in citable, (
+            f'{alias} is the name the model copied on 09-10 and it still '
+            f'resolves to nothing')
+
+
+def test_a_mixed_list_lends_its_name_to_nobody():
+    """The alias is only unambiguous where the list is.
+
+    `breaches` holds `single_name`, `leveraged_exposure`, `beta`,
+    `factor_concentration` — `risk:breaches:07226` names a row without saying
+    which, and a citation that vague is the thing this resolver exists to
+    refuse. Computed from the rows, not from a list of key names, so a family
+    that later becomes homogeneous (or stops being) does not need a second
+    edit here to stay right.
+    """
+    from clawock.harness import brief_postflight
+
+    guardrail = {
+        'breaches': [
+            {'type': 'single_name', 'leg': 'HK', 'ticker': '07226'},
+            {'type': 'beta', 'leg': 'US', 'ticker': None},
+        ],
+        'hard_stop_watch': [
+            {'type': 'leveraged_hard_stop', 'leg': 'US', 'ticker': 'RKLX'},
+        ],
+        'concentration_reviews': [],
+    }
+    citable = brief_postflight._citable_refs({'risk_guardrail': guardrail})
+
+    assert 'risk:breaches:07226' not in citable
+    assert 'risk:breaches' not in citable
+    assert 'risk:single_name:07226' in citable
+    assert 'risk:hard_stop_watch:RKLX' in citable
+
+    # One type in the list, spelled differently: still one row, still an alias.
+    guardrail['breaches'] = [{'type': 'single_name', 'leg': 'HK',
+                              'ticker': '07226'}]
+    citable = brief_postflight._citable_refs({'risk_guardrail': guardrail})
+    assert 'risk:breaches:07226' in citable
+
+
+def test_a_news_event_advertises_the_id_it_wants_copied():
+    """The `risk:` half learned this on 09-08; the `news:` half had not.
+
+    A real event id is `evt_3ffdc891b1dd9eb52b84` — opaque, and nothing in it
+    says which story it is. On 2026-09-10 the model cited
+    `news:00100-humain-m3-2026-09-04` and `news:02208-h1-report-2026-09-08`:
+    `<ticker>-<topic>-<date>`, the format a human would choose. Both resolved
+    to nothing. Asking for an opaque token it cannot check is asking for a
+    plausible one, so the projected event now carries the finished string.
+    """
+    from clawock.decision import risk as discipline
+    from clawock.harness import brief_postflight
+
+    events = discipline.attach_event_ids([
+        {'event_id': 'evt_3ffdc891b1dd9eb52b84', 'ticker': '00100'},
+        {'event_id': 'evt_77a4a4ba2707f628518c', 'ticker': '02208'},
+    ])
+    assert [e['evidence_id'] for e in events] == [
+        'news:evt_3ffdc891b1dd9eb52b84', 'news:evt_77a4a4ba2707f628518c']
+
+    citable = brief_postflight._citable_refs(
+        {'news_evidence_graph': {'events': events}})
+    for event in events:
+        assert event['evidence_id'] in citable
+    # The invented shape is still dropped — this is a copy aid, not an amnesty.
+    assert 'news:00100-humain-m3-2026-09-04' not in citable
+
+
+def test_the_projection_the_model_reads_is_the_one_that_advertises():
+    """An `evidence_id` on the source graph and not on the 40-row projection
+    would be a field nobody reads: the model is handed the projection."""
+    import inspect
+    from clawock.harness import brief_preflight
+
+    source = inspect.getsource(brief_preflight)
+    block = source[source.index("'events': "):]
+    block = block[:block.index('],') + 2]
+    assert 'attach_event_ids' in block, (
+        'the projection handed to the model must be the one carrying the ids')
+
+
+def test_every_namespace_the_skill_teaches_says_copy_not_compose():
+    """Three namespaces, one discipline. `quant:` is deliberately excluded: its
+    reference IS composed, from a ticker and a field the model reads off the
+    row, and both halves are legible — nothing opaque to copy wrong."""
+    skill = (Path(__file__).resolve().parents[1]
+             / 'skills' / 'daily-deep-brief' / 'SKILL.md').read_text(
+                 encoding='utf-8')
+    block = skill[skill.index('`evidence_ids`（≤6 条'):]
+    block = block[:block.index('**没有可引的证据就不填**')]
+    for namespace in ('news', 'risk'):
+        line = block[block.index(f'- `{namespace}:'):]
+        line = line[:line.index('\n')]
+        assert '`evidence_id`' in line, (
+            f'the {namespace}: namespace still teaches a grammar to compose: '
+            f'{line}')


### PR DESCRIPTION
#1392 / #1408 把丢引用从 **66 条/天**压到 09-08、09-09 各 1 条，09-10 又弹回 **9 条**。拆开看是同一个根因的三个面：**要模型抄一个 id，得先保证它眼前只有一个 id。**

## ① risk：list 的键名和行的 type 是同一行的两个名字

`hard_stop_watch` 是那个 list，`leveraged_hard_stop` 是行自己的 `type`。context 把两个名字同时递给模型——键包着行，type 在行里——09-10 它抄了外层那个两次：`risk:hard_stop_watch:RKLX`、`risk:hard_stop_watch:SPCH`。

两个名字指同一行，无歧义 ⇒ resolver 接受键名作为别名。**只在该 list 里所有行 type 相同时**，而且这个条件是**算出来的，不是列出来的**：`breaches` 装着 `single_name` / `leveraged_exposure` / `beta` / `regime_delever` 四种，`risk:breaches:07226` 说不清指哪一行,照样被丢——含糊的引用正是这个 resolver 存在的理由。

**不是放松**：每个别名仍然解析到一条真实存在的行，真编的照样丢（下表可见）。

## ② news：真 id 不透明，模型就发明了一个像样的

另外两条是 `news:00100-humain-m3-2026-09-04` 和 `news:02208-h1-report-2026-09-08`——`<票>-<主题>-<日期>`，一个人会取的名字。真 id 是 `evt_3ffdc891b1dd9eb52b84`，不透明，本身不说它是哪条新闻。

**要一个它没法自查的 token，就是在要一个看起来合理的。** `risk:` 那半 09-08 就学过这课（#1408 给每行贴 `evidence_id`），`news:` 那半没跟上。现在投影出去的每条 event 自带 `evidence_id`，SKILL 措辞跟 `risk:` 对齐。

贴在**投影**上而不是源图上：模型读到的是那 40 行的投影，贴在源上等于贴了个没人读的字段（有闸钉住）。

## 真 context 上的验证

拿 09-10 那天的 `brief-context-2026-09-10.json`（343 条可引）跑：

| 09-10 被丢的引用 | 改后 | 为什么 |
|---|---|---|
| `risk:hard_stop_watch:RKLX` | ✅ **可核** | 别名 |
| `risk:hard_stop_watch:SPCH` | ✅ **可核** | 别名 |
| `risk:single_name_review:07226` | ❌ 仍丢 | 当天只有 00100 有 review 行——**票是编的，本来就该丢** |
| `news:00100-humain-m3-…` | ❌ 仍丢 | 发明的 slug；修的是让它**明天有东西可抄** |
| `news:02208-h1-report-…` | ❌ 仍丢 | 同上 |

## 闸

四个新闸，各自撤掉对应的一半就点名一次（实测）：

- `test_the_key_a_row_is_filed_under_resolves_to_that_row`
- `test_a_mixed_list_lends_its_name_to_nobody`
- `test_the_projection_the_model_reads_is_the_one_that_advertises`
- `test_every_namespace_the_skill_teaches_says_copy_not_compose`

全量 **3613 passed**。

https://claude.ai/code/session_01RC61NsgyH4o1xZAyBY2spw