### PR TITLE
payload: 探测「东西在不在」必须整条链退 0——找不到是答案，不是失败

### DIFF
--- a/config/cron-payloads/brief.md
+++ b/config/cron-payloads/brief.md
@@ -17,9 +17,10 @@ clawock brief preflight
 **持仓相关数字**（FX、book USD/HKD、concentration HHI、retrospective、单股 RSI/MA/PnL）只从这个 JSON 取，不要凭空造。
 **板块全景/同行涨幅榜/当日催化** context.json 没覆盖 — Step 3 用 tavily-search 拉实时。
 
-**跑命令的两条硬约束（同属「工具报错=整轮记 error」那一族）**
+**跑命令的硬约束（同属「工具报错=整轮记 error」那一族）**
 - 脚本路径**照抄 SKILL.md，不要猜**。猜错了不许全盘扫描：`find /` 会被转入后台会话，而**主动 `process kill` 掉它的 toolResult 带 isError**，整个 cron 会被记成 error —— 2026-08-21 的简报就是这样在两个渠道都投递成功之后仍然判红的。
 - 任何可能长跑的命令自己用 `timeout` 包住（如 `timeout 20 <cmd>`），让它自己结束，这样就永远不需要 kill。
+- **探测「东西在不在」的命令必须整条链退出 0。** `ls`/`grep`/`head`/`test` 找不到东西时退非零，`;` 链的退出码是**最后一条**的退出码，而 `2>/dev/null` 只吞 stderr、不改退出码 —— 于是「今天的还没写」这个**正确答案**会以 `Exec failed` 的形式回来，把整轮记成 error。写成 `ls X 2>/dev/null || true`，或者把存在性检查放在链首而不是链尾。2026-09-02 的简报就是这么判红的：`ls …/2026-09-01*; echo ---; ls …/2026-09-02*` 退 2，而那天 08:08 简报已写好、postflight pass、微信已投。
 - **`clawock brief postflight` 是这条规则的例外：绝不给它包 `timeout`，也不要 kill 它。** 它是「先投递、后提交」两段（#765 的顺序），提交那一段要跑 log_decisions + 重建 dashboard + push，几十秒到几分钟，在机器吃紧时更久。杀在中间的结果是**投递成功了但简报没入库**：`memory/{date}-pre-open.md` 与 `plan.json` 留在工作区不进 git，公开页 404，决策台账整天不动（日更简报的 commit 是那个台账唯一的搬运工）。2026-09-01 就是这样丢的：`timeout 90` 退出码 124，而 `brief-sent-*.json` 已经写好，于是看起来完全成功。
 - **看到 `memory/.tmp/brief-sent-{date}.json` 只说明「投出去了」，不说明 postflight 跑完了。** 判完成看它自己那份 JSON 里的 `commit_ok`；`commit_ok: false` 就是没入库，要把 postflight 重跑到底，不要收尾。
 

--- a/config/cron-payloads/intraday.md
+++ b/config/cron-payloads/intraday.md
@@ -12,6 +12,8 @@ clawock intraday preflight --market {{market}}
 若 exec 返回 `Command still running`，只用 `process` poll 对应 session；禁止新开 exec 用 sleep/ps/ls/grep 探测进度。preflight 内置休市闸；若输出 `status: market_closed`，立即结束，不生成报告、不调用 postflight/send/message。
 输出 `memory/.tmp/intraday-context-{{market}}-latest.json`，同一份 JSON 也打到 stdout。关键字段 `should_alert` + `alert_reasons` + `anomalies`，以及 `context_id` —— **Step 3 要原样回传**。
 
