### PR TITLE
calendar: 休市是答案不是失败——每逢周一简报都因此判红

### DIFF
--- a/config/cron-payloads/brief.md
+++ b/config/cron-payloads/brief.md
@@ -1,7 +1,7 @@
 **第一轮强制动作（不能跳过）**：在同一条回复中并行调用 `read` 读取 `/root/.openclaw/workspace/skills/daily-deep-brief/SKILL.md` 与下方 Step 0 的两个休市闸命令。`read` 成功前不得进入分析；skills catalog 只有索引，不含 SKILL.md 正文。
 
 **Step 0 — 休市闸（最先执行）**
-分别跑 `/root/.local/bin/clawock calendar hk` 与 `/root/.local/bin/clawock calendar us`。**仅当两者都输出 `CLOSED`**（港股+美股同日休市）才跳过：立即结束本回合、不生成简报、不调用任何 send/postflight 工具，回一句「两市今日均休市，跳过」。只要任一市场 `OPEN` 就照常继续 Step 1。
+分别跑 `/root/.local/bin/clawock calendar hk --status` 与 `/root/.local/bin/clawock calendar us --status`（`--status` 让休市也退出 0；不带它时 `CLOSED` 的退出码是 1，exec 会读成工具失败，而一次已恢复的工具错误仍会把整个 cron 记成 error——每逢周一美股闸必然触发）。答案只看 stdout 的 `OPEN`/`CLOSED`。**仅当两者都输出 `CLOSED`**（港股+美股同日休市）才跳过：立即结束本回合、不生成简报、不调用任何 send/postflight 工具，回一句「两市今日均休市，跳过」。只要任一市场 `OPEN` 就照常继续 Step 1。
 
 你是 Rick，kcn 的全市场盘前深度分析师。08:03 HKT 工作日，HK 开盘前约 87 分钟，US 已收盘 ~4 小时。
 

