### PR TITLE
tests: peer 残差「无未挣得的规则」断言钉错了东西——规则按规矩解锁，master 就红了

### DIFF
--- a/tests/test_peer_residual_engine.py
+++ b/tests/test_peer_residual_engine.py
@@ -175,16 +175,60 @@ def test_registered_rule_contract_keeps_hk_automatic_discovery_disabled():
 
 
 def test_checked_in_peer_artifact_has_no_unearned_live_rule():
+    """What the name says: nothing is usable that did not EARN it.
+
+    The first version asserted that nothing was usable at all — a proxy that
+    held only while no rule had cleared its gate. On 2026-09-11 the daily brief
+    commit refreshed this artifact with `leader_continuation` crossing its 24th
+    prospective date (every check true, `blockers: []`) and master went red on
+    a data commit, with the rule having done exactly what `activate_rules` was
+    pre-registered to let it do. Same family as pinning today's holdings in an
+    assertion: a statement about the current contents is not an invariant.
+
+    The invariant is the gate itself, and it must hold with zero active rules
+    or with all of them: a usable rule has every check passed and no blocker,
+    and a usable live row names only rules that are active.
+    """
     artifact = json.loads(
         (ROOT / "assets" / "data" / "peer_residual.json").read_text()
     )
 
     assert artifact["taxonomy"]["automatic_hk_peer_discovery"] is False
-    assert all(
-        state["usable_for_decisions"] is False
-        for state in artifact["rule_activation"].values()
-    )
-    assert all(
-        row["usable_for_decisions"] is False
-        for row in artifact["live"].values()
-    )
+
+    activation = artifact["rule_activation"]
+    for rule, state in activation.items():
+        if state["usable_for_decisions"]:
+            assert state["active"] is True, rule
+            assert state["blockers"] == [], rule
+            assert all(state["checks"].values()), rule
+            assert state["checks"]["hk_automatic_discovery_disabled"] is True, rule
+        else:
+            assert state["blockers"], f"{rule} is unusable with no blocker named"
+
+    active = {rule for rule, state in activation.items() if state["active"]}
+    for ticker, row in artifact["live"].items():
+        usable = set(row.get("usable_rules") or [])
+        assert usable <= active, f"{ticker} borrows an unearned rule: {usable - active}"
+        assert usable <= set(row.get("triggered_rules") or []), ticker
+        assert row["usable_for_decisions"] is bool(usable), ticker
+
+
+def test_the_activation_gate_refuses_a_rule_one_date_short():
+    """The rule that went live on 2026-09-11 was blocked by `dates` alone the
+    day before (23 of 24). Pin that the gate says so — the checked-in artifact
+    only ever shows one side of the line."""
+    config = json.loads((ROOT / "config" / "peer-residual-rules.json").read_text())
+    need = config["activation_criteria"]["min_prospective_dates"]
+    summary = {
+        "n_dates": need - 1, "n_tickers": 10,
+        "signed_residual_ci95": [0.0047, 0.0618], "hit_rate_ci95": [0.5167, 0.8904],
+    }
+
+    short = peer.activate_rules(config, {"leader_continuation": summary})
+    enough = peer.activate_rules(
+        config, {"leader_continuation": {**summary, "n_dates": need}})
+
+    assert short["leader_continuation"]["blockers"] == ["dates"]
+    assert short["leader_continuation"]["usable_for_decisions"] is False
+    assert enough["leader_continuation"]["blockers"] == []
+    assert enough["leader_continuation"]["usable_for_decisions"] is True


### PR DESCRIPTION
## 发生了什么

master 从 2026-09-11 00:12 UTC（每日简报的数据提交）起一直红，一个测试：`test_checked_in_peer_artifact_has_no_unearned_live_rule`。没人改代码。

那次提交刷新了 `assets/data/peer_residual.json`，其中 `leader_continuation` 这条预注册规则**按设计解锁了**：

| | 09-10 | 09-11 |
|---|---|---|
| 前瞻日期 `n_dates` | 23 | **24**（门槛 ≥24） |
| blockers | `["dates"]` | `[]` |
| signed residual CI95 | [+0.48%, +6.18%] | [+0.66%, +6.36%] |
| hit rate CI95 | [51.7%, 89.0%] | [54.0%, 89.3%] |
| usable_for_decisions | false | **true**（ROBN / CRCL / SKHY 三行） |

前瞻样本：81 events / 10 tickers，date×ticker 两路 cluster bootstrap。

## 为什么是测试错了，不是数据错了

测试名说「没有**未挣得**的规则」，实现断言「没有**任何**规则可用」——只在还没有规则过闸时成立的代理。今天有规则按 `activate_rules` 的预注册标准挣到了，代理就翻了。同一族：断言点名今天的持仓 / 靠内容量才成立的断言不是断言。

## 改成断言闸本身（0 条或全部活跃时都成立）

- 可用的规则：`active`、所有 check 为真、无 blocker；
- 不可用的规则：必须点名至少一个 blocker；
- 可用的行：`usable_rules` ⊆ 活跃规则 ⊆ 该行的 `triggered_rules`，且 `usable_for_decisions` 与之一致。

外加 `test_the_activation_gate_refuses_a_rule_one_date_short`：用 09-10 的真实数字，差一个日期必须被 `dates` 挡住、够了必须放行（checked-in 产物永远只展示线的一侧）。

验过会红：让 CRCL 借一条未活跃的 `mean_reversion` ⇒ `CRCL borrows an unearned rule`。

## 给 kcn 的提醒（不在这个 PR 的范围里）

规则刚好卡在 24 日期的最低线上，而 retrospective 诊断（60 个日期）**不支持**它（signed CI 跨 0、hit CI 下沿 41%）。闸是预注册的、它过了，所以这里不推翻；但值得盯着接下来几周的前瞻结果。

https://claude.ai/code/session_01YYr5ivRkD3NsJtxZoUAjrE