+- **探测「东西在不在」的命令必须整条链退出 0。** `ls`/`grep`/`head`/`test` 找不到东西时退非零，`;` 链的退出码是**最后一条**的退出码，而 `2>/dev/null` 只吞 stderr、不改退出码 —— 于是「今天的还没写」这个**正确答案**会以 `Exec failed` 的形式回来，把整轮记成 error。写成 `ls X 2>/dev/null || true`，或者把存在性检查放在链首而不是链尾。2026-09-02 的简报就是这么判红的：`ls …/2026-09-01*; echo ---; ls …/2026-09-02*` 退 2，而那天 08:08 简报已写好、postflight pass、微信已投。
+
 若 `delivery_mode=unchanged_receipt`：说明和上一次实际送达相比，风险档位、异动档位、盘中 setup、未成交计划和一级披露都没有语义变化。**不要生成散文、不要写 prose/sidecar**，直接运行：
 ```
 clawock intraday postflight --market {{market}} --context-id {CTXID}

--- a/config/cron-payloads/report.md
+++ b/config/cron-payloads/report.md
@@ -33,6 +33,7 @@ clawock report postflight --market {{market}} --phase {{phase}} --context-id <St
 
 **铁律**：
 - ⚠️ 数据缺口必说，禁止编造（postflight 扫敷衍词）
+- **探测「东西在不在」的命令必须整条链退出 0。** `ls`/`grep`/`head`/`test` 找不到东西时退非零，`;` 链的退出码是**最后一条**的退出码，而 `2>/dev/null` 只吞 stderr、不改退出码 —— 于是「今天的还没写」这个**正确答案**会以 `Exec failed` 的形式回来，把整轮记成 error。写成 `ls X 2>/dev/null || true`，或者把存在性检查放在链首而不是链尾。2026-09-02 的简报就是这么判红的：`ls …/2026-09-01*; echo ---; ls …/2026-09-02*` 退 2，而那天 08:08 简报已写好、postflight pass、微信已投。
 - 不简单复述数字，必须做模型自己的解读
 - {{market_rule}}
 - 直接回复文本

--- a/config/cron-schedules.json
+++ b/config/cron-schedules.json
@@ -30,7 +30,7 @@
       "required_substrings": [
         "skills/{skill}/SKILL.md",
         "并行调用 `read` 读取 `/root/.openclaw/workspace/skills/{skill}/SKILL.md` 与 Step 1 preflight",
-        "skills catalog 只有索引，不含 SKILL.md 正文",
+        "skills catalog 只有索引，不含 SKILL.md 正文", "探测「东西在不在」的命令必须整条链退出 0",
         "clawock report preflight --market {market} --phase {phase}",
         "context_id",
         "clawock report postflight --market {market} --phase {phase} --context-id",
@@ -80,7 +80,7 @@
       "required_substrings": [
         "skills/{skill}/SKILL.md",
         "并行调用 `read` 读取 `/root/.openclaw/workspace/skills/{skill}/SKILL.md` 与 Step 1 preflight",
-        "skills catalog 只有索引，不含 SKILL.md 正文",
+        "skills catalog 只有索引，不含 SKILL.md 正文", "探测「东西在不在」的命令必须整条链退出 0",
         "clawock intraday preflight --market {market}",
         "market_closed",
         "所有脚本 exec 调用都显式设置 `timeout: 300`",
@@ -143,7 +143,7 @@
         "/root/.local/bin/clawock calendar us --status",
         "skills/daily-deep-brief/SKILL.md",
         "并行调用 `read` 读取 `/root/.openclaw/workspace/skills/daily-deep-brief/SKILL.md` 与下方 Step 0 的两个休市闸命令",
-        "skills catalog 只有索引，不含 SKILL.md 正文",
+        "skills catalog 只有索引，不含 SKILL.md 正文", "探测「东西在不在」的命令必须整条链退出 0",
         "clawock brief preflight",
         "clawock brief postflight",
         "首次生成和 postflight 修复 Step 4 产物都只用 `write` 完整覆盖；禁止 `edit` 精确文本替换",

--- a/tests/test_cron_contracts.py
+++ b/tests/test_cron_contracts.py
@@ -629,6 +629,42 @@ def test_brief_repair_uses_whole_file_write_instead_of_brittle_edit():
     assert '一次已恢复的 `edit` 工具错误仍会把整个 cron 记成 error' in message
 
 
+def test_every_agent_payload_requires_probe_chains_to_exit_zero():
+    """A probe that legitimately finds nothing must not read as a failed run.
+
+    `ls`/`grep`/`head`/`test` exit non-zero when they find nothing, a `;` chain
+    carries the exit code of its LAST stage, and `2>/dev/null` hides the message
+    without touching the code. So the model's own existence probes came back as
+    `Exec failed` and the whole cron was recorded `error` — 7 runs across all
+    three payloads between 2026-07-30 and 2026-09-02. The one session that
+    survived GC proves the shape: on 2026-09-02 the brief job ran
+
+        ls .../memory/2026-09-01* 2>/dev/null; echo "---"; ls .../2026-09-02*
+
+    got exit 2 because today's brief did not exist yet — which was the correct
+    answer to the question it asked — and the run went red although the brief
+    was written at 08:08, postflight passed and `0f341eac` is in git.
+
+    Pinned for all three agent payloads because the family hit all three:
+    brief (08-10, 08-18, 09-02), report (08-10 x2, 08-14), intraday (07-30).
+    """
+    data = contract()
+    rule = '探测「东西在不在」的命令必须整条链退出 0'
+    jobs = {job['name']: job for job in data['jobs']}
+    for profile_name, job_name in (
+        ('brief', '盘前深度简报'),
+        ('report', '港股开盘报告'),
+        ('intraday', '盘中盯盘'),
+    ):
+        profile = data['payload_profiles'][profile_name]
+        assert rule in profile['required_substrings'], profile_name
+        message = cron_contract.render_payload_message(data, jobs[job_name])
+        assert rule in message, profile_name
+        # The fix has to be the exit code, not a silenced stderr — that is the
+        # half that never worked.
+        assert '`2>/dev/null` 只吞 stderr、不改退出码' in message, profile_name
+
+
 def test_brief_uses_the_installed_calendar_command():
     """Step 0 calls the guard in the shape whose exit code is not a verdict.
 


### PR DESCRIPTION
接 #1429。那个 PR 修的是**我们自己命令**的形态（`clawock calendar` 休市退 1）。同一个病还有第二个入口：**模型自己临时写的 shell 探测**。

## 直接证据

09-02 的会话是这一族里唯一没被 GC 的，盘前简报当时跑的是：

```bash
ls /root/.openclaw/workspace/memory/2026-09-01* 2>/dev/null; echo "---"; ls /root/.openclaw/workspace/memory/2026-09-02* 2>/dev/null
```

toolResult 原文：

```json
{"status":"completed","exitCode":2,"isError":true,"durationMs":104,
 "aggregated":".../2026-09-01-plan.json\n.../2026-09-01-pre-open.md\n---\n\n(Command exited with code 2)"}