--- a/config/cron-schedules.json
+++ b/config/cron-schedules.json
@@ -139,8 +139,8 @@
       "message_template": "config/cron-payloads/brief.md",
       "delivery_mode": "none",
       "required_substrings": [
-        "/root/.local/bin/clawock calendar hk",
-        "/root/.local/bin/clawock calendar us",
+        "/root/.local/bin/clawock calendar hk --status",
+        "/root/.local/bin/clawock calendar us --status",
         "skills/daily-deep-brief/SKILL.md",
         "并行调用 `read` 读取 `/root/.openclaw/workspace/skills/daily-deep-brief/SKILL.md` 与下方 Step 0 的两个休市闸命令",
         "skills catalog 只有索引，不含 SKILL.md 正文",

--- a/src/clawock/cli.py
+++ b/src/clawock/cli.py
@@ -170,6 +170,8 @@ def _calendar(args) -> int:
         forwarded += ["--session", args.session]
     if args.quiet:
         forwarded.append("--quiet")
+    if args.status:
+        forwarded.append("--status")
     return calendar_main(forwarded)
 
 
@@ -596,6 +598,10 @@ def main(argv=None) -> int:
     calendar.add_argument(
         "--session", choices=("full", "morning", "afternoon"), default="full")
     calendar.add_argument("--quiet", action="store_true")
+    calendar.add_argument(
+        "--status", action="store_true",
+        help="report on stdout and always exit 0, for callers that read a "
+             "non-zero exit as a failed command")
     calendar.set_defaults(func=_calendar)
 
     profile = sub.add_parser(

--- a/src/clawock/sessions.py
+++ b/src/clawock/sessions.py
@@ -36,9 +36,21 @@ CLI:
                                             -> CLOSED on HK half-days too
   clawock calendar us --date 2026-06-19
                                             -> check a specific date
+  clawock calendar us --status              -> prints OPEN/CLOSED, always exit 0
 
 Exit code: 0 = market open (trading day), 1 = closed. So bash guards read as:
   clawock calendar us || exit 0              # bail on closed
+
+--status exists because that exit code makes this command uncallable by any
+caller that reads a non-zero exit as a failed command. The pre-open brief's
+Step 0 is exactly that: `config/cron-payloads/brief.md` tells the model to read
+`OPEN`/`CLOSED` off stdout, but the agent's exec tool judges the exit code, so
+every Monday morning (US "today" is Sunday in ET at 08:00 HKT -> CLOSED -> 1)
+the run's first mandatory action came back as `Exec failed: clawock calendar
+us` and the whole cron was recorded `error` — on 2026-08-17, 2026-08-24 and
+2026-09-08 the brief itself had already been written and pushed. A closed
+market is an answer, not a failure; `--status` is the shape for callers that
+want the answer on stdout.
 """
 from __future__ import annotations
 
@@ -303,7 +315,15 @@ def main(argv: list[str]) -> int:
     p.add_argument("--session", choices=["full", "morning", "afternoon"],
                    default="full")
     p.add_argument("--quiet", action="store_true", help="suppress OPEN/CLOSED print")
+    p.add_argument("--status", action="store_true",
+                   help="report on stdout and always exit 0 (for callers that "
+                        "read a non-zero exit as a failed command)")
     a = p.parse_args(argv)
+
+    if a.status and a.quiet:
+        # --status moves the whole answer onto stdout; silencing that leaves a
+        # call that always exits 0 and prints nothing, which says nothing.
+        p.error("--status prints the answer; it cannot be combined with --quiet")
 
     d = date.fromisoformat(a.date) if a.date else _today_in_market(a.market)
     if d.year > LATEST_YEAR:
@@ -318,6 +338,8 @@ def main(argv: list[str]) -> int:
         label = "OPEN" if open_ else "CLOSED"
         sess = "" if a.session == "full" else f" {a.session}"
         print(f"{label} ({a.market.upper()}{sess} {d.isoformat()})")
+    if a.status:
+        return 0
     return 0 if open_ else 1
 
 

--- a/tests/test_cron_contracts.py
+++ b/tests/test_cron_contracts.py
@@ -630,15 +630,27 @@ def test_brief_repair_uses_whole_file_write_instead_of_brittle_edit():
 
 
 def test_brief_uses_the_installed_calendar_command():
+    """Step 0 calls the guard in the shape whose exit code is not a verdict.
+
+    Without `--status` the command exits 1 on a closed market, and the agent's
+    exec tool reads that as a failed command — so on 2026-08-17, 2026-08-24 and
+    2026-09-08 (every Monday: at 08:00 HKT the US "today" is Sunday in ET) the
+    brief's first mandatory action came back `Exec failed: clawock calendar us`
+    and the whole cron was recorded `error`, in each case after the brief had
+    already been written and pushed. The payload reads OPEN/CLOSED off stdout,
+    so the bare form must not come back.
+    """
     data = contract()
     profile = data['payload_profiles']['brief']
     brief = next(job for job in data['jobs'] if job['name'] == '盘前深度简报')
     message = cron_contract.render_payload_message(data, brief)
 
     for market in ('hk', 'us'):
-        command = f'/root/.local/bin/clawock calendar {market}'
+        command = f'/root/.local/bin/clawock calendar {market} --status'
         assert command in profile['required_substrings']
         assert command in message
+        bare = f'/root/.local/bin/clawock calendar {market}`'
+        assert bare not in message
     assert 'trading_calendar.py' in profile['forbidden_substrings']
     assert 'trading_calendar.py' not in message
 

--- a/tests/test_trading_calendar.py
+++ b/tests/test_trading_calendar.py
@@ -42,6 +42,45 @@ def test_calendar_implementation_and_cli_ship_in_the_product():
     assert result.stdout.strip() == "CLOSED (US 2026-06-19)"
 
 
+def test_status_reports_closed_on_stdout_without_failing_the_command():
+    """`--status` keeps the verdict on stdout and off the exit code.
+
+    The exit-code form cannot be called by anything that reads a non-zero exit
+    as a failed command. The pre-open brief's Step 0 is exactly that caller —
+    it reads OPEN/CLOSED off stdout while the agent's exec tool judges the exit
+    code — so every Monday (US "today" is Sunday in ET at 08:00 HKT) the run's
+    first mandatory action was reported as `Exec failed: clawock calendar us`
+    and the cron was recorded `error` with the brief already delivered.
+    """
+    def run(*args):
+        return subprocess.run(
+            [sys.executable, "-m", "clawock", "calendar", *args],
+            cwd=ROOT, capture_output=True, text=True, timeout=30,
+            env={**os.environ, "PYTHONPATH": str(ROOT / "src")},
+        )
+
+    closed = run("us", "--date", "2026-06-19", "--status")
+    assert closed.returncode == 0
+    assert closed.stdout.strip() == "CLOSED (US 2026-06-19)"
+
+    # An open day is unchanged, so a caller cannot tell the two apart by exit
+    # code alone — stdout is the whole answer.
+    open_ = run("us", "--date", "2026-06-18", "--status")
+    assert open_.returncode == 0
+    assert open_.stdout.strip() == "OPEN (US 2026-06-18)"
+
+    # Silencing the report would leave a call that always exits 0 and says
+    # nothing at all.
+    muted = run("us", "--date", "2026-06-19", "--status", "--quiet")
+    assert muted.returncode == 2
+    assert "cannot be combined with --quiet" in muted.stderr
+
+    # The guard shape other callers rely on (`clawock calendar us || exit 0`)
+    # is untouched.
+    guard = run("us", "--date", "2026-06-19")
+    assert guard.returncode == 1
+
+
 # --------------------------------------------------------------------------
 # 2027 — the year this suite was written to land
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## 问题

`clawock calendar {hk,us}` 休市时退出码 1 —— 这是给 shell 闸用的形态（`clawock calendar us || exit 0`）。但 `config/cron-payloads/brief.md` 的 Step 0 是**另一类调用者**：payload 让模型读 stdout 的 `OPEN`/`CLOSED`，而 agent 的 exec 工具判的是**退出码**。

每逢周一，08:00 HKT 时美股的「今天」在 ET 还是周日 → `CLOSED` → 退出 1 → 整轮的第一个强制动作回来的是 `⚠️ 🛠️ Exec failed: ~/.local/bin/clawock calendar us`。而 payload 自己就写着「一次已恢复的工具错误仍会把整个 cron 记成 error」。

最近 50 次盘前简报里有三次这么红：

| 日期 | run 状态 | 简报 |
|---|---|---|
| 2026-09-08 (一) | `error` @ 08:14 | `memory/2026-09-08-pre-open.md` 08:12 已落盘并 push |
| 2026-08-24 (一) | `error` @ 08:09 | 08:08 已落盘 |
| 2026-08-17 (一) | `error` @ 10:39 | 已落盘 |

外加 2026-08-16（周六）`calendar hk` 连报 6 次。**红的是判词的形状，不是简报。**

## 修法

不是在 payload 里加 `|| true` —— 模型会重写命令（现场证据：它把 `/root/.local/bin` 抄成了 `~/.local/bin`），后缀一样会掉。改成给命令一个**退出码不承载判词**的形态：

- `clawock calendar <market> --status`：照常打印 `OPEN`/`CLOSED`，一律退出 0。
- `--status --quiet` 被 argparse 拒绝：一个永远退 0 又什么都不打印的调用什么也没说。
- 原来的退出码闸一个字没动，`clawock calendar us || exit 0` 这类 shell 调用者不受影响（测试里钉住了）。
- Step 0 改用 `--status`，`config/cron-schedules.json` 的 `required_substrings` 跟着钉到新形态；contract 测试同时断言裸形态不再出现在 payload 里。

## 验证

- `tests/test_trading_calendar.py::test_status_reports_closed_on_stdout_without_failing_the_command` —— 休市 `--status` 退 0 且 stdout 仍是 `CLOSED`；开市同样退 0（所以退出码不再能区分两者，stdout 才是答案）；`--quiet` 组合退 2；裸形态仍退 1。
- `tests/test_cron_contracts.py::test_brief_uses_the_installed_calendar_command` —— payload 与 contract 双向钉住 `--status`。
- 465 passed（`-k "calendar or cron or session or cli or payload"`）。

合并后需要在 live 上跑 `ops/host/sync_cron_payloads.py --apply` 把新 payload 推到 openclaw cron，否则 `system_check` 的 cron runtime contract 会判 drift。

https://claude.ai/code/session_01UT4UbT7X7nGXS5gpRT2qYW