### PR TITLE
dashboard 尺寸闸：降级梯子从来没被真跑过一次

### DIFF
--- a/src/clawock/publish/dashboard.py
+++ b/src/clawock/publish/dashboard.py
@@ -149,6 +149,23 @@ MAX_OUT_BYTES          = 200_000   # final dashboard.json hard cap (~200KB)
 MIN_SNAPSHOTS_UNDER_BUDGET = 30
 MAX_OVERVIEW_BYTES      = 80_000    # Hero-only projection hard cap
 
+#: Every marker the size-cap ladder writes INTO the payload to record that a
+#: lever was pulled. Declared once, here, because the page's "every published
+#: block has a reader" gate has to know they are metadata rather than content —
+#: and it can only learn that from a list the producer also uses.
+#:
+#: `snapshots_trimmed_for_budget` is why this exists. Two of the three markers
+#: were in that gate's allowlist and it was not, so the day the second lever
+#: fired, `validate` would have gone red on a key it had just written itself —
+#: on the one generation already in trouble. Nothing caught it because the gate
+#: builds a payload that is under the cap: a lever that only fires on a bad day
+#: is not exercised by a good one.
+BUDGET_DEGRADATION_KEYS = (
+    'recent_plans_dropped',
+    'snapshots_trimmed_for_budget',
+    'payload_over_cap',
+)
+
 
 def _fields(value, names):
     """Copy an explicit public projection surface from an optional mapping."""