```

**这条探测完全成功。** 它问的是「昨天的简报在不在、今天的写了没有」，而「昨天两个都在、今天还没有」正是 08:03 应该得到的答案。红在三处叠加：

1. `;` 链的退出码 = **最后一条**的退出码；
2. 最后那条 `ls` 匹配不到今天的文件（当然匹配不到，简报还没写）→ exit 2；
3. `2>/dev/null` 只吞 stderr，**退出码一个字没动**。

于是 exec 回 `isError: true` → 整轮 cron 记 error，末尾那句 `postflight pass / wechat_sent: true / commit_ok: true` 被丢掉。那天简报 08:08 就写好了，`0f341eac memory: daily deep brief 2026-09-02` 已入库、微信已投。**纯假红。**

## 全表量化

翻 `cron_run_logs`（07-21 起 **3221 次运行 / 47 次 `Exec failed`**）：

| 家族 | 次数 | |
|---|---|---|
| `clawock calendar` 退出码闸 | 27 | #1429 已修 |
| **探测型 `;` 链（本 PR）** | **7** | brief 08-10/08-18/09-02 · report 08-10×2/08-14 · intraday 07-30 |
| 真失败（report postflight ×3、intraday_postflight、heredoc、agent 子调用） | 13 | 真的坏过 |

链尾那条命令分别是 `ls` 一个还没写的 glob、`grep` 一个还没出现的词、读一个不存在的 `.claim.json`、`ls` 一个不存在的目录——形状全同。

## 改动

- 规则进**三个 payload**（brief / report / intraday），不只是 brief——这一族三个都中过。
- 三个 profile 的 `required_substrings` 各钉一份；contract 测试同时断言「修的是**退出码**而不是 `2>/dev/null`」那半句还在（那半句才是从没工作过的部分）。
- 第 11 个 job（Memory Dreaming Promotion）的 message 是 openclaw 自己的固定哨兵串 `__openclaw_memory_core_short_term_promotion_dream__`，不是我们写的文本，无处可加也不需要——测试里只覆盖三个 profile。
- 顺手把 brief.md 那个「**两条**硬约束」的标题改成「硬约束」：它底下早就是四条了，数字自己在撒谎。

## 这条规则有多强，说清楚

**它靠模型自觉，只把概率压下去，不是闸。** 真正的闸要在 openclaw 侧把「一次已恢复的工具错误」和「整轮失败」分开，不在本仓库。

另外这 7 次假红**没骗过任何闸**——`cron_health_check.py` 判简报健康看的是当天有没有 commit，不看 run 的颜色。骗的是翻 run feed 的人。

## 验证

521 passed（`-k "cron or payload or contract or schedul"`）；`generate_cron_docs.py` 重跑无 diff；渲染后 11 个 job 里 10 个带上这条规则，缺的那个就是上面说的哨兵串 job。

合并后需在 live 跑 `ops/host/sync_cron_payloads.py --apply`。

https://claude.ai/code/session_01UT4UbT7X7nGXS5gpRT2qYW