@@ -3736,6 +3753,97 @@ class UnsupportedLegShape(ProjectionInputError):
     """
 
 
+def apply_size_budget(out):
+    """Spend the size-cap levers, in order, and return `(payload, size_bytes)`.
+
+    Extracted from `build_projection` so the ladder can be DRIVEN rather than
+    described. It was only ever exercised by a test that re-implemented the
+    trim loop beside it and by a `grep` for the marker's name — so on the day
+    it fired for real, nothing had run it. That is how
+    `snapshots_trimmed_for_budget` came to be the one marker of three missing
+    from the page gate's allowlist: a lever that fires only on a bad day is not
+    exercised by a good one (same shape as #1230).
+
+    Three levers, each recorded IN the payload under one of
+    `BUDGET_DEGRADATION_KEYS`, because a degradation that lives only on stderr
+    reaches no gate.
+    """
+    payload = dashboard_wire_payload(out)
+    size_bytes = len(payload.encode('utf-8'))
+
+    if size_bytes > MAX_OUT_BYTES:
+        # Last resort: drop recent_plans entirely + keep snapshot summaries only
+        print(f'⚠️  payload still {size_bytes} bytes > {MAX_OUT_BYTES} cap — dropping recent_plans', file=sys.stderr)
+        out['recent_plans'] = []
+        out['recent_plans_dropped'] = True
+        payload = dashboard_wire_payload(out)
+        size_bytes = len(payload.encode('utf-8'))
+        if size_bytes > MAX_OUT_BYTES:
+            # Second lever: shorten the embedded snapshot series from the OLD
+            # end. It is the largest single section (37KB of 195KB at 76 rows,
+            # ~489 bytes each) and the only one that grows by one row every
+            # trading day, so it — not `recent_plans` — is what actually walks
+            # this payload into the cap. Measured 2026-08-26: 195,680 bytes with
+            # 4,320 to spare and MAX_SNAPSHOTS_EMBEDDED=90 still 14 rows away,
+            # i.e. the cap arrives in ~9 trading days and then stays breached.
+            #
+            # Oldest-first, because the equity curve's recent shape is what is
+            # read; and never below MIN_SNAPSHOTS_UNDER_BUDGET, because past
+            # that point the trim stops being cosmetic.
+            kept = list(out.get('snapshots') or [])
+            dropped = 0
+            while (size_bytes > MAX_OUT_BYTES
+                   and len(kept) > MIN_SNAPSHOTS_UNDER_BUDGET):
+                kept.pop(0)
+                dropped += 1
+                out['snapshots'] = kept
+                payload = dashboard_wire_payload(out)
+                size_bytes = len(payload.encode('utf-8'))
+            if dropped:
+                # Recorded IN the payload, not only on stderr: `recent_plans`
+                # already learned this lesson (`recent_plans_dropped`), and a
+                # degradation that lives only in a build log is one no gate can
+                # read back.
+                out['snapshots_trimmed_for_budget'] = dropped
+                payload = dashboard_wire_payload(out)
+                size_bytes = len(payload.encode('utf-8'))
+                print(f'⚠️  dropped the {dropped} oldest snapshot(s) to fit the '
+                      f'{MAX_OUT_BYTES} cap — now {size_bytes} bytes', file=sys.stderr)
+        if size_bytes > MAX_OUT_BYTES:
+            # Both levers spent; publishing an oversized payload still beats not
+            # publishing, but say so — on 2026-07-28 the file shipped 3.7KB over
+            # the cap with only the line above to show for it, which reads as
+            # "handled".
+            #
+            # Recorded IN the payload as well (#1215). A stderr line reaches no
+            # gate: not the build card, not the cron log, not watchdog.jsonl. So
+            # the 2026-07-28 breach was invisible to everything that could have
+            # acted on it, and "publishing over cap" was a decision nothing
+            # downstream could see had been taken. `recent_plans_dropped` and
+            # `snapshots_trimmed_for_budget` already live here for this reason;
+            # the terminal case was the one that did not.
+            #
+            # Writing it grows the payload by ~60 bytes, which is the right
+            # trade in a branch that is already over: a breach that is 60 bytes
+            # worse and legible beats one that is silent.
+            # `bytes` is the size with both levers spent and before this marker
+            # was added, which is a fixed number; recording the post-marker size
+            # would be a value that changes itself.
+            out['payload_over_cap'] = {
+                'bytes': size_bytes,
+                'cap': MAX_OUT_BYTES,
+                'over_by': size_bytes - MAX_OUT_BYTES,
+                'levers_spent': ['recent_plans', 'snapshots'],
+                'measured': 'before this marker was written',
+            }
+            payload = dashboard_wire_payload(out)
+            size_bytes = len(payload.encode('utf-8'))
+            print(f'⚠️  payload STILL {size_bytes} bytes > {MAX_OUT_BYTES} cap after '
+                  f'dropping recent_plans and trimming snapshots — publishing over cap',
+                  file=sys.stderr)
+    return payload, size_bytes
+
+
 def build_projection(previous_source=None, shadow_previous=None):
     """Compute the four public payloads from the workspace. Writes nothing.
 
@@ -4196,79 +4304,7 @@ def build_projection(previous_source=None, shadow_previous=None):
     # dashboard.json is the canonical cross-tab browser document. Keep it compact:
     # detail activation still pays this parse, and producers should not spend
     # recovered headroom on indentation that adds no user value.
-    payload = dashboard_wire_payload(out)
-    size_bytes = len(payload.encode('utf-8'))
-
-    if size_bytes > MAX_OUT_BYTES:
-        # Last resort: drop recent_plans entirely + keep snapshot summaries only
-        print(f'⚠️  payload still {size_bytes} bytes > {MAX_OUT_BYTES} cap — dropping recent_plans', file=sys.stderr)
-        out['recent_plans'] = []
-        out['recent_plans_dropped'] = True
-        payload = dashboard_wire_payload(out)
-        size_bytes = len(payload.encode('utf-8'))
-        if size_bytes > MAX_OUT_BYTES:
-            # Second lever: shorten the embedded snapshot series from the OLD
-            # end. It is the largest single section (37KB of 195KB at 76 rows,
-            # ~489 bytes each) and the only one that grows by one row every
-            # trading day, so it — not `recent_plans` — is what actually walks
-            # this payload into the cap. Measured 2026-08-26: 195,680 bytes with
-            # 4,320 to spare and MAX_SNAPSHOTS_EMBEDDED=90 still 14 rows away,
-            # i.e. the cap arrives in ~9 trading days and then stays breached.
-            #
-            # Oldest-first, because the equity curve's recent shape is what is
-            # read; and never below MIN_SNAPSHOTS_UNDER_BUDGET, because past
-            # that point the trim stops being cosmetic.
-            kept = list(out.get('snapshots') or [])
-            dropped = 0
-            while (size_bytes > MAX_OUT_BYTES
-                   and len(kept) > MIN_SNAPSHOTS_UNDER_BUDGET):
-                kept.pop(0)
-                dropped += 1
-                out['snapshots'] = kept
-                payload = dashboard_wire_payload(out)
-                size_bytes = len(payload.encode('utf-8'))
-            if dropped:
-                # Recorded IN the payload, not only on stderr: `recent_plans`
-                # already learned this lesson (`recent_plans_dropped`), and a
-                # degradation that lives only in a build log is one no gate can
-                # read back.
-                out['snapshots_trimmed_for_budget'] = dropped
-                payload = dashboard_wire_payload(out)
-                size_bytes = len(payload.encode('utf-8'))
-                print(f'⚠️  dropped the {dropped} oldest snapshot(s) to fit the '
-                      f'{MAX_OUT_BYTES} cap — now {size_bytes} bytes', file=sys.stderr)
-        if size_bytes > MAX_OUT_BYTES:
-            # Both levers spent; publishing an oversized payload still beats not
-            # publishing, but say so — on 2026-07-28 the file shipped 3.7KB over
-            # the cap with only the line above to show for it, which reads as
-            # "handled".
-            #
-            # Recorded IN the payload as well (#1215). A stderr line reaches no
-            # gate: not the build card, not the cron log, not watchdog.jsonl. So
-            # the 2026-07-28 breach was invisible to everything that could have
-            # acted on it, and "publishing over cap" was a decision nothing
-            # downstream could see had been taken. `recent_plans_dropped` and
-            # `snapshots_trimmed_for_budget` already live here for this reason;
-            # the terminal case was the one that did not.
-            #
-            # Writing it grows the payload by ~60 bytes, which is the right
-            # trade in a branch that is already over: a breach that is 60 bytes
-            # worse and legible beats one that is silent.
-            # `bytes` is the size with both levers spent and before this marker
-            # was added, which is a fixed number; recording the post-marker size
-            # would be a value that changes itself.
-            out['payload_over_cap'] = {
-                'bytes': size_bytes,
-                'cap': MAX_OUT_BYTES,
-                'over_by': size_bytes - MAX_OUT_BYTES,
-                'levers_spent': ['recent_plans', 'snapshots'],
-                'measured': 'before this marker was written',
-            }
-            payload = dashboard_wire_payload(out)
-            size_bytes = len(payload.encode('utf-8'))
-            print(f'⚠️  payload STILL {size_bytes} bytes > {MAX_OUT_BYTES} cap after '
-                  f'dropping recent_plans and trimming snapshots — publishing over cap',
-                  file=sys.stderr)
+    payload, size_bytes = apply_size_budget(out)
 
     overview_payload = serialize_dashboard_payload(compile_overview_projection(out))
     overview_size = len(overview_payload.encode('utf-8'))

--- a/tests/test_dashboard_payload_readers.py
+++ b/tests/test_dashboard_payload_readers.py
@@ -32,6 +32,12 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 SITE = ROOT / "site"
 
+
+def _budget_degradation_keys() -> tuple[str, ...]:
+    from clawock.publish import dashboard
+
+    return dashboard.BUDGET_DEGRADATION_KEYS
+
 #: Keys that are artifact metadata rather than content: they describe how the
 #: payload was cut, and their readers are `clawock validate-sidecar`, the
 #: dashboard build itself and the tests around them — never the page. Adding to
@@ -42,8 +48,11 @@ METADATA_KEYS = {
     "plans_count",
     "recent_plans_cap",
     "decision_schema_version",
-    "recent_plans_dropped",
-    "payload_over_cap",
+    # The size-cap ladder's markers come from the producer's own list, not a
+    # copy kept in step by hand. Two of the three were here and
+    # `snapshots_trimmed_for_budget` was not, so the day the second lever fired
+    # this gate would have reddened on a key the build had just written itself.
+    *_budget_degradation_keys(),
 }
 
 SITE_SUFFIXES = {".js", ".html", ".css", ".md"}
@@ -84,3 +93,80 @@ def test_the_metadata_allowlist_does_not_outlive_its_keys():
     for key in sorted(METADATA_KEYS):
         assert f"'{key}'" in source or f'"{key}"' in source, (
             f"{key} is exempted here but the build no longer writes it")
+
+
+def test_every_marker_the_size_ladder_writes_is_one_this_gate_knows_about():
+    """The ladder is DRIVEN here, not described.
+
+    `snapshots_trimmed_for_budget` was the one marker of three missing from
+    `METADATA_KEYS`, so the day the second lever fired this gate would have gone
+    red on a key the build had just written itself — on the one generation
+    already in trouble. Nothing caught it: the ladder had never been executed.
+    Its only coverage was a test that re-implemented the trim loop beside it and
+    a `grep` of the source for the marker's name. A lever that fires only on a
+    bad day is not exercised by a good one (#1230).
+
+    So: push a payload past the cap for real, three times, and assert that every
+    key the ladder adds is one this gate will let through.
+    """
+    from clawock.publish import dashboard
+
+    def ladder(monkeyed_cap, snapshots, plans):
+        out = {
+            "snapshots": [{"date": f"2026-01-{i:02d}", "pad": "x" * 400}
+                          for i in range(1, snapshots + 1)],
+            "recent_plans": [{"pad": "y" * 400} for _ in range(plans)],
+        }
+        before = set(out)
+        original = dashboard.MAX_OUT_BYTES
+        dashboard.MAX_OUT_BYTES = monkeyed_cap
+        try:
+            dashboard.apply_size_budget(out)
+        finally:
+            dashboard.MAX_OUT_BYTES = original
+        return set(out) - before
+
+    # Lever 1 only: dropping the plans is enough.
+    first = ladder(14_000, snapshots=30, plans=20)
+    assert first == {"recent_plans_dropped"}, first
+
+    # Levers 1 and 2: the plans go, then the oldest snapshots.
+    second = ladder(14_000, snapshots=60, plans=20)
+    assert second == {"recent_plans_dropped", "snapshots_trimmed_for_budget"}
+
+    # All three: the floor of 30 snapshots holds and it publishes over cap.
+    third = ladder(2_000, snapshots=60, plans=20)
+    assert third == {"recent_plans_dropped", "snapshots_trimmed_for_budget",
+                     "payload_over_cap"}
+
+    written = first | second | third
+    assert written == set(dashboard.BUDGET_DEGRADATION_KEYS), (
+        "the ladder writes a marker the producer does not declare, so the page "
+        f"gate cannot know it is metadata: {written ^ set(dashboard.BUDGET_DEGRADATION_KEYS)}")
+    assert written <= METADATA_KEYS, (
+        "a size-cap marker would redden `every published block has a reader` on "
+        "the very generation that needed the lever")
+
+
+def test_the_snapshot_floor_survives_the_ladder():
+    """`decision_metrics` reads `snapshots[-30:]`; trimming past that changes
+    what the window means instead of shortening a chart. Driven, because the
+    floor is inside the loop nothing used to run."""
+    from clawock.publish import dashboard
+
+    out = {
+        "snapshots": [{"date": f"2026-01-{i:02d}", "pad": "x" * 400}
+                      for i in range(1, 61)],
+        "recent_plans": [],
+    }
+    original = dashboard.MAX_OUT_BYTES
+    dashboard.MAX_OUT_BYTES = 2_000
+    try:
+        dashboard.apply_size_budget(out)
+    finally:
+        dashboard.MAX_OUT_BYTES = original
+
+    assert len(out["snapshots"]) == dashboard.MIN_SNAPSHOTS_UNDER_BUDGET
+    # Oldest-first: the recent shape is what the equity curve is read for.
+    assert out["snapshots"][-1]["date"] == "2026-01-60"
+    assert out["snapshots_trimmed_for_budget"] == 30


### PR DESCRIPTION
kcn 让我先量再决定要不要给 `dashboard.json` 瘦身。**结论是不用瘦身**——但量出了另一件事。

## 测量（2026-09-10）

`192,540 / 200,000`，头部很分散：

| 块 | 字节 | 占比 |
|---|---|---|
| `decision_traces` | 30,850 | 16.0% |
| `snapshots` | 16,316 | 8.5% |
| `plan_timeline` | 15,663 | 8.1% |
| `decision_metrics` | 10,981 | 5.7% |
| `workflow_outcomes` | 10,868 | 5.6% |
| `recent_decisions` | 10,668 | 5.5% |

最大的一块只占 16%，前六块合计 49%——**砍任何单独一块都救不了多少**。而且它没在涨：#1078 记的 2026-08-26 是 **195,680**，十五天过去反而**小了 3,140 字节**。撞线本来也不是悬崖，三级降级梯子早就建好了。

## 量出来的东西

三个降级标记，两个在 `test_every_published_block_has_a_reader_on_the_page` 的 `METADATA_KEYS` 白名单里：

| 标记 | 页面上有读者 | 在白名单 | |
|---|---|---|---|
| `recent_plans_dropped` | 否 | ✅ | ok |
| `snapshots_trimmed_for_budget` | 否 | ❌ | **会让 validate 变红** |
| `payload_over_cap` | 否 | ✅ | ok |

⇒ **第二级降级一触发，`validate` 就红在一个它自己刚写进去的 key 上**——而且是在 payload 已经撑爆的那一天，最不该添乱的时候。

## 为什么没人发现

**那条梯子从来没被执行过。** 它的全部覆盖是：

- `test_trimming_takes_the_oldest_and_records_that_it_happened`——在旁边把 trim 循环**重抄了一遍**，跑的是测试自己的副本；
- `test_the_builder_actually_wires_that_lever`——对源码 **grep 标记的名字**。

跑绿的运行走的是没超 cap 的那条路径。同 #1230：**只在坏日子才拉的杆，好日子跑一遍证明不了它。**

## 改了什么

- `BUDGET_DEGRADATION_KEYS` 在生产者这里**声明一次**，页面闸读它，而不是手工同步一份副本——漏掉一个的那种失败正是这次的形状；
- 把梯子抽成 `apply_size_budget(out)`，于是它可以**被驱动**而不是被描述；
- 新闸真的把 payload 推过 cap **三次**（只第一级 / 前两级 / 三级全用尽），断言梯子写出来的每个 key 都是页面闸认得的，且下限 30 与「保留最近的」都成立。

## 验证

撤掉修复点名一次：把 `snapshots_trimmed_for_budget` 从声明里删掉（即回到出事前的状态），新闸红。全量 **3610 passed**。

https://claude.ai/code/session_01RC61NsgyH4o1xZAyBY2spw