### PR TITLE
brief 页：每个小节一张卡，散文不再塞表格——手机上「理由」整列在屏幕外

### DIFF
--- a/memory/2026-09-07-pre-open.md
+++ b/memory/2026-09-07-pre-open.md
@@ -6,43 +6,169 @@ description: "clawock 盘前深度简报 2026-09-07：港股 + 美股真实持�
 
 # 盘前深度简报｜2026-09-07 周一 08:03 HKT
 
+<div class="brief-card brief-lede" markdown="1">
+
 book 双视角都亏：USD base 浮亏 5,191 + HKD base 浮亏 40,698。HK leg 72,139 HKD 00100 占 60.12% 触发 single_name 硬闸，07226 占 27.35% 触发 hard_stop + leveraged_exposure 双闸；US leg 3,641 USD SPCH 占 81.32% 触发 hard_stop + single_name + leveraged + beta 四闸，RKLX 占 4.16% 触发 hard_stop。8 条 breach 中 5 条 decision_overdue (RKLX 54d、07226 25d、SPCH single_name 54d、US leveraged 54d、HK leveraged 54d) 全部站在 threshold_days=10d 之外且 override 字段从未启用。今日 5 笔 risk_rebalance 与 9/4 高度同构：cut RKLX + cut SPCH 配 buy SPCX + cut 07226 配 buy 03033 + trim 00100 1 lot，本质同一组纪律重复触发；区别在 SPCH 硬止损 0d 新触发、00100 单名 breach 3d 仍未执行 9/4 trim。core thesis（00100 ARR $800M、02208 风电、CRCL stablecoin、SKHY HBM、SPCX SpaceX 1x）未破，5 笔 risk_rebalance 全走 risk_rule 不受 risk_on HOLD 默认豁免。
 
 **反方**：5 笔 risk_rebalance 与 9/4 plan 同构 → 写而不砍的可能性高：纪律账本显示 5/8 breach decision_overdue，override 字段 8 条全部 status=none，没有一条「看见了、决定不做」的留痕。最强反方论点不是「该砍」而是「该不该再写一遍」：同一条砍单发了多次、执行 0 次、override 没用过，账本读起来像「没人看」，但实际是「有人每天看、每天决定不做」。如果今天仍然不执行，5 笔 risk_rebalance 与 9/4 计划完全重合再发一次会形成 daily 噪音；如果执行，4 重 SPCH breach + 3 重 07226 breach + RKLX 1 重 + 00100 single_name 1 重 共 9 重 breach 一次性同步关闭。第二个反方是 swap_mandate 不彻底：07226 cut 释放 19,728 HKD，03033 packet max_add 1000 股只能吸 4,484 HKD（23%），剩 76% 现金；SPCH cut 释放 2,961 USD，SPCX packet max_add 1 股只能吸 148 USD（5%），剩 95% 现金。换仓名义上保留敞口，实际大量现金留 CPI/FOMC 部署窗口，本质是一次 partial 缩表而非完整 swap。第三个反方是 core_position 层面 9 笔 episode 胜率 79.3% 是当前最强 edge（CI [0.62, 0.90] significant），但本轮 5 笔 risk_rebalance + 1 笔 trim 全是 policy 而非择时，reflections 经验上看 risk_rule 6 战 3 胜 50% CI 跨 0.5 不显著，与 core edge 不可比。
 
+</div>
+
 ## 今天做什么
+
+<div class="brief-card" markdown="1">
 
 ### 今日动作
 
-| Ticker | Action | Frame | Strategy | driven_by | 理由 |
-|---|---|---|---|---|---|
-| 07226 | **cut** | technical_breakdown + relative_strength | risk_rebalance | risk_rule | 三重硬闸同时触发：硬止损 -27.1% ≤ -18% 线 (breach risk-4ab7eff27f15 critical)、HK 杠杆 ETF 27.3% > 25% cap (breach risk-da9861ae6562)、HK lev_regime amber (cap ×0.5=25%)。cut 全仓 6200 股释放 19,728 HKD，配同 transaction_group_id add 03033 5 lot = 1000 股 4,484 HKD 同因子换仓，保留 HSTECH 敞口停 2x 日内重置 chop drag (~0.42%/月)。剩余现金 15,244 HKD 留 9/11 CPI + 9/16 FOMC 部署。 |
-| 03033 | **add_only_on_trigger** | sector_rotation | risk_rebalance | risk_rule | swap_mandate 授权的 1x 同因子换仓买腿 (breach risk-4ab7eff27f15)；不需技术 setup，风控规则即授权。1 lot 200 股 = packet max_add 200 上限；买完 03033/HK 由 6.2% 升至 7.4%，与 03032 合计 HSTECH 1x 敞口 8.6%，杠杆 ETF 净敞口由 27.3% 降至 0%。 |
-| SPCH | **cut** | technical_breakdown + mean_reversion + relative_strength | risk_rebalance | risk_rule | 四重硬闸同时触发：硬止损 -18.2% ≤ -18% 线 (breach risk-95ac7f6cd591 critical, 0d)、单名 81.32% > 35% mandatory cap (breach risk-66a236e9b7e1 high, 54d)、US 杠杆 85.5% > 50% (breach risk-80e3b5a6819f high, 54d)、US β 5.53 > 3.0 (breach risk-66b800a6afe2 high, 3d)。cut 全仓 300 股释放 2,961 USD，配同 transaction_group_id add SPCX 1 股 147.95 USD 同因子换仓；剩余 2,813 USD 现金。SPCH 5d +8.2% 反弹窗口已开，借此切。 |
-| SPCX | **add_only_on_trigger** | sector_rotation | risk_rebalance | risk_rule | swap_mandate 授权的 1x 同因子换仓买腿 (breach risk-95ac7f6cd591)；不需技术 setup，风控规则即授权。1 股 = packet max_add 1 上限；买完 SPCX 持仓由 1 股升至 2 股，cash 2,813 USD 留宏观部署。 |
-| RKLX | **cut** | technical_breakdown + mean_reversion | risk_rebalance | risk_rule | 硬止损 -69.6% ≤ -18% 线 (breach risk-0a0af7ae3b3a critical, 54d decision_overdue)；breakeven 需 +228.4% 5-sigma 不可达；横盘 chop drag 1.2%/月每天烧钱。RKLB 6/13 已清仓 swap_mandate=null → 无 1x 替代，纯 cut 释放 151 USD 现金。RKLX 5d -1.2% 跑输 RKLB 5d -0.2% 是 2x chop drag 主导。 |
-| 00100 | **trim_on_rebound** | technical_breakdown + relative_strength | risk_rebalance | risk_rule | 单名 60.12% > 60% mandatory cap (breach risk-2a450e7c896e high, 3d)，9/4 plan trim 1 lot ≥365 未执行；今日重复同决策，借 5d +20.3% 反弹窗口。1 lot 减 7,300 HKD 把 00100/HK 拉到 55.7%（cap 内 4.3pp 缓冲）。降 β 优先削杠杆 ETF，00100 是单票不是杠杆，这里只解 single_name 硬闸，不动 thesis（M3 Pro 9-10 月 + ARR >$800M 仍是 hard catalyst confirming）。 |
-| 02208 | **hold_and_watch** | mean_reversion | core_position | technical | 02208 reflections 持×17 胜5 = 32% book 最差，主动 call 多半跑不赢持有；趋势 off 阻挡 add；1-7 月装机 +19.5% + 累计回购 1302 万股耗资 3 亿是 supporting 已价；JPM 减持 1.08% 是软利空已部分消化 (5d -6.2%)。仓位 3,646 HKD 占 book 5.05% 不催主动 call，维持 hold。 |
-| 03032 | **hold_and_watch** | sector_rotation | core_position | technical | 03032 reflections 持×16 胜5 = 31% book 较差但 1x ETF 跟踪误差小不需要主动加减；仓位 912 HKD 占 book 1.26% 太小不值得动；维持 hold 等待趋势确认。9/7 小米发布会是潜在催化但对 1x 贡献极微。 |
-| CRCL | **hold_and_watch** | mean_reversion + sentiment_shift | core_position | technical | CRCL reflections 持×16 胜10 = 63% book 第三高；5d +17.1% 反弹 + 9/3 +15.16% GENIUS/CLARITY 听证会是 hard catalyst confirming 已价；但 5d +17.1% 极端位置有回调风险；21 家国际机构联合发稳定币 2027 H1 是长期软利空；内部人 sell 7,458 股。仓位 204 USD 占 book 5.61% 仅 2 股，1 股加减不抵交易成本，维持 hold。 |
-| SKHY | **hold_and_watch** | sector_rotation | core_position | technical | SKHY 5d +9.9% 反弹区间位置 92.9% 顶部属追高低质；HBM 板块双向不确定 (美光台湾罢工投票 + 长鑫 IPO 全球市占率 10%)；SK 海力士 CEO 称存储短缺到 2030 是 supporting 长期；reflections 持×10 胜6 = 60% book 中位。仓位 177 USD 占 book 4.86% 仅 1 股，1 股加减不抵交易成本，维持 hold。同业 STX 9/4 +6.34% / MU +6.1% / WDC +5.86% 集体强，SKHY 5d +9.9% 是 peer leader。 |
-| 03033 | **hold_and_watch** | sector_rotation | core_position | technical | 03033 reflections 持×14 胜4 = 36% book 较差；1x ETF 跟踪 HSTECH 与 03032 几乎一致。现有 1,000 股维持 hold（仓位 4,484 HKD 占 book 6.22%）；07226 swap 配套 buy 5 lot = 1,000 股另由独立 decision 处理 (add_only_on_trigger, 共享 transaction_group_id swap-07226-03033-20260907)。买完 03033 单名 13.0% HK leg 接近单名 review 35%，仍安全。 |
+<div class="brief-entries" markdown="1">
+
+- **07226** · **cut**
+
+  <span class="entry-meta">technical_breakdown + relative_strength · risk_rebalance · risk_rule</span>
+
+  **理由**　三重硬闸同时触发：硬止损 -27.1% ≤ -18% 线 (breach risk-4ab7eff27f15 critical)、HK 杠杆 ETF 27.3% > 25% cap (breach risk-da9861ae6562)、HK lev_regime amber (cap ×0.5=25%)。cut 全仓 6200 股释放 19,728 HKD，配同 transaction_group_id add 03033 5 lot = 1000 股 4,484 HKD 同因子换仓，保留 HSTECH 敞口停 2x 日内重置 chop drag (~0.42%/月)。剩余现金 15,244 HKD 留 9/11 CPI + 9/16 FOMC 部署。
+
+- **03033** · **add_only_on_trigger**
+
+  <span class="entry-meta">sector_rotation · risk_rebalance · risk_rule</span>
+
+  **理由**　swap_mandate 授权的 1x 同因子换仓买腿 (breach risk-4ab7eff27f15)；不需技术 setup，风控规则即授权。1 lot 200 股 = packet max_add 200 上限；买完 03033/HK 由 6.2% 升至 7.4%，与 03032 合计 HSTECH 1x 敞口 8.6%，杠杆 ETF 净敞口由 27.3% 降至 0%。
+
+- **SPCH** · **cut**
+
+  <span class="entry-meta">technical_breakdown + mean_reversion + relative_strength · risk_rebalance · risk_rule</span>
+
+  **理由**　四重硬闸同时触发：硬止损 -18.2% ≤ -18% 线 (breach risk-95ac7f6cd591 critical, 0d)、单名 81.32% > 35% mandatory cap (breach risk-66a236e9b7e1 high, 54d)、US 杠杆 85.5% > 50% (breach risk-80e3b5a6819f high, 54d)、US β 5.53 > 3.0 (breach risk-66b800a6afe2 high, 3d)。cut 全仓 300 股释放 2,961 USD，配同 transaction_group_id add SPCX 1 股 147.95 USD 同因子换仓；剩余 2,813 USD 现金。SPCH 5d +8.2% 反弹窗口已开，借此切。
+
+- **SPCX** · **add_only_on_trigger**
+
+  <span class="entry-meta">sector_rotation · risk_rebalance · risk_rule</span>
+
+  **理由**　swap_mandate 授权的 1x 同因子换仓买腿 (breach risk-95ac7f6cd591)；不需技术 setup，风控规则即授权。1 股 = packet max_add 1 上限；买完 SPCX 持仓由 1 股升至 2 股，cash 2,813 USD 留宏观部署。
+
+- **RKLX** · **cut**
+
+  <span class="entry-meta">technical_breakdown + mean_reversion · risk_rebalance · risk_rule</span>
+
+  **理由**　硬止损 -69.6% ≤ -18% 线 (breach risk-0a0af7ae3b3a critical, 54d decision_overdue)；breakeven 需 +228.4% 5-sigma 不可达；横盘 chop drag 1.2%/月每天烧钱。RKLB 6/13 已清仓 swap_mandate=null → 无 1x 替代，纯 cut 释放 151 USD 现金。RKLX 5d -1.2% 跑输 RKLB 5d -0.2% 是 2x chop drag 主导。
+
+- **00100** · **trim_on_rebound**
+
+  <span class="entry-meta">technical_breakdown + relative_strength · risk_rebalance · risk_rule</span>
+
+  **理由**　单名 60.12% > 60% mandatory cap (breach risk-2a450e7c896e high, 3d)，9/4 plan trim 1 lot ≥365 未执行；今日重复同决策，借 5d +20.3% 反弹窗口。1 lot 减 7,300 HKD 把 00100/HK 拉到 55.7%（cap 内 4.3pp 缓冲）。降 β 优先削杠杆 ETF，00100 是单票不是杠杆，这里只解 single_name 硬闸，不动 thesis（M3 Pro 9-10 月 + ARR >$800M 仍是 hard catalyst confirming）。
+
+- **02208** · **hold_and_watch**
+
+  <span class="entry-meta">mean_reversion · core_position · technical</span>
+
+  **理由**　02208 reflections 持×17 胜5 = 32% book 最差，主动 call 多半跑不赢持有；趋势 off 阻挡 add；1-7 月装机 +19.5% + 累计回购 1302 万股耗资 3 亿是 supporting 已价；JPM 减持 1.08% 是软利空已部分消化 (5d -6.2%)。仓位 3,646 HKD 占 book 5.05% 不催主动 call，维持 hold。
+
+- **03032** · **hold_and_watch**
+
+  <span class="entry-meta">sector_rotation · core_position · technical</span>
+
+  **理由**　03032 reflections 持×16 胜5 = 31% book 较差但 1x ETF 跟踪误差小不需要主动加减；仓位 912 HKD 占 book 1.26% 太小不值得动；维持 hold 等待趋势确认。9/7 小米发布会是潜在催化但对 1x 贡献极微。
+
+- **CRCL** · **hold_and_watch**
+
+  <span class="entry-meta">mean_reversion + sentiment_shift · core_position · technical</span>
+
+  **理由**　CRCL reflections 持×16 胜10 = 63% book 第三高；5d +17.1% 反弹 + 9/3 +15.16% GENIUS/CLARITY 听证会是 hard catalyst confirming 已价；但 5d +17.1% 极端位置有回调风险；21 家国际机构联合发稳定币 2027 H1 是长期软利空；内部人 sell 7,458 股。仓位 204 USD 占 book 5.61% 仅 2 股，1 股加减不抵交易成本，维持 hold。
+
+- **SKHY** · **hold_and_watch**
+
+  <span class="entry-meta">sector_rotation · core_position · technical</span>
+
+  **理由**　SKHY 5d +9.9% 反弹区间位置 92.9% 顶部属追高低质；HBM 板块双向不确定 (美光台湾罢工投票 + 长鑫 IPO 全球市占率 10%)；SK 海力士 CEO 称存储短缺到 2030 是 supporting 长期；reflections 持×10 胜6 = 60% book 中位。仓位 177 USD 占 book 4.86% 仅 1 股，1 股加减不抵交易成本，维持 hold。同业 STX 9/4 +6.34% / MU +6.1% / WDC +5.86% 集体强，SKHY 5d +9.9% 是 peer leader。
+
+- **03033** · **hold_and_watch**
+
+  <span class="entry-meta">sector_rotation · core_position · technical</span>
+
+  **理由**　03033 reflections 持×14 胜4 = 36% book 较差；1x ETF 跟踪 HSTECH 与 03032 几乎一致。现有 1,000 股维持 hold（仓位 4,484 HKD 占 book 6.22%）；07226 swap 配套 buy 5 lot = 1,000 股另由独立 decision 处理 (add_only_on_trigger, 共享 transaction_group_id swap-07226-03033-20260907)。买完 03033 单名 13.0% HK leg 接近单名 review 35%，仍安全。
+
+</div>
+
+</div>
+
+<div class="brief-card" markdown="1">
 
 ### 信心与判定
 
-| Ticker | Action | Confidence | Verdict | 理由 | 证伪条件 |
-|---|---|---|---|---|---|
-| 07226 | cut | 92% | <span class="verdict verdict-bearish">🔴 看空</span> | 硬止损 + 单名超限 + 杠杆超限 三闸同时，breach 站 25 天 decision_overdue；2x 日内重置 chop drag 每月白付 0.42% decay；breakeven 37.1% 半年窗含 drag 等效标的需 18.6% 难现。swap_mandate 授权 buy 03033 同 transaction_group_id 保留 HSTECH 敞口停 2x chop drag。 | HSTECH 周一跳空高开收复 200 日线 5093 + 20d vol < 50% → breach 缓解可改 trim_on_rebound 收 300 股底仓；但 2x 杠杆敞口仍须 ≤25% |
-| 03033 | add_only_on_trigger | 90% | <span class="verdict verdict-neutral">⚪ 中性</span> | swap_mandate 授权的 1x 同因子换仓买腿（breach risk-4ab7eff27f15）；不需技术 setup，风控规则即授权；HSTECH +2.27% 反弹给支撑；9 月招商证券 AI 利润迁移研报是 supporting。disposition 保持 wait 是因为 swap-mandate 是政策型 add，不能升级 packet 的 non-candidate 判定。 | HSTECH 9/7 继续破 4569 支撑 → 暂缓第二批 buy，1x 03033 不抢跌 |
-| SPCH | cut | 92% | <span class="verdict verdict-bearish">🔴 看空</span> | 4 重 breach 同步；硬止损 0d 全新触发；breakeven 22.2% 1x 容易但 2x 难；2x 日内重置 chop drag 每天烧钱。swap_mandate 授权 buy SPCX 同 transaction_group_id 保留 SpaceX 主题敞口。 | 若 SpaceX 9/8 公布 Starship 14 次试飞轨道入轨成功 + Starlink IPO 时间表确认 → 重新评估 1x SPCX 底仓（但要等 breach 全解） |
-| SPCX | add_only_on_trigger | 88% | <span class="verdict verdict-neutral">⚪ 中性</span> | 1x SpaceX 个股 + 流动性差 + Musk 风险；reflections 40% 胜率不催主动 call；SPCH swap 配套 buy 1 股 148 USD 由风控规则授权 atomic；仓位太小不催。swap-mandate 政策型 add 不升级 packet 的 non-candidate 判定，disposition 保持 wait。 | Starship 14 次试飞成功 + Starlink IPO 时间表确认 + Musk 风险定价重估 → 评估 add；试飞失败 → 评估 hard cut |
-| RKLX | cut | 95% | <span class="verdict verdict-bearish">🔴 看空</span> | 硬止损 + breakeven 5-sigma 不可达 + 横盘 chop drag 1.2%/月每天烧钱 + RKLB 6/13 已清仓 → 必须 cut 全仓；reflections 9 次清仓 6 胜 67% 是当前唯一可执行路径。 | 若 Q4 Neutron 公告 / 国防合同 + RKLB 9/8 跳空 +15% → RKLX 同步反弹 30%，但纪律优先于择时；保留 cut 决策 |
-| 00100 | trim_on_rebound | 72% | <span class="verdict verdict-neutral">⚪ 中性</span> | 00100 reflections 9 次减仓 7 胜 78% 是当前最强 peer-set trim 历史；9/4 trim 1 lot ≥365 触发价 365 今日 361.4 收盘未站上但 5d 反弹 395 给的成交价区间有支撑；今日重复同 trim 决策，借 5d 反弹窗口。 | M3 Pro 9-10 月确认跳票 / 智谱 02513 同业继续跑输（5d -1.4% 已弱）/ 港股通 9/3 净买入 33.95 亿资金 9/7 撤出 / trim 触发价 ≤340 持续 3 日 → 暂停 trim 转为 hold_and_watch 评估 thesis 失效 |
-| 02208 | hold_and_watch | 55% | <span class="verdict verdict-neutral">⚪ 中性</span> | 02208 不在 hard catalyst 列表中，仓位 3,646 HKD 占 book 5.05% 仅 400 股；reflections 历史胜率低不催主动 call；维持 hold 等技术止跌与 8 月装机数据。 | 8 月装机大幅回落 / JPM 继续减持 / 趋势破 9.00 → 重新评估 hard cut |
-| 03032 | hold_and_watch | 50% | <span class="verdict verdict-neutral">⚪ 中性</span> | 03032 与 03033 跟踪同一指数，07226 swap 完 03033 才是 1x 主力，03032 冗余但不动；仓位太小不值得动。 | HSTECH 跳空高开收复 200 日线 5093 + 9/7 小米发布会催化 + 南向资金持续净买入 → 评估 add 1 lot |
-| CRCL | hold_and_watch | 55% | <span class="verdict verdict-neutral">⚪ 中性</span> | 5d +17.1% + z 极端位置有回调风险；不在 hard catalyst 列表中；仓位太小不催主动 call；维持 hold。 | 21 家机构联合稳定币 2027 H1 抢份额兑现 / 内部人 sell 加速 / Q3 EPS miss → 重新评估 hard cut |
-| SKHY | hold_and_watch | 50% | <span class="verdict verdict-neutral">⚪ 中性</span> | HBM 板块双向不确定；仓位 177 USD 占 book 4.86% 仅 1 股，1 股加减不抵交易成本；维持 hold。 | 美光台湾罢工停工 + 长鑫 LPDDR6 量产挤压市占 / HBM 价格战 / 9/4 区间顶部 92.9% 失守 → 重新评估 hard cut |
-| 03033 | hold_and_watch | 50% | <span class="verdict verdict-neutral">⚪ 中性</span> | swap_mandate 授权的 1x 同因子换仓买腿（breach risk-4ab7eff27f15）；不需技术 setup，风控规则即授权；HSTECH +2.27% 反弹给支撑；9 月招商证券 AI 利润迁移研报是 supporting。disposition 保持 wait 是因为 swap-mandate 是政策型 add，不能升级 packet 的 non-candidate 判定。 | HSTECH 9/7 继续破 4569 支撑 → 暂缓第二批 buy，1x 03033 不抢跌 |
+<div class="brief-entries" markdown="1">
+
+- **07226** · cut · 信心 92% · <span class="verdict verdict-bearish">🔴 看空</span>
+
+  **理由**　硬止损 + 单名超限 + 杠杆超限 三闸同时，breach 站 25 天 decision_overdue；2x 日内重置 chop drag 每月白付 0.42% decay；breakeven 37.1% 半年窗含 drag 等效标的需 18.6% 难现。swap_mandate 授权 buy 03033 同 transaction_group_id 保留 HSTECH 敞口停 2x chop drag。
+
+  **证伪条件**　HSTECH 周一跳空高开收复 200 日线 5093 + 20d vol < 50% → breach 缓解可改 trim_on_rebound 收 300 股底仓；但 2x 杠杆敞口仍须 ≤25%
+
+- **03033** · add_only_on_trigger · 信心 90% · <span class="verdict verdict-neutral">⚪ 中性</span>
+
+  **理由**　swap_mandate 授权的 1x 同因子换仓买腿（breach risk-4ab7eff27f15）；不需技术 setup，风控规则即授权；HSTECH +2.27% 反弹给支撑；9 月招商证券 AI 利润迁移研报是 supporting。disposition 保持 wait 是因为 swap-mandate 是政策型 add，不能升级 packet 的 non-candidate 判定。
+
+  **证伪条件**　HSTECH 9/7 继续破 4569 支撑 → 暂缓第二批 buy，1x 03033 不抢跌
+
+- **SPCH** · cut · 信心 92% · <span class="verdict verdict-bearish">🔴 看空</span>
+
+  **理由**　4 重 breach 同步；硬止损 0d 全新触发；breakeven 22.2% 1x 容易但 2x 难；2x 日内重置 chop drag 每天烧钱。swap_mandate 授权 buy SPCX 同 transaction_group_id 保留 SpaceX 主题敞口。
+
+  **证伪条件**　若 SpaceX 9/8 公布 Starship 14 次试飞轨道入轨成功 + Starlink IPO 时间表确认 → 重新评估 1x SPCX 底仓（但要等 breach 全解）
+
+- **SPCX** · add_only_on_trigger · 信心 88% · <span class="verdict verdict-neutral">⚪ 中性</span>
+
+  **理由**　1x SpaceX 个股 + 流动性差 + Musk 风险；reflections 40% 胜率不催主动 call；SPCH swap 配套 buy 1 股 148 USD 由风控规则授权 atomic；仓位太小不催。swap-mandate 政策型 add 不升级 packet 的 non-candidate 判定，disposition 保持 wait。
+
+  **证伪条件**　Starship 14 次试飞成功 + Starlink IPO 时间表确认 + Musk 风险定价重估 → 评估 add；试飞失败 → 评估 hard cut
+
+- **RKLX** · cut · 信心 95% · <span class="verdict verdict-bearish">🔴 看空</span>
+
+  **理由**　硬止损 + breakeven 5-sigma 不可达 + 横盘 chop drag 1.2%/月每天烧钱 + RKLB 6/13 已清仓 → 必须 cut 全仓；reflections 9 次清仓 6 胜 67% 是当前唯一可执行路径。
+
+  **证伪条件**　若 Q4 Neutron 公告 / 国防合同 + RKLB 9/8 跳空 +15% → RKLX 同步反弹 30%，但纪律优先于择时；保留 cut 决策
+
+- **00100** · trim_on_rebound · 信心 72% · <span class="verdict verdict-neutral">⚪ 中性</span>
+
+  **理由**　00100 reflections 9 次减仓 7 胜 78% 是当前最强 peer-set trim 历史；9/4 trim 1 lot ≥365 触发价 365 今日 361.4 收盘未站上但 5d 反弹 395 给的成交价区间有支撑；今日重复同 trim 决策，借 5d 反弹窗口。
+
+  **证伪条件**　M3 Pro 9-10 月确认跳票 / 智谱 02513 同业继续跑输（5d -1.4% 已弱）/ 港股通 9/3 净买入 33.95 亿资金 9/7 撤出 / trim 触发价 ≤340 持续 3 日 → 暂停 trim 转为 hold_and_watch 评估 thesis 失效
+
+- **02208** · hold_and_watch · 信心 55% · <span class="verdict verdict-neutral">⚪ 中性</span>
+
+  **理由**　02208 不在 hard catalyst 列表中，仓位 3,646 HKD 占 book 5.05% 仅 400 股；reflections 历史胜率低不催主动 call；维持 hold 等技术止跌与 8 月装机数据。
+
+  **证伪条件**　8 月装机大幅回落 / JPM 继续减持 / 趋势破 9.00 → 重新评估 hard cut
+
+- **03032** · hold_and_watch · 信心 50% · <span class="verdict verdict-neutral">⚪ 中性</span>
+
+  **理由**　03032 与 03033 跟踪同一指数，07226 swap 完 03033 才是 1x 主力，03032 冗余但不动；仓位太小不值得动。
+
+  **证伪条件**　HSTECH 跳空高开收复 200 日线 5093 + 9/7 小米发布会催化 + 南向资金持续净买入 → 评估 add 1 lot
+
+- **CRCL** · hold_and_watch · 信心 55% · <span class="verdict verdict-neutral">⚪ 中性</span>
+
+  **理由**　5d +17.1% + z 极端位置有回调风险；不在 hard catalyst 列表中；仓位太小不催主动 call；维持 hold。
+
+  **证伪条件**　21 家机构联合稳定币 2027 H1 抢份额兑现 / 内部人 sell 加速 / Q3 EPS miss → 重新评估 hard cut
+
+- **SKHY** · hold_and_watch · 信心 50% · <span class="verdict verdict-neutral">⚪ 中性</span>
+
+  **理由**　HBM 板块双向不确定；仓位 177 USD 占 book 4.86% 仅 1 股，1 股加减不抵交易成本；维持 hold。
+
+  **证伪条件**　美光台湾罢工停工 + 长鑫 LPDDR6 量产挤压市占 / HBM 价格战 / 9/4 区间顶部 92.9% 失守 → 重新评估 hard cut
+
+- **03033** · hold_and_watch · 信心 50% · <span class="verdict verdict-neutral">⚪ 中性</span>
+
+  **理由**　swap_mandate 授权的 1x 同因子换仓买腿（breach risk-4ab7eff27f15）；不需技术 setup，风控规则即授权；HSTECH +2.27% 反弹给支撑；9 月招商证券 AI 利润迁移研报是 supporting。disposition 保持 wait 是因为 swap-mandate 是政策型 add，不能升级 packet 的 non-candidate 判定。
+
+  **证伪条件**　HSTECH 9/7 继续破 4569 支撑 → 暂缓第二批 buy，1x 03033 不抢跌
+
+</div>
+
+</div>
+
+<div class="brief-card" markdown="1">
 
 ### 下一节点
 
@@ -52,7 +178,11 @@ book 双视角都亏：USD base 浮亏 5,191 + HKD base 浮亏 40,698。HK leg 7
 4. 21:30 HKT US 复盘（9/8 周一）：监控 SPCH / SPCX swap 配套是否成交（US atomic）、RKLX 全仓 10 cut 是否执行；查 9/9 SpaceX 解禁前最新动态；查 NFP 8 月数据 9/5 公布后的市场反应
 5. Friday EOD 09/12：5 笔 risk_rebalance + 2 笔 swap buy + 1 笔 trim 实际执行报告写进 decisions.jsonl；9/11 CPI 后再评估 RKLX 释放 151 USD 现金是否重建 1x 底仓（即使 RKLB 6/13 已清，9/11 CPI 后可重开 entry gate）
 
+</div>
+
 ## 我的看法
+
+<div class="brief-card" markdown="1">
 
 ### 多空对辩
 
@@ -68,6 +198,10 @@ book 双视角都亏：USD base 浮亏 5,191 + HKD base 浮亏 40,698。HK leg 7
 
 攻击的是「5 重 breach 站 25-54 天 + override 字段从未启用 = 纪律层失效」这条最强共识：账本读起来像「没人看」是表象，真相是有人每天看、每天决定不做。RKLX 54 天站岗 1.2%/月 chop drag 已烧掉 50%+ 名义价值（-69.6% 浮亏），breakeven +228.4% 5-sigma 不可达 → 切在反弹中已不可能 → 必须 cut（无 1x 替代）。07226 25 天站岗 0.42%/月 chop drag 已烧掉 9% 名义价值，breakeven 37.1% 半年窗含 drag 18.6% → 必须 swap 而非 hold。SPCH 0d 全新硬止损 -18.2% ≤ -18% + 4 重 breach 同步 → 必须 cut 全仓 swap 1x。纪律不是择时，不能用「再等一天」来解释 54 天站岗。
 
+</div>
+
+<div class="brief-card" markdown="1">
+
 ### 风险官三票
 
 **Aggressive（抓 upside） · 今日首位表态**
@@ -82,22 +216,121 @@ book 双视角都亏：USD base 浮亏 5,191 + HKD base 浮亏 40,698。HK leg 7
 
 对每个争议票必须拍一边：00100 trim 1 lot ≥365 政策型拉回 cap 内并留缓冲（4.3pp）→ 维持 9/4 决策；02208 hold 等 8 月装机数据；03032 hold 冗余但不动；CRCL hold 5d +17.1% 极端不追；SKHY hold HBM 双向不催。5 笔 risk_rebalance 政策型全数维持，0 笔新增主动 call（除 swap 配套 buy）。neutral 主张：今天 plan 与 9/4 plan 同构是必要的纪律重复，不是 noise，但需要 ack 留痕（risk ack）区分「看见了」与「决定不执行」两种状态；如全部 plan 转 risk_rebalance.status=overridden 留痕「纪律不适用」或 risk_rebalance.status=acknowledged 留痕「决定执行」都行，不能再让 breach 站 54d 无任何反馈。
 
+</div>
+
+<div class="brief-card" markdown="1">
+
 ### 分析师四格
 
-| 票 | Market（harness 计算） | Fundamentals | Sentiment | Cross-Market |
-|---|---|---|---|---|
-| 00100 | -34.66% / RSI 57.8 / 趋势OFF | EDGAR 不适用 HK；00100 是 HK 主板，2026 H1 财报已披露，ARR $800M 是 hard catalyst（9/3 已兑现） | 南向资金 9/3 净买入 33.95 亿是 hard catalyst confirming；智谱 9/4 -2.98% 同业弱是 soft 不动 00100 决策；散户温度无 Reddit 数据 | 美股 AI 板块 9/4 软：SPX -0.38% / NDX -0.29% 与 00100 5d +20.3% 反向，港股 AI 板块独立行情；中概互联网（美团 +5.28% / 网易 +3.33% / 京东 +3.27% / 阿里 +2.42% / 腾讯 +2.26%）HSTECH +2.27% 与 00100 +1.8% 共振 |
-| 02208 | -35.28% / RSI 39.3 / 趋势OFF · 已破吊灯止损 / 距 MA200 -30.80% | 1-7 月装机 +19.5% + 累计回购 1302 万股耗资 3 亿是 supporting hard 已价；JPM 减持 1.08% 软利空已部分消化 | JPM 减持 1.08% 是 soft 已部分消化；1-7 月装机 +19.5% 是 hard 已价；散户温度无 Reddit 数据 | 02208 与美股无 cross-market 关联；与同业 00916 / 01798 / 01072 风电板块共振 |
-| 03032 | -15.60% / RSI 43.3 / 趋势OFF · 已破吊灯止损 / 距 MA200 -10.00% | 1x ETF 跟踪 HSTECH 误差小；招商证券研报 soft supporting | 招商证券研报 soft supporting；港股通 9/3 净买入 33.95 亿 hard confirming 但只是日数据 | 03032 跟踪 HSTECH 与美股科技板块关联弱（间接通过 09988 / 00700 等权重股） |
-| 03033 | -12.76% / RSI 43.8 / 趋势OFF · 已破吊灯止损 / 距 MA200 -10.00% | 1x ETF 跟踪 HSTECH 误差小；招商证券研报 soft supporting；9/7 小米发布会潜在催化 | 招商证券研报 soft supporting；港股通 9/3 净买入 33.95 亿 hard confirming | 03033 跟踪 HSTECH 与 03032 几乎一致；HSTECH +2.27% 9/4 反弹领先 SPX -0.38% |
-| 07226 | -27.07% / RSI 43.7 / 趋势OFF · 已破吊灯止损 / 距 MA200 -10.20% | 2x 杠杆 ETF 跟踪 HSTECH 2 倍，招商证券研报 soft supporting；9/7 小米发布会潜在催化 | 招商证券研报 soft supporting；港股通 9/3 净买入 33.95 亿 hard confirming 但只是日数据 | 07226 跟踪 HSTECH 2 倍，HSTECH +2.27% 9/4 反弹；杠杆放大 2x 反向 |
-| CRCL | +17.30% / RSI 67.0 / 趋势OFF / 距 MA200 +19.90% | 持×16 胜10 = 63% book 第三高；GENIUS/CLARITY 听证会 hard 已价；21 家机构联合 long-term 软利空；内部人 sell soft 持续利空 | GENIUS/CLARITY hard 已价；21 家机构联合 long-term 软利空；内部人 sell soft 持续利空 | CRCL 跟踪 Circle 美元稳定币 USDC，与美股无 cross-market 关联；同板块 HOOD 9/4 +16.57% / COIN +10.35% 共振 |
-| RKLX | -69.55% / RSI 37.2 / 趋势OFF · 已破吊灯止损 / 距 MA200 -19.10% | 硬止损 -69.6% ≤ -18% 线；breakeven +228.4% 5-sigma 不可达；横盘 chop drag 1.2%/月 | Q4 Neutron + Trump 太空学院 hard catalyst 链；Musk rel 72 投资者风险口径 soft 利空 | RKLX 跟踪 RKLB 2 倍，RKLB 5d -0.2% 弱；与 SPCH / SPCX 商业航天板块弱关联 |
-| SKHY | +4.62% / RSI 59.3 / 趋势OFF | SK 海力士 CEO 表态支持存储短缺到 2030；美光罢工是 supply risk soft；长鑫 IPO 是市占率 soft | SK 海力士 CEO hard supporting 长期；美光罢工 soft；长鑫 IPO soft | SKHY 与美股科技板块关联弱（间接通过 NVDA / MU HBM 客户）；同板块 STX / MU / WDC 9/4 集体强 |
-| SPCH | -18.16% / RSI 58.5 / 趋势OFF | 硬止损 -18.2% ≤ -18% 线；breakeven 22.2% 1x 容易 2x 难；2x chop drag 月烧 | Trump 太空学院新政 hard 催化；Musk rel 72 投资者风险 soft 利空；Starship 试飞 event-driven | SPCH 跟踪 SPCX 2 倍，SPCX 5d +4.6% 反弹；与 RKLX / RKLB 商业航天板块弱关联 |
-| SPCX | +0.31% / RSI 58.5 / 趋势OFF | 1x SpaceX 个股 + 流动性差 + Musk 风险；reflections 40% 胜率 | Trump 太空学院新政 hard 催化；Musk rel 72 投资者风险 soft 利空；Starship 试飞 event-driven | SPCX 1x 标的与美股科技板块关联弱；同板块 RKLX / RKLB / ASTS 9/4 涨跌参差 |
+<div class="brief-entries" markdown="1">
+
+- **00100**
+
+  <span class="entry-meta">-34.66% / RSI 57.8 / 趋势OFF</span>
+
+  **Fundamentals**　EDGAR 不适用 HK；00100 是 HK 主板，2026 H1 财报已披露，ARR $800M 是 hard catalyst（9/3 已兑现）
+
+  **Sentiment**　南向资金 9/3 净买入 33.95 亿是 hard catalyst confirming；智谱 9/4 -2.98% 同业弱是 soft 不动 00100 决策；散户温度无 Reddit 数据
+
+  **Cross-Market**　美股 AI 板块 9/4 软：SPX -0.38% / NDX -0.29% 与 00100 5d +20.3% 反向，港股 AI 板块独立行情；中概互联网（美团 +5.28% / 网易 +3.33% / 京东 +3.27% / 阿里 +2.42% / 腾讯 +2.26%）HSTECH +2.27% 与 00100 +1.8% 共振
+
+- **02208**
+
+  <span class="entry-meta">-35.28% / RSI 39.3 / 趋势OFF · 已破吊灯止损 / 距 MA200 -30.80%</span>
+
+  **Fundamentals**　1-7 月装机 +19.5% + 累计回购 1302 万股耗资 3 亿是 supporting hard 已价；JPM 减持 1.08% 软利空已部分消化
+
+  **Sentiment**　JPM 减持 1.08% 是 soft 已部分消化；1-7 月装机 +19.5% 是 hard 已价；散户温度无 Reddit 数据
+
+  **Cross-Market**　02208 与美股无 cross-market 关联；与同业 00916 / 01798 / 01072 风电板块共振
+
+- **03032**
+
+  <span class="entry-meta">-15.60% / RSI 43.3 / 趋势OFF · 已破吊灯止损 / 距 MA200 -10.00%</span>
+
+  **Fundamentals**　1x ETF 跟踪 HSTECH 误差小；招商证券研报 soft supporting
+
+  **Sentiment**　招商证券研报 soft supporting；港股通 9/3 净买入 33.95 亿 hard confirming 但只是日数据
+
+  **Cross-Market**　03032 跟踪 HSTECH 与美股科技板块关联弱（间接通过 09988 / 00700 等权重股）
+
+- **03033**
+
+  <span class="entry-meta">-12.76% / RSI 43.8 / 趋势OFF · 已破吊灯止损 / 距 MA200 -10.00%</span>
+
+  **Fundamentals**　1x ETF 跟踪 HSTECH 误差小；招商证券研报 soft supporting；9/7 小米发布会潜在催化
+
+  **Sentiment**　招商证券研报 soft supporting；港股通 9/3 净买入 33.95 亿 hard confirming
+
+  **Cross-Market**　03033 跟踪 HSTECH 与 03032 几乎一致；HSTECH +2.27% 9/4 反弹领先 SPX -0.38%
+
+- **07226**
+
+  <span class="entry-meta">-27.07% / RSI 43.7 / 趋势OFF · 已破吊灯止损 / 距 MA200 -10.20%</span>
+
+  **Fundamentals**　2x 杠杆 ETF 跟踪 HSTECH 2 倍，招商证券研报 soft supporting；9/7 小米发布会潜在催化
+
+  **Sentiment**　招商证券研报 soft supporting；港股通 9/3 净买入 33.95 亿 hard confirming 但只是日数据
+
+  **Cross-Market**　07226 跟踪 HSTECH 2 倍，HSTECH +2.27% 9/4 反弹；杠杆放大 2x 反向
+
+- **CRCL**
+
+  <span class="entry-meta">+17.30% / RSI 67.0 / 趋势OFF / 距 MA200 +19.90%</span>
+
+  **Fundamentals**　持×16 胜10 = 63% book 第三高；GENIUS/CLARITY 听证会 hard 已价；21 家机构联合 long-term 软利空；内部人 sell soft 持续利空
+
+  **Sentiment**　GENIUS/CLARITY hard 已价；21 家机构联合 long-term 软利空；内部人 sell soft 持续利空
+
+  **Cross-Market**　CRCL 跟踪 Circle 美元稳定币 USDC，与美股无 cross-market 关联；同板块 HOOD 9/4 +16.57% / COIN +10.35% 共振
+
+- **RKLX**
+
+  <span class="entry-meta">-69.55% / RSI 37.2 / 趋势OFF · 已破吊灯止损 / 距 MA200 -19.10%</span>
+
+  **Fundamentals**　硬止损 -69.6% ≤ -18% 线；breakeven +228.4% 5-sigma 不可达；横盘 chop drag 1.2%/月
+
+  **Sentiment**　Q4 Neutron + Trump 太空学院 hard catalyst 链；Musk rel 72 投资者风险口径 soft 利空
+
+  **Cross-Market**　RKLX 跟踪 RKLB 2 倍，RKLB 5d -0.2% 弱；与 SPCH / SPCX 商业航天板块弱关联
+
+- **SKHY**
+
+  <span class="entry-meta">+4.62% / RSI 59.3 / 趋势OFF</span>
+
+  **Fundamentals**　SK 海力士 CEO 表态支持存储短缺到 2030；美光罢工是 supply risk soft；长鑫 IPO 是市占率 soft
+
+  **Sentiment**　SK 海力士 CEO hard supporting 长期；美光罢工 soft；长鑫 IPO soft
+
+  **Cross-Market**　SKHY 与美股科技板块关联弱（间接通过 NVDA / MU HBM 客户）；同板块 STX / MU / WDC 9/4 集体强
+
+- **SPCH**
+
+  <span class="entry-meta">-18.16% / RSI 58.5 / 趋势OFF</span>
+
+  **Fundamentals**　硬止损 -18.2% ≤ -18% 线；breakeven 22.2% 1x 容易 2x 难；2x chop drag 月烧
+
+  **Sentiment**　Trump 太空学院新政 hard 催化；Musk rel 72 投资者风险 soft 利空；Starship 试飞 event-driven
+
+  **Cross-Market**　SPCH 跟踪 SPCX 2 倍，SPCX 5d +4.6% 反弹；与 RKLX / RKLB 商业航天板块弱关联
+
+- **SPCX**
+
+  <span class="entry-meta">+0.31% / RSI 58.5 / 趋势OFF</span>
+
+  **Fundamentals**　1x SpaceX 个股 + 流动性差 + Musk 风险；reflections 40% 胜率
+
+  **Sentiment**　Trump 太空学院新政 hard 催化；Musk rel 72 投资者风险 soft 利空；Starship 试飞 event-driven
+
+  **Cross-Market**　SPCX 1x 标的与美股科技板块关联弱；同板块 RKLX / RKLB / ASTS 9/4 涨跌参差
+
+</div>
+
+</div>
 
 ## 这本账现在什么样
+
+<div class="brief-card" markdown="1">
 
 ### 双币账本（HK + USD 不能直接相加）
 
@@ -112,12 +345,20 @@ book 双视角都亏：USD base 浮亏 5,191 + HKD base 浮亏 40,698。HK leg 7
 HK 现金: 17,597 HKD | US 现金: 264.28 USD
 ```
 
+</div>
+
+<div class="brief-card" markdown="1">
+
 ### 集中度
 
 | Leg | HHI | 判定 | Top2 | 腿总值 |
 |---|---|---|---|---|
 | HK | 0.443 | 🔴 危险集中 | 87.50% | 72,139 |
 | US | 0.670 | 🔴 危险集中 | 86.90% | 3,641 |
+
+</div>
+
+<div class="brief-card" markdown="1">
 
 ### 风控硬闸
 
@@ -137,6 +378,10 @@ open **8** / overridden 0 / unacknowledged 8 / oldest 54d / decision_overdue 5
 | beta | US | high | US β vs S&P = 5.5268 (cap 3.0) — 大盘 −1% 本子约 −5.5% | risk-66b800a6afe2 |
 
 **directive**: ⛔ 5 仓位硬闸 + 3 杠杆止损触发。每条必须在 Judge 段出一个对应动作(driven_by=risk_rule,纪律性再平衡,不算听消息、不受 risk_on HOLD 默认约束)；其余主动 call 仍按 regime guard。杠杆ETF解套口径=2x→1x 同因子换仓而非清仓(见各 action)。
+
+</div>
+
+<div class="brief-card" markdown="1">
 
 ### 加仓面（收盘确认）
 
@@ -167,6 +412,10 @@ candidate **0** / wait 8 / reject 0　·　技术突破(收盘站上前 20 日�
 
 _冷启动期：单族 + 价格确认 + 非杠杆 ⇒ 半个试探仓（policy `cold_start_single_family_enabled`）；计数器填满后此例外自动失效_
 
+</div>
+
+<div class="brief-card" markdown="1">
+
 ### 回本测算
 
 | Ticker | 浮% | 2x chop drag/月 | 回本需 | 半年窗含 drag 等效标的需 |
@@ -180,6 +429,10 @@ _冷启动期：单族 + 价格确认 + 非杠杆 ⇒ 半个试探仓（policy `
 | 03033 | -12.80% | — | +14.60% | — |
 
 注：回本涨幅=成本/现价−1。2x 行加印：标的σ、横盘 decay≈σ²/12 每月、半年窗含 drag 的等效标的涨幅。解读纪律：直线涨→2x 回本更快；横盘→2x 每月白付 decay；再跌→2x 双倍挨打。换 1x 买的是后两种情景的保护，不是回本速度。
+
+</div>
+
+<div class="brief-card" markdown="1">
 
 ### 仓位明细
 
@@ -205,6 +458,10 @@ _冷启动期：单族 + 价格确认 + 非杠杆 ⇒ 半个试探仓（policy `
 | SKHY SK海力士 ADR | 1 | 169.19 | 177.00 | +8.14% | +4.62% | 8 |
 | **小计 US** |  |  |  | -67 | -20.94% | **-964** |
 
+</div>
+
+<div class="brief-card" markdown="1">
+
 ### 大盘趋势（两条腿各自的读数）
 
 | 腿 | 窗口 | 距均线/动量 | 趋势 | 读数 |
@@ -216,8 +473,12 @@ _regime3=近10日动量分 牛(>+3%)/熊(<-3%)/震荡；trend_on=200日线；US 
 
 _HK 的趋势闸只收紧 HK 杠杆腿的上限；US 杠杆腿走它自己的 per-name dial_
 
+</div>
+
 <details class="brief-appendix" markdown="1">
 <summary>背景与校准</summary>
+
+<div class="brief-card" markdown="1">
 
 ### 昨日兑现（2026-09-04 的 plan）
 
@@ -234,24 +495,87 @@ _HK 的趋势闸只收紧 HK 杠杆腿的上限；US 杠杆腿走它自己的 pe
 | SKHY | hold_and_watch | core_position | — | 50% | pending |
 | SPCX | hold_and_watch | core_position | — | 50% | pending |
 
+</div>
+
+<div class="brief-card" markdown="1">
+
 ### 同行扫描
 
-| 持仓 | 主题 | 今日 self | 最强同行 | 差距 | 判断 |
-|---|---|---|---|---|---|
-| 00100 | HK AI 大模型 | +1.80% | 06682 范式智能 +14.66% | -12.86pp | 同业 06682 +14.7% / 09678 +9.9% / 00020 +5.86% / 01384 +4.5% / 03317 +0.16% / 02513 -2.98% 板块共振，00100 +1.8% 落后涨幅是同业更弱而非个股更强，慎言 alpha |
-| 02208 | 风电 | -0.33% | 00916 龙源电力 +2.20% | -2.53pp | 同业 00916 +2.2% / 01798 +1.4% / 01072 +1.11% / 00956 -1.06% 风电板块共振弱，02208 5d -6.2% 仍弱但单日 +1.27% 反弹 |
-| 03032 | HK 科技指数 1x (HSTECH 标的) | +2.10% | 03033 南方恒生科技 +2.33% | -0.23pp | 03032 与 03033 跟踪同一指数，同业 03067 安硕恒生科技同赛道 |
-| 03033 | HK 科技指数 1x (HSTECH 标的) | +2.33% | 03032 恒生科技ETF +2.10% | +0.23pp | 03032 跟踪同指数同业；HSTECH 9/4 +2.27% 借权重股美团 +5.28% / 网易 +3.33% / 京东 +3.27% / 阿里 +2.42% / 腾讯 +2.26% 反弹 |
-| 07226 | HK 科技指数 2x leveraged (HSTECH 标的) | +4.40% | 03690 美团-W +5.28% | -0.88pp | 03032 / 03033 1x ETF 同业，07226 是 2x 杠杆；同板块权重股美团 +5.28% / 网易 +3.33% / 京东 +3.27% 反弹共振 |
-| CRCL | 稳定币 + agent 支付 | -1.14% | BKKT Bakkt, Inc. -0.60% | -0.54pp | HOOD 9/4 +16.57% / COIN +10.35% 5d 跑赢 CRCL +15.16% 同板块共振 |
-| RKLX | RKLB 2x leveraged | +1.27% | RKLB Rocket Lab +0.71% | +0.56pp | RKLX 是 2x RKLB，RKLB 9/4 +0.71% 5d -0.2% 弱；ASTS / BKSY / LMT 9/4 涨跌参差 |
-| SKHY | 存储芯片 / HBM (AI 内存) | +8.14% | STX 希捷科技 +6.34% | +1.80pp | 同业 STX 9/4 +6.34% / MU +6.1% / WDC +5.86% / NVDA +0.84% 集体强，SKHY 5d +9.9% peer leader |
-| SPCH | SpaceX 2x leveraged (商业航天) | -2.57% | RKLX 2倍做多Rocket Lab ETF-Defiance +1.27% | -3.84pp | SPCX 9/4 +1.27% 5d +4.6% 反弹；RKLB 9/4 +0.71% 5d -0.2% 弱；ASTS 9/4 +0.29% 5d +7.34% 卫星通信同业 |
-| SPCX | 商业航天 (火箭发射 + Starlink 卫星互联网) | -1.20% | RKLB Rocket Lab +0.71% | -1.91pp | RKLB 9/4 +0.71% 5d -0.2% 弱；ASTS 9/4 +0.29% 5d +7.34% 卫星通信同业；SPCX 5d +4.6% 反弹 |
+<div class="brief-entries" markdown="1">
+
+- **00100** · 今日 +1.80% · 差距 -12.86pp
+
+  <span class="entry-meta">HK AI 大模型 · 最强同行 06682 范式智能 +14.66%</span>
+
+  **判断**　同业 06682 +14.7% / 09678 +9.9% / 00020 +5.86% / 01384 +4.5% / 03317 +0.16% / 02513 -2.98% 板块共振，00100 +1.8% 落后涨幅是同业更弱而非个股更强，慎言 alpha
+
+- **02208** · 今日 -0.33% · 差距 -2.53pp
+
+  <span class="entry-meta">风电 · 最强同行 00916 龙源电力 +2.20%</span>
+
+  **判断**　同业 00916 +2.2% / 01798 +1.4% / 01072 +1.11% / 00956 -1.06% 风电板块共振弱，02208 5d -6.2% 仍弱但单日 +1.27% 反弹
+
+- **03032** · 今日 +2.10% · 差距 -0.23pp
+
+  <span class="entry-meta">HK 科技指数 1x (HSTECH 标的) · 最强同行 03033 南方恒生科技 +2.33%</span>
+
+  **判断**　03032 与 03033 跟踪同一指数，同业 03067 安硕恒生科技同赛道
+
+- **03033** · 今日 +2.33% · 差距 +0.23pp
+
+  <span class="entry-meta">HK 科技指数 1x (HSTECH 标的) · 最强同行 03032 恒生科技ETF +2.10%</span>
+
+  **判断**　03032 跟踪同指数同业；HSTECH 9/4 +2.27% 借权重股美团 +5.28% / 网易 +3.33% / 京东 +3.27% / 阿里 +2.42% / 腾讯 +2.26% 反弹
+
+- **07226** · 今日 +4.40% · 差距 -0.88pp
+
+  <span class="entry-meta">HK 科技指数 2x leveraged (HSTECH 标的) · 最强同行 03690 美团-W +5.28%</span>
+
+  **判断**　03032 / 03033 1x ETF 同业，07226 是 2x 杠杆；同板块权重股美团 +5.28% / 网易 +3.33% / 京东 +3.27% 反弹共振
+
+- **CRCL** · 今日 -1.14% · 差距 -0.54pp
+
+  <span class="entry-meta">稳定币 + agent 支付 · 最强同行 BKKT Bakkt, Inc. -0.60%</span>
+
+  **判断**　HOOD 9/4 +16.57% / COIN +10.35% 5d 跑赢 CRCL +15.16% 同板块共振
+
+- **RKLX** · 今日 +1.27% · 差距 +0.56pp
+
+  <span class="entry-meta">RKLB 2x leveraged · 最强同行 RKLB Rocket Lab +0.71%</span>
+
+  **判断**　RKLX 是 2x RKLB，RKLB 9/4 +0.71% 5d -0.2% 弱；ASTS / BKSY / LMT 9/4 涨跌参差
+
+- **SKHY** · 今日 +8.14% · 差距 +1.80pp
+
+  <span class="entry-meta">存储芯片 / HBM (AI 内存) · 最强同行 STX 希捷科技 +6.34%</span>
+
+  **判断**　同业 STX 9/4 +6.34% / MU +6.1% / WDC +5.86% / NVDA +0.84% 集体强，SKHY 5d +9.9% peer leader
+
+- **SPCH** · 今日 -2.57% · 差距 -3.84pp
+
+  <span class="entry-meta">SpaceX 2x leveraged (商业航天) · 最强同行 RKLX 2倍做多Rocket Lab ETF-Defiance +1.27%</span>
+
+  **判断**　SPCX 9/4 +1.27% 5d +4.6% 反弹；RKLB 9/4 +0.71% 5d -0.2% 弱；ASTS 9/4 +0.29% 5d +7.34% 卫星通信同业
+
+- **SPCX** · 今日 -1.20% · 差距 -1.91pp
+
+  <span class="entry-meta">商业航天 (火箭发射 + Starlink 卫星互联网) · 最强同行 RKLB Rocket Lab +0.71%</span>
+
+  **判断**　RKLB 9/4 +0.71% 5d -0.2% 弱；ASTS 9/4 +0.29% 5d +7.34% 卫星通信同业；SPCX 5d +4.6% 反弹
+
+</div>
+
+</div>
+
+<div class="brief-card" markdown="1">
 
 ### 板块全景
 
 港股 AI 大模型 9/4 范式智能 06682 +14.66% / 云知声 09678 +9.9% / 商汤-W 00020 +5.86% / 滴普 01384 +4.5% 共振，00100 1.8% 是同业偏后；5d 范式 +11.6% / 云知声 +32.31% / 商汤 -2.36% / 滴普 +7.65% / 智谱 -1.38% 板块强弱分明。00100 5d +20.3% 反弹是同业领涨但 9/4 单日 +1.8% 落后，归因(a) 同业补涨抢占资金 + 00100 短期获利回吐。HSTECH 9/4 +2.27% 收 4569.8 借美团 +5.28% / 网易 +3.33% / 京东 +3.27% / 阿里 +2.42% / 腾讯 +2.26% 权重股反弹，07226 2x 放大 +4.4% 是杠杆放大反弹。商业航天 9/4 SPCX +1.27% 收 149.74 / RKLB +0.71% / ASTS +0.29% 弱反弹但 5d SPCX +4.6% / ASTS +7.34% / RKLB -0.2% 同业分化，SPCH 5d +8.2% 是 2x 放大 4.6% underlying。HBM 9/4 STX +6.34% / MU +6.1% / WDC +5.86% / NVDA +0.84% 集体强，SKHY 9/4 持平 5d +9.9% peer leader。
+
+</div>
+
+<div class="brief-card" markdown="1">
 
 ### 大盘速读
 
@@ -259,24 +583,107 @@ VIX **14.53** (+1.47%) · HSI **25,650.87** (+1.74%) · HSTECH **4,569.80** (+2.
 
 VIX 14.53 (+1.47%) + F&G 41.9 fear (前 35.2) + 10Y 4.784% + DXY 99.15 (-0.03%) + SPX 7718.6 (-0.38%) + NDX 26506.99 (-0.29%) + HSI 25650.87 (+1.74%) + HSTECH 4569.8 (+2.27%)。VIX 极低 + F&G 仍 fear + 美股软 + 港股强 + 利率升 + DXY 平 是 risk_neutral：风险偏好未破但杠杆 ETF 在窄幅震荡中每天烧 chop drag。9/11 BLS 8 月 CPI + 9/16 FOMC 是 7d 内两个最大黑天鹅，9/4 已显示 10Y 升 + 美股弱是利率敏感的早期信号。
 
+</div>
+
+<div class="brief-card" markdown="1">
+
 ### 社交舆情
 
-| 票 | Reddit 7d | 新闻关键词 | 近 5 日 | 信号判断 |
-|---|---|---|---|---|
-| CRCL | 0 mentions | What Is Driving Circle Internet Grou、Why Did CRCL Stock Lose Steam? Wall 、Circle Internet Group Stock Price: C | — | GENIUS/CLARITY hard 已价；21 家机构联合 long-term 软利空；内部人 sell soft 持续利空 |
-| RKLX | 0 mentions | RKLX: Benefits And Risks Of Leveragi、RKLX - Defiance Daily Target 2X Long、Defiance Daily Target 2X Long RKLB E | — | Q4 Neutron + Trump 太空学院 hard catalyst 链；Musk rel 72 投资者风险口径 soft 利空 |
-| SPCX | 0 mentions | Should You Forget SpaceX (SPCX) Stoc、SpaceX Stock (SPCX) Price Prediction、SpaceX Offers Exponential Upside And | — | Trump 太空学院新政 hard 催化；Musk rel 72 投资者风险 soft 利空；Starship 试飞 event-driven |
-| SPCH | 0 mentions | SPCH ETF Price and Chart — CBOE:SPCH、SPCH - Leverage Shares 2X Long SPCX 、SPCH \| Leverage Shares 2X Long Stock | — | Trump 太空学院新政 hard 催化；Musk rel 72 投资者风险 soft 利空；Starship 试飞 event-driven |
-| SKHY | 0 mentions | SK hynix(SKHY) Stock Price Today \| Q、Is SK Hynix (NasdaqGS:SKHY) Underval、SKHY Stock Slips Premarket After Kor | — | SK 海力士 CEO hard supporting 长期；美光罢工 soft；长鑫 IPO soft |
-| 00100 | 0 mentions | HK Stock Market Watch \| MINIMAX-W (0、Hong Kong Stocks in Focus \| MINIMAX-、MINIMAX-WP (00100.HK): ARR Exceeds U | — | 南向资金 9/3 净买入 33.95 亿是 hard catalyst confirming；智谱 9/4 -2.98% 同业弱是 soft 不动 00100 决策；散户温度无 Reddit 数据 |
-| 02208 | 0 mentions | JPMorgan reduced its stake in Goldwi、Hong Kong Stock Market Movement \| Co、Jinfeng Technology's Hong Kong-liste | — | JPM 减持 1.08% 是 soft 已部分消化；1-7 月装机 +19.5% 是 hard 已价；散户温度无 Reddit 数据 |
-| 03032 | 0 mentions | Year-End Review \| The Strongest ETF 、Zhitong HK Stock Connect Holdings Ra、New funds are channeling into the Ho | — | 招商证券研报 soft supporting；港股通 9/3 净买入 33.95 亿 hard confirming 但只是日数据 |
-| 07226 | 0 mentions | ETF Market Movement \| CSOP FTSE Chin、Hang Seng Tech Index Surges, Souther、What signal? Significant inflows of  | — | 招商证券研报 soft supporting；港股通 9/3 净买入 33.95 亿 hard confirming 但只是日数据 |
-| 03033 | 0 mentions | Zhitong HK Stock Connect Holdings An、Zhitong HK Stock Connect Holdings Ra、Zhitong HK Connect Active Trading \|  | — | 招商证券研报 soft supporting；港股通 9/3 净买入 33.95 亿 hard confirming |
+<div class="brief-entries" markdown="1">
+
+- **CRCL** · 近 5 日 —
+
+  <span class="entry-meta">Reddit 7d 0 mentions</span>
+
+  **新闻**　What Is Driving Circle Internet Grou、Why Did CRCL Stock Lose Steam? Wall 、Circle Internet Group Stock Price: C
+
+  **信号判断**　GENIUS/CLARITY hard 已价；21 家机构联合 long-term 软利空；内部人 sell soft 持续利空
+
+- **RKLX** · 近 5 日 —
+
+  <span class="entry-meta">Reddit 7d 0 mentions</span>
+
+  **新闻**　RKLX: Benefits And Risks Of Leveragi、RKLX - Defiance Daily Target 2X Long、Defiance Daily Target 2X Long RKLB E
+
+  **信号判断**　Q4 Neutron + Trump 太空学院 hard catalyst 链；Musk rel 72 投资者风险口径 soft 利空
+
+- **SPCX** · 近 5 日 —
+
+  <span class="entry-meta">Reddit 7d 0 mentions</span>
+
+  **新闻**　Should You Forget SpaceX (SPCX) Stoc、SpaceX Stock (SPCX) Price Prediction、SpaceX Offers Exponential Upside And
+
+  **信号判断**　Trump 太空学院新政 hard 催化；Musk rel 72 投资者风险 soft 利空；Starship 试飞 event-driven
+
+- **SPCH** · 近 5 日 —
+
+  <span class="entry-meta">Reddit 7d 0 mentions</span>
+
+  **新闻**　SPCH ETF Price and Chart — CBOE:SPCH、SPCH - Leverage Shares 2X Long SPCX 、SPCH \| Leverage Shares 2X Long Stock
+
+  **信号判断**　Trump 太空学院新政 hard 催化；Musk rel 72 投资者风险 soft 利空；Starship 试飞 event-driven
+
+- **SKHY** · 近 5 日 —
+
+  <span class="entry-meta">Reddit 7d 0 mentions</span>
+
+  **新闻**　SK hynix(SKHY) Stock Price Today \| Q、Is SK Hynix (NasdaqGS:SKHY) Underval、SKHY Stock Slips Premarket After Kor
+
+  **信号判断**　SK 海力士 CEO hard supporting 长期；美光罢工 soft；长鑫 IPO soft
+
+- **00100** · 近 5 日 —
+
+  <span class="entry-meta">Reddit 7d 0 mentions</span>
+
+  **新闻**　HK Stock Market Watch \| MINIMAX-W (0、Hong Kong Stocks in Focus \| MINIMAX-、MINIMAX-WP (00100.HK): ARR Exceeds U
+
+  **信号判断**　南向资金 9/3 净买入 33.95 亿是 hard catalyst confirming；智谱 9/4 -2.98% 同业弱是 soft 不动 00100 决策；散户温度无 Reddit 数据
+
+- **02208** · 近 5 日 —
+
+  <span class="entry-meta">Reddit 7d 0 mentions</span>
+
+  **新闻**　JPMorgan reduced its stake in Goldwi、Hong Kong Stock Market Movement \| Co、Jinfeng Technology's Hong Kong-liste
+
+  **信号判断**　JPM 减持 1.08% 是 soft 已部分消化；1-7 月装机 +19.5% 是 hard 已价；散户温度无 Reddit 数据
+
+- **03032** · 近 5 日 —
+
+  <span class="entry-meta">Reddit 7d 0 mentions</span>
+
+  **新闻**　Year-End Review \| The Strongest ETF 、Zhitong HK Stock Connect Holdings Ra、New funds are channeling into the Ho
+
+  **信号判断**　招商证券研报 soft supporting；港股通 9/3 净买入 33.95 亿 hard confirming 但只是日数据
+
+- **07226** · 近 5 日 —
+
+  <span class="entry-meta">Reddit 7d 0 mentions</span>
+
+  **新闻**　ETF Market Movement \| CSOP FTSE Chin、Hang Seng Tech Index Surges, Souther、What signal? Significant inflows of 
+
+  **信号判断**　招商证券研报 soft supporting；港股通 9/3 净买入 33.95 亿 hard confirming 但只是日数据
+
+- **03033** · 近 5 日 —
+
+  <span class="entry-meta">Reddit 7d 0 mentions</span>
+
+  **新闻**　Zhitong HK Stock Connect Holdings An、Zhitong HK Stock Connect Holdings Ra、Zhitong HK Connect Active Trading \| 
+
+  **信号判断**　招商证券研报 soft supporting；港股通 9/3 净买入 33.95 亿 hard confirming
+
+</div>
+
+</div>
+
+<div class="brief-card" markdown="1">
 
 ### 名人异动 / 政策风向（1.0h 前）
 
 撞持仓 **0** · 新机会 0 · 板块相关 0
+
+</div>
+
+<div class="brief-card" markdown="1">
 
 ### 决策校准
 
@@ -290,6 +697,10 @@ VIX 14.53 (+1.47%) + F&G 41.9 fear (前 35.2) + 10Y 4.784% + DXY 99.15 (-0.03%) 
 
 decision_metrics 35 笔 settled_episodes 样本足够读 baseline：core_position 29 战 23 胜 79.3% CI [0.62, 0.90] significant edge；risk_rebalance 6 战 3 胜 50% CI [0.19, 0.81] edge 不显著；by_driver technical 22 战 18 胜 81.8% CI [0.62, 0.93] technical edge 强；sentiment 7 战 5 胜 71.4% CI [0.36, 0.92] 样本小；risk_rule 6 战 3 胜 50% CI [0.19, 0.81] 不显著。本轮 5 笔 risk_rebalance 全走 risk_rule 不是择时而是政策，reflections 历史 risk_rule 不显著但纪律是政策不是预测。Brier 0.4157 待与 baseline 对比。execution 118 followed / 52 not_followed / 10 unknown，主动决策 by_driver edge 不等同执行率。
 
+</div>
+
+<div class="brief-card" markdown="1">
+
 ### 待补
 
 - 9/4 US 8 月 NFP 9/5 公布但 preflight 未抓（macro 只到 9/4 收盘），9/8 US 复盘前需查 9/5 NFP 实际数与市场反应
@@ -299,5 +710,7 @@ decision_metrics 35 笔 settled_episodes 样本足够读 baseline：core_positio
 - 9/9 SPCX 解禁前最新动态（preflight 仅有「SpaceX Stock Price Prediction」标题与 5d +4.6% 反弹）
 - 9/16 FOMC 加息 25bp 隐含 36%，Waller 9/2 表态 hold，任何鹰派讲话（Bostic / Bowman）都会推动曲线
 - 7 bar conflicts need --repair
+
+</div>
 
 </details>

--- a/memory/2026-09-08-pre-open.md
+++ b/memory/2026-09-08-pre-open.md
@@ -6,39 +6,145 @@ description: "clawock 盘前深度简报 2026-09-08：港股 + 美股真实持�
 
 # 盘前深度简报｜2026-09-08 周二 08:03 HKT
 
+<div class="brief-card brief-lede" markdown="1">
+
 纪律日, 7 guardrail breach + hard stop 同开 (4 critical + 3 hard stop) — 今日 3 个 swap cut (HK 07226, US SPCH) + 1 个 RKLX cut + 1 个 SPCX swap add 配套一次清完. 9/7 已 cut 07226 释放 19,683 HKD 现金, 03033 swap buy 腿因 9/8 packet 无 technical setup 暂不执行, 依赖现有 03032 1x 1.26% book 维持 HSTECH 敞口. 9/4 plan 中 SPCH cut 300 + SPCX add 1 + RKLX cut 10 因 9/7 US Labor Day 全部未执行, 今日一并重发. 00100 trim 1 lot @365 9/7 high 393 已 fire, settlement pending, 今日不复议等回报. 全部执行后 US beta 由 5.53 降至 <1.0, HK 杠杆由 27.5% 降至 0%, 单名 81% 降至 SPCX 8%, 7 breach 全清.
 
 **反方**：Decision v2 Brier 0.3223 LOSES to baseline 0.3061 = 信心 calibration 不合格, mean_conf 0.89 vs 实际 62.5% base rate 严重 overconfident. 0 edge-supported predictions, 51 abstentions — 数据不足以撑任何主动 call 的 confidence. 5d 内 7 breach 同步触发 = book 风险 budget 已透支, breach_return 几乎确定 (swap 后 00100 仍 55.7% HK + SPCX/CRCL/SKHY US 单名集中度返回只是时间问题). US 报价 0/5 from Nasdaq primary, 数据 stale through 9/4 (5 天). 9/11 CPI 是本周最大 catalyst, 软数据可能 risk_on, 硬数据必须继续降 beta. 03033 swap add 暂缓暴露出 1x 替代不齐全问题, 若 HSTECH 持续下行 03032 + 03033 现有 1x 敞口 8.6% 不足以承担原 27.5% 2x 敞口的对冲作用.
 
+</div>
+
 ## 今天做什么
+
+<div class="brief-card" markdown="1">
 
 ### 今日动作
 
-| Ticker | Action | Frame | Strategy | driven_by | 理由 |
-|---|---|---|---|---|---|
-| 07226 | **cut** | technical_breakdown | risk_rebalance | risk_rule | 9/4 plan cut 全仓 6200 股 @3.174 9/7 fire 已执行 (高 3.178 低 3.104 收 3.128), 释放 19,683 HKD 现金. 硬止损 -28.3% <= -18% 线 critical + HK 杠杆 ETF 27.5% > 25% amber cap + HK lev_regime amber (基准 x 0.5 = 25%) 三闸并发. cut 必发. 1x 替代 03033 add 9/8 packet 无 technical setup, 暂不执行; 依赖现有 03032 1x 1.26% book 维持 HSTECH 敞口. |
-| SPCH | **cut** | technical_breakdown | risk_rebalance | risk_rule | 硬止损 -18.2% <= -18% 线 critical 0d + 单名 81.32% > 35% mandatory + US 杠杆 85.5% > 50% + US beta 5.5268 > 3.0 四闸并发. cut 释放 2961 USD 配同 group_id add SPCX 1 股 147.95 USD 同因子换仓. breakeven 22.2% 5-sigma 不可达, chop drag 1.2%/月每天烧钱. |
-| SPCX | **add_only_on_trigger** | mean_reversion | risk_rebalance | risk_rule | SPCH cut 配套买腿; breach risk-95ac7f6cd591 swap_mandate 授权; 1 股 = packet max_add 1 上限; 买完 SPCX 由 1 股到 2 股; cash 2,813 USD 留宏观部署; 敞口不变停 2x 日内重置 chop drag |
-| RKLX | **cut** | technical_breakdown | risk_rebalance | risk_rule | 硬止损 -69.6% <= -18% 线 critical 54d decision_overdue; breakeven 需 +228.4% 5-sigma 不可达; 横盘 chop drag 1.2%/月每天烧钱; RKLB 6/13 已清仓 swap_mandate = null 无 1x 替代, 纯 cut 释放 151 USD 现金; RKLX 5d -1.2% 跑输 RKLB 5d -0.2% 是 2x chop drag 主导实证 |
-| 00100 | **hold_and_watch** | mean_reversion | core_position | risk_rule | 9/4 plan trim 1 lot 20 股 @365 已 fire (9/7 high 393 > 365), settlement pending; 若成交 00100/HK 由 60.12% 到 55.7% 解 single_name 60% cap; 今日不复议等回报; 若未成交 T+1 后未确认再考虑重发 open |
-| 03032 | **hold_and_watch** | mean_reversion | core_position | technical | 03032 5d -1.9% 跟随 HSTECH 同步; 仓位 912 HKD 占 book 1.26% 太小不值得动; 与 03033 合计 HSTECH 1x 敞口 8.6%; 9/7 硬件龙头新品发布是潜在催化但对 1x 贡献极微 |
-| 02208 | **hold_and_watch** | mean_reversion | core_position | technical | 5d -4.0% 受 JPM 减持 1.08% 软利空 + 商业航天回调拖累; 1-7 月装机 +19.5% + 累计回购 1302 万股是 supporting 已价; 仓位 3,646 HKD 占 book 5.05% 不催主动 call |
-| CRCL | **hold_and_watch** | mean_reversion | core_position | technical | 5d +17.1% 反弹 + 9/3 +15.16% GENIUS/CLARITY 听证会是 hard catalyst confirming 已价; reflections 持 x 16 胜 10 = 63% book 第三高; 但 5d +17.1% 极端位置有回调风险; Mizuho downgrade 软利空; 仓位 204 USD 占 book 5.61% 仅 2 股 1 股加减不抵交易成本 |
-| SKHY | **hold_and_watch** | relative_strength | core_position | peer | 5d +9.9% 反弹区间位置 92.9% 顶部属追高低质; HBM 板块双向不确定; SK 海力士 CEO 称存储短缺到 2030 是 supporting 长期; reflections 持 x 10 胜 6 = 60% book 中位; 仓位 177 USD 占 book 4.86% 仅 1 股, 1 股加减不抵交易成本; 同业 STX 9/4 +6.34% / MU +6.1% / WDC +5.86% 集体强, SKHY 5d +9.9% 是 peer leader |
+<div class="brief-entries" markdown="1">
+
+- **07226** · **cut**
+
+  <span class="entry-meta">technical_breakdown · risk_rebalance · risk_rule</span>
+
+  **理由**　9/4 plan cut 全仓 6200 股 @3.174 9/7 fire 已执行 (高 3.178 低 3.104 收 3.128), 释放 19,683 HKD 现金. 硬止损 -28.3% <= -18% 线 critical + HK 杠杆 ETF 27.5% > 25% amber cap + HK lev_regime amber (基准 x 0.5 = 25%) 三闸并发. cut 必发. 1x 替代 03033 add 9/8 packet 无 technical setup, 暂不执行; 依赖现有 03032 1x 1.26% book 维持 HSTECH 敞口.
+
+- **SPCH** · **cut**
+
+  <span class="entry-meta">technical_breakdown · risk_rebalance · risk_rule</span>
+
+  **理由**　硬止损 -18.2% <= -18% 线 critical 0d + 单名 81.32% > 35% mandatory + US 杠杆 85.5% > 50% + US beta 5.5268 > 3.0 四闸并发. cut 释放 2961 USD 配同 group_id add SPCX 1 股 147.95 USD 同因子换仓. breakeven 22.2% 5-sigma 不可达, chop drag 1.2%/月每天烧钱.
+
+- **SPCX** · **add_only_on_trigger**
+
+  <span class="entry-meta">mean_reversion · risk_rebalance · risk_rule</span>
+
+  **理由**　SPCH cut 配套买腿; breach risk-95ac7f6cd591 swap_mandate 授权; 1 股 = packet max_add 1 上限; 买完 SPCX 由 1 股到 2 股; cash 2,813 USD 留宏观部署; 敞口不变停 2x 日内重置 chop drag
+
+- **RKLX** · **cut**
+
+  <span class="entry-meta">technical_breakdown · risk_rebalance · risk_rule</span>
+
+  **理由**　硬止损 -69.6% <= -18% 线 critical 54d decision_overdue; breakeven 需 +228.4% 5-sigma 不可达; 横盘 chop drag 1.2%/月每天烧钱; RKLB 6/13 已清仓 swap_mandate = null 无 1x 替代, 纯 cut 释放 151 USD 现金; RKLX 5d -1.2% 跑输 RKLB 5d -0.2% 是 2x chop drag 主导实证
+
+- **00100** · **hold_and_watch**
+
+  <span class="entry-meta">mean_reversion · core_position · risk_rule</span>
+
+  **理由**　9/4 plan trim 1 lot 20 股 @365 已 fire (9/7 high 393 > 365), settlement pending; 若成交 00100/HK 由 60.12% 到 55.7% 解 single_name 60% cap; 今日不复议等回报; 若未成交 T+1 后未确认再考虑重发 open
+
+- **03032** · **hold_and_watch**
+
+  <span class="entry-meta">mean_reversion · core_position · technical</span>
+
+  **理由**　03032 5d -1.9% 跟随 HSTECH 同步; 仓位 912 HKD 占 book 1.26% 太小不值得动; 与 03033 合计 HSTECH 1x 敞口 8.6%; 9/7 硬件龙头新品发布是潜在催化但对 1x 贡献极微
+
+- **02208** · **hold_and_watch**
+
+  <span class="entry-meta">mean_reversion · core_position · technical</span>
+
+  **理由**　5d -4.0% 受 JPM 减持 1.08% 软利空 + 商业航天回调拖累; 1-7 月装机 +19.5% + 累计回购 1302 万股是 supporting 已价; 仓位 3,646 HKD 占 book 5.05% 不催主动 call
+
+- **CRCL** · **hold_and_watch**
+
+  <span class="entry-meta">mean_reversion · core_position · technical</span>
+
+  **理由**　5d +17.1% 反弹 + 9/3 +15.16% GENIUS/CLARITY 听证会是 hard catalyst confirming 已价; reflections 持 x 16 胜 10 = 63% book 第三高; 但 5d +17.1% 极端位置有回调风险; Mizuho downgrade 软利空; 仓位 204 USD 占 book 5.61% 仅 2 股 1 股加减不抵交易成本
+
+- **SKHY** · **hold_and_watch**
+
+  <span class="entry-meta">relative_strength · core_position · peer</span>
+
+  **理由**　5d +9.9% 反弹区间位置 92.9% 顶部属追高低质; HBM 板块双向不确定; SK 海力士 CEO 称存储短缺到 2030 是 supporting 长期; reflections 持 x 10 胜 6 = 60% book 中位; 仓位 177 USD 占 book 4.86% 仅 1 股, 1 股加减不抵交易成本; 同业 STX 9/4 +6.34% / MU +6.1% / WDC +5.86% 集体强, SKHY 5d +9.9% 是 peer leader
+
+</div>
+
+</div>
+
+<div class="brief-card" markdown="1">
 
 ### 信心与判定
 
-| Ticker | Action | Confidence | Verdict | 理由 | 证伪条件 |
-|---|---|---|---|---|---|
-| 07226 | cut | 95% | <span class="verdict verdict-neutral">⚪ 中性</span> | cut 必发, 1x 替代靠 03032 现有 1.26% 承担; 若 HSTECH 持续下行 03032 1x 敞口不足对冲 | 若 9/8 仍持仓 (cut settlement 失败) 立即重发 cut open |
-| SPCH | cut | 95% | <span class="verdict verdict-bearish">🔴 看空</span> | hard stop 纪律绝对优先, chop drag 1.2%/月 + breakeven 5-sigma 不可达 = 不该继续持有 | 若 SPCH 仓位已 0 (cut 已 settled), 本条不再执行 |
-| SPCX | add_only_on_trigger | 85% | <span class="verdict verdict-neutral">⚪ 中性</span> | swap 纪律 = 风险规则授权, 切 1x 拿住 SpaceX 敞口不死 | 若 SPCH 仓位已 0, buy 腿不再执行 |
-| RKLX | cut | 95% | <span class="verdict verdict-bearish">🔴 看空</span> | hard stop 纪律 + chop drag 双向烧钱, 无 1x 替代必须 cut | 若 RKLX 仓位已 0 (cut 已 settled), 本条不再执行 |
-| 00100 | hold_and_watch | 60% | <span class="verdict verdict-neutral">⚪ 中性</span> | 若 9/7 trim 已成交, 00100 = 1060 股 55.7% HK (cap 内) 不复议. 若未成交, 明日 9/9 open 重发. | 若 9/7 trim settlement 失败且 9/8 00100 仍 > 60% HK 重新进入 cap breach, 立即重发 trim open |
-| 03032 | hold_and_watch | 50% | <span class="verdict verdict-neutral">⚪ 中性</span> | 维持 hold, 仓位小不值得交易成本; 1x 替代靠 03032 承担, 不加仓 | 若 HSTECH 跌破 4500 触发新一轮下行 |
-| 02208 | hold_and_watch | 50% | <span class="verdict verdict-neutral">⚪ 中性</span> | 维持 hold, 反思 30% + 仓位小不催 call | 若风电政策超预期转空或 JPM 继续减持至 <8% 触发被动卖压 |
-| CRCL | hold_and_watch | 55% | <span class="verdict verdict-neutral">⚪ 中性</span> | hold, 2 股无操作空间, 下个加仓点需重新评估 | 若 USDC 监管超预期收紧或 Arc 实际 launch 推迟 |
-| SKHY | hold_and_watch | 50% | <span class="verdict verdict-neutral">⚪ 中性</span> | hold, 1 股无操作空间, 下个加仓点需等回调 | 若 HBM 价格反转或长鑫 IPO 抢市占 >15% |
+<div class="brief-entries" markdown="1">
+
+- **07226** · cut · 信心 95% · <span class="verdict verdict-neutral">⚪ 中性</span>
+
+  **理由**　cut 必发, 1x 替代靠 03032 现有 1.26% 承担; 若 HSTECH 持续下行 03032 1x 敞口不足对冲
+
+  **证伪条件**　若 9/8 仍持仓 (cut settlement 失败) 立即重发 cut open
+
+- **SPCH** · cut · 信心 95% · <span class="verdict verdict-bearish">🔴 看空</span>
+
+  **理由**　hard stop 纪律绝对优先, chop drag 1.2%/月 + breakeven 5-sigma 不可达 = 不该继续持有
+
+  **证伪条件**　若 SPCH 仓位已 0 (cut 已 settled), 本条不再执行
+
+- **SPCX** · add_only_on_trigger · 信心 85% · <span class="verdict verdict-neutral">⚪ 中性</span>
+
+  **理由**　swap 纪律 = 风险规则授权, 切 1x 拿住 SpaceX 敞口不死
+
+  **证伪条件**　若 SPCH 仓位已 0, buy 腿不再执行
+
+- **RKLX** · cut · 信心 95% · <span class="verdict verdict-bearish">🔴 看空</span>
+
+  **理由**　hard stop 纪律 + chop drag 双向烧钱, 无 1x 替代必须 cut
+
+  **证伪条件**　若 RKLX 仓位已 0 (cut 已 settled), 本条不再执行
+
+- **00100** · hold_and_watch · 信心 60% · <span class="verdict verdict-neutral">⚪ 中性</span>
+
+  **理由**　若 9/7 trim 已成交, 00100 = 1060 股 55.7% HK (cap 内) 不复议. 若未成交, 明日 9/9 open 重发.
+
+  **证伪条件**　若 9/7 trim settlement 失败且 9/8 00100 仍 > 60% HK 重新进入 cap breach, 立即重发 trim open
+
+- **03032** · hold_and_watch · 信心 50% · <span class="verdict verdict-neutral">⚪ 中性</span>
+
+  **理由**　维持 hold, 仓位小不值得交易成本; 1x 替代靠 03032 承担, 不加仓
+
+  **证伪条件**　若 HSTECH 跌破 4500 触发新一轮下行
+
+- **02208** · hold_and_watch · 信心 50% · <span class="verdict verdict-neutral">⚪ 中性</span>
+
+  **理由**　维持 hold, 反思 30% + 仓位小不催 call
+
+  **证伪条件**　若风电政策超预期转空或 JPM 继续减持至 <8% 触发被动卖压
+
+- **CRCL** · hold_and_watch · 信心 55% · <span class="verdict verdict-neutral">⚪ 中性</span>
+
+  **理由**　hold, 2 股无操作空间, 下个加仓点需重新评估
+
+  **证伪条件**　若 USDC 监管超预期收紧或 Arc 实际 launch 推迟
+
+- **SKHY** · hold_and_watch · 信心 50% · <span class="verdict verdict-neutral">⚪ 中性</span>
+
+  **理由**　hold, 1 股无操作空间, 下个加仓点需等回调
+
+  **证伪条件**　若 HBM 价格反转或长鑫 IPO 抢市占 >15%
+
+</div>
+
+</div>
+
+<div class="brief-card" markdown="1">
 
 ### 下一节点
 
@@ -48,7 +154,11 @@ description: "clawock 盘前深度简报 2026-09-08：港股 + 美股真实持�
 4. 09:30 ET 重发 RKLX cut 10 股 (no substitute, hard stop 0d decision_overdue 54d)
 5. EOD 检查 9/8 breach 状态, 理想 0 breach, 若仍 breach 升级到 durable override 或 durable 重新评估
 
+</div>
+
 ## 我的看法
+
+<div class="brief-card" markdown="1">
 
 ### 多空对辩
 
@@ -64,6 +174,10 @@ Decision v2 active 8 eps cluster CI [-2.59%, 2.10%] 跨 0 = 主动 call 无 edge
 
 攻击最强共识: 3 个 swap + RKLX cut 清完所有 breach → book 转安全. Bear 视角是 swap 后 00100 仍 55.7% HK + SPCX 8% + CRCL 5.6% + SKHY 4.9% = 74% 集中度 + 现金 81% 闲置, breach_return 几乎确定, 9/4 起的 4 个 breach 中 2 个已 54d 老, 7 天内第 N 次重复发送同一纪律 swap 是 '无新信息焦虑'. swap 完不解决 root cause: book 设计就高 beta 高集中, 2x→1x 是降 chop drag 不降 beta exposure, 真正清 breach 要砍 00100 这种单股不是砍杠杆. 03033 buy 腿因 setup 缺失暂缓, 暴露 1x 替代不齐全问题, 现有 03032 1x 8% 不足以对冲原 27.5% 2x 敞口.
 
+</div>
+
+<div class="brief-card" markdown="1">
+
 ### 风险官三票
 
 **Conservative（保本 derisk） · 今日首位表态**
@@ -78,22 +192,121 @@ Brier 0.3223 vs baseline 0.3061 = 信心 calibration 不合格, 5d 内 7 breach 
 
 swap 纪律必执行 (KCN 6/11 方针 2x→1x, swap 不择时), 但 swap 完不再动作. 00100 单看 thesis 完好 (Catalyst confirming 国泰海通 增持 + Aug ARR > 800M), 但 cap breach 与 reflection 35% 主动 call 胜率提示 hold 是更优. CRCL/SKHY 仓位各 2 股 / 1 股 不值得交易. 03032/03033/02208 reflections 31-35% book 较差反映择时无效, 维持 hold. SPCX reflection 36% 也是 swap 标的非择时. 5d +20% 反弹对 00100 trim 1 lot @365 已 fire 验证, 等 settlement. 03033 buy 腿暂缓因 setup 缺失, 1x 替代不齐全要靠现有 03032 承担.
 
+</div>
+
+<div class="brief-card" markdown="1">
+
 ### 分析师四格
 
-| 票 | Market（harness 计算） | Fundamentals | Sentiment | Cross-Market |
-|---|---|---|---|---|
-| 00100 | -36.57% / RSI 55.5 / 趋势OFF | 国泰海通 增持 + Aug ARR > 800M USD 预测 USD 500M 全年收入, hard catalyst confirming | 南向资金 4 天连续净买入 + 沙特 Humain 阿拉伯语 AI 模型引入 MiniMax 是 supporting 已价 | 9/7 HSTECH -0.92%, 00100 5d +0.5% 跑输 HSTECH +0.5pp 个股 alpha 缺失 |
-| 02208 | -35.07% / RSI 39.8 / 趋势OFF · 已破吊灯止损 / 距 MA200 -30.50% | 风电运营商, 1-7 月装机 +19.5% hard catalyst | JPM 减持 1.08% 至 9.77% 软利空 | 9/7 HSTECH -0.92% 不同市场, 02208 跟随 A 股风电板块 |
-| 03032 | -16.15% / RSI 41.6 / 趋势OFF · 已破吊灯止损 / 距 MA200 -10.50% | 1x HSTECH ETF | 9/7 硬件龙头新品发布是 supporting 已价 | 9/7 HSTECH -0.92% 5d -1.9% 趋势 off |
-| 03033 | -13.66% / RSI 41.1 / 趋势OFF · 已破吊灯止损 / 距 MA200 -10.80% | 1x ETF 跟踪 HSTECH, mom_1m -6.9% mom_3m -4.8% 下行 | 南向资金 9/3 净买 33.95 亿港元是 supporting | 9/7 HSTECH -0.92% 5d -1.9% 趋势 off |
-| 07226 | -28.31% / RSI 41.3 / 趋势OFF · 已破吊灯止损 / 距 MA200 -10.90% | HSTECH 9/7 -0.92% 5d -1.9% 趋势 off + 已破吊灯止损, 1x 替代仍趋势 off | 南向资金 9/3 净买 33.95 亿港元是 supporting 已价, 9/7 弱市 | 9/7 US 闭市, HK 9/7 收 -0.92%, HK 跑输 NDX -0.29% 约 0.6pp |
-| CRCL | +17.30% / RSI 67.0 / 趋势OFF / 距 MA200 +19.90% | GENIUS Act 利好, Arc 即将 launch 是 catalyst | Mizuho downgrade 是 disconfirming 软利空, 21 家国际机构 2027 H1 稳定币是长期软利空 | 9/7 US Labor Day 闭市, CRCL 跟随 crypto 板块 |
-| RKLX | -69.55% / RSI 37.2 / 趋势OFF · 已破吊灯止损 / 距 MA200 -19.10% | 2x RKLB 杠杆 ETF, 5d -1.2% 跑输 RKLB -0.2% 是 2x chop drag 实证 | 无 held 关联新闻, Musk SpaceX 太空数据中心是 sector hit 利好但 RKLX 是 RKLB 不是 SpaceX | 9/7 US Labor Day 闭市 |
-| SKHY | +4.62% / RSI 59.3 / 趋势OFF | HBM 龙头, AI 内存需求长期支撑 | Musk 太空数据中心构想是 sector hit 利好 SKHY, 长鑫 IPO 是软利空 | 9/7 US Labor Day 闭市 |
-| SPCH | -18.16% / RSI 58.5 / 趋势OFF | 2x SPCX 杠杆 ETF, underlying SpaceX private 无公开价, 5d +8.2% 反弹属 hard stop 反弹窗口 | 新闻 SPCX 跌 +8.2% 后 Scott Galloway 悲观预测 + Risk Reward Never Worse 是 disconfirming | 9/7 US Labor Day 闭市, US 数据 stale through 9/4 |
-| SPCX | +0.31% / RSI 58.5 / 趋势OFF | 1x SpaceX 私募, 5d +4.6% 反弹 | UNC endowment 30% return 含 SpaceX 投资是 supporting, Scott Galloway 悲观预测 disconfirming | 9/7 US Labor Day 闭市 |
+<div class="brief-entries" markdown="1">
+
+- **00100**
+
+  <span class="entry-meta">-36.57% / RSI 55.5 / 趋势OFF</span>
+
+  **Fundamentals**　国泰海通 增持 + Aug ARR > 800M USD 预测 USD 500M 全年收入, hard catalyst confirming
+
+  **Sentiment**　南向资金 4 天连续净买入 + 沙特 Humain 阿拉伯语 AI 模型引入 MiniMax 是 supporting 已价
+
+  **Cross-Market**　9/7 HSTECH -0.92%, 00100 5d +0.5% 跑输 HSTECH +0.5pp 个股 alpha 缺失
+
+- **02208**
+
+  <span class="entry-meta">-35.07% / RSI 39.8 / 趋势OFF · 已破吊灯止损 / 距 MA200 -30.50%</span>
+
+  **Fundamentals**　风电运营商, 1-7 月装机 +19.5% hard catalyst
+
+  **Sentiment**　JPM 减持 1.08% 至 9.77% 软利空
+
+  **Cross-Market**　9/7 HSTECH -0.92% 不同市场, 02208 跟随 A 股风电板块
+
+- **03032**
+
+  <span class="entry-meta">-16.15% / RSI 41.6 / 趋势OFF · 已破吊灯止损 / 距 MA200 -10.50%</span>
+
+  **Fundamentals**　1x HSTECH ETF
+
+  **Sentiment**　9/7 硬件龙头新品发布是 supporting 已价
+
+  **Cross-Market**　9/7 HSTECH -0.92% 5d -1.9% 趋势 off
+
+- **03033**
+
+  <span class="entry-meta">-13.66% / RSI 41.1 / 趋势OFF · 已破吊灯止损 / 距 MA200 -10.80%</span>
+
+  **Fundamentals**　1x ETF 跟踪 HSTECH, mom_1m -6.9% mom_3m -4.8% 下行
+
+  **Sentiment**　南向资金 9/3 净买 33.95 亿港元是 supporting
+
+  **Cross-Market**　9/7 HSTECH -0.92% 5d -1.9% 趋势 off
+
+- **07226**
+
+  <span class="entry-meta">-28.31% / RSI 41.3 / 趋势OFF · 已破吊灯止损 / 距 MA200 -10.90%</span>
+
+  **Fundamentals**　HSTECH 9/7 -0.92% 5d -1.9% 趋势 off + 已破吊灯止损, 1x 替代仍趋势 off
+
+  **Sentiment**　南向资金 9/3 净买 33.95 亿港元是 supporting 已价, 9/7 弱市
+
+  **Cross-Market**　9/7 US 闭市, HK 9/7 收 -0.92%, HK 跑输 NDX -0.29% 约 0.6pp
+
+- **CRCL**
+
+  <span class="entry-meta">+17.30% / RSI 67.0 / 趋势OFF / 距 MA200 +19.90%</span>
+
+  **Fundamentals**　GENIUS Act 利好, Arc 即将 launch 是 catalyst
+
+  **Sentiment**　Mizuho downgrade 是 disconfirming 软利空, 21 家国际机构 2027 H1 稳定币是长期软利空
+
+  **Cross-Market**　9/7 US Labor Day 闭市, CRCL 跟随 crypto 板块
+
+- **RKLX**
+
+  <span class="entry-meta">-69.55% / RSI 37.2 / 趋势OFF · 已破吊灯止损 / 距 MA200 -19.10%</span>
+
+  **Fundamentals**　2x RKLB 杠杆 ETF, 5d -1.2% 跑输 RKLB -0.2% 是 2x chop drag 实证
+
+  **Sentiment**　无 held 关联新闻, Musk SpaceX 太空数据中心是 sector hit 利好但 RKLX 是 RKLB 不是 SpaceX
+
+  **Cross-Market**　9/7 US Labor Day 闭市
+
+- **SKHY**
+
+  <span class="entry-meta">+4.62% / RSI 59.3 / 趋势OFF</span>
+
+  **Fundamentals**　HBM 龙头, AI 内存需求长期支撑
+
+  **Sentiment**　Musk 太空数据中心构想是 sector hit 利好 SKHY, 长鑫 IPO 是软利空
+
+  **Cross-Market**　9/7 US Labor Day 闭市
+
+- **SPCH**
+
+  <span class="entry-meta">-18.16% / RSI 58.5 / 趋势OFF</span>
+
+  **Fundamentals**　2x SPCX 杠杆 ETF, underlying SpaceX private 无公开价, 5d +8.2% 反弹属 hard stop 反弹窗口
+
+  **Sentiment**　新闻 SPCX 跌 +8.2% 后 Scott Galloway 悲观预测 + Risk Reward Never Worse 是 disconfirming
+
+  **Cross-Market**　9/7 US Labor Day 闭市, US 数据 stale through 9/4
+
+- **SPCX**
+
+  <span class="entry-meta">+0.31% / RSI 58.5 / 趋势OFF</span>
+
+  **Fundamentals**　1x SpaceX 私募, 5d +4.6% 反弹
+
+  **Sentiment**　UNC endowment 30% return 含 SpaceX 投资是 supporting, Scott Galloway 悲观预测 disconfirming
+
+  **Cross-Market**　9/7 US Labor Day 闭市
+
+</div>
+
+</div>
 
 ## 这本账现在什么样
+
+<div class="brief-card" markdown="1">
 
 ### 双币账本（HK + USD 不能直接相加）
 
@@ -108,12 +321,20 @@ swap 纪律必执行 (KCN 6/11 方针 2x→1x, swap 不择时), 但 swap 完不�
 HK 现金: 17,597 HKD | US 现金: 264.28 USD
 ```
 
+</div>
+
+<div class="brief-card" markdown="1">
+
 ### 集中度
 
 | Leg | HHI | 判定 | Top2 | 腿总值 |
 |---|---|---|---|---|
 | HK | 0.439 | 🔴 危险集中 | 87.20% | 70,492 |
 | US | 0.670 | 🔴 危险集中 | 86.90% | 3,641 |
+
+</div>
+
+<div class="brief-card" markdown="1">
 
 ### 风控硬闸
 
@@ -132,6 +353,10 @@ open **7** / overridden 0 / unacknowledged 7 / oldest 55d / decision_overdue 5
 | beta | US | high | US β vs S&P = 5.5268 (cap 3.0) — 大盘 −1% 本子约 −5.5% | risk-66b800a6afe2 |
 
 **directive**: ⛔ 4 仓位硬闸 + 3 杠杆止损触发。每条必须在 Judge 段出一个对应动作(driven_by=risk_rule,纪律性再平衡,不算听消息、不受 risk_on HOLD 默认约束)；其余主动 call 仍按 regime guard。杠杆ETF解套口径=2x→1x 同因子换仓而非清仓(见各 action)。
+
+</div>
+
+<div class="brief-card" markdown="1">
 
 ### 加仓面（收盘确认）
 
@@ -162,6 +387,10 @@ candidate **0** / wait 9 / reject 0　·　技术突破(收盘站上前 20 日�
 
 _冷启动期：单族 + 价格确认 + 非杠杆 ⇒ 半个试探仓（policy `cold_start_single_family_enabled`）；计数器填满后此例外自动失效_
 
+</div>
+
+<div class="brief-card" markdown="1">
+
 ### 回本测算
 
 | Ticker | 浮% | 2x chop drag/月 | 回本需 | 半年窗含 drag 等效标的需 |
@@ -175,6 +404,10 @@ _冷启动期：单族 + 价格确认 + 非杠杆 ⇒ 半个试探仓（policy `
 | 03033 | -13.70% | — | +15.80% | — |
 
 注：回本涨幅=成本/现价−1。2x 行加印：标的σ、横盘 decay≈σ²/12 每月、半年窗含 drag 的等效标的涨幅。解读纪律：直线涨→2x 回本更快；横盘→2x 每月白付 decay；再跌→2x 双倍挨打。换 1x 买的是后两种情景的保护，不是回本速度。
+
+</div>
+
+<div class="brief-card" markdown="1">
 
 ### 仓位明细
 
@@ -200,6 +433,10 @@ _冷启动期：单族 + 价格确认 + 非杠杆 ⇒ 半个试探仓（policy `
 | SKHY SK海力士 ADR | 1 | 169.19 | 177.00 | +8.14% | +4.62% | 8 |
 | **小计 US** |  |  |  | -67 | -20.94% | **-964** |
 
+</div>
+
+<div class="brief-card" markdown="1">
+
 ### 大盘趋势（两条腿各自的读数）
 
 | 腿 | 窗口 | 距均线/动量 | 趋势 | 读数 |
@@ -211,8 +448,12 @@ _regime3=近10日动量分 牛(>+3%)/熊(<-3%)/震荡；trend_on=200日线；US 
 
 _HK 的趋势闸只收紧 HK 杠杆腿的上限；US 杠杆腿走它自己的 per-name dial_
 
+</div>
+
 <details class="brief-appendix" markdown="1">
 <summary>背景与校准</summary>
+
+<div class="brief-card" markdown="1">
 
 ### 昨日兑现（2026-09-07 的 plan）
 
@@ -230,24 +471,87 @@ _HK 的趋势闸只收紧 HK 杠杆腿的上限；US 杠杆腿走它自己的 pe
 | SKHY | hold_and_watch | core_position | — | 50% | unknown |
 | 03033 | hold_and_watch | core_position | — | 50% | pending |
 
+</div>
+
+<div class="brief-card" markdown="1">
+
 ### 同行扫描
 
-| 持仓 | 主题 | 今日 self | 最强同行 | 差距 | 判断 |
-|---|---|---|---|---|---|
-| 00100 | HK AI 大模型 | -2.93% | 03317 迅策 +1.09% | -4.02pp | AI 大模型同业智谱 02513 / 商汤 00020 9/7 表现未确认, 00100 与板块同步 |
-| 02208 | 风电 | +0.33% | 01798 大唐新能源 +1.38% | -1.05pp | 龙源 00916 / 大唐新能源 01798 / 新天绿色 00956 同板块, 9/7 表现未确认 |
-| 03032 | HK 科技指数 1x (HSTECH 标的) | -0.66% | 03067 安硕恒生科技 -0.93% | +0.27pp | 03033 跟踪同 HSTECH 5d -2.1% 同步 |
-| 03033 | HK 科技指数 1x (HSTECH 标的) | -1.03% | 03032 恒生科技ETF -0.66% | -0.37pp | 03032 跟踪同 HSTECH, 5d -1.9% 同步 |
-| 07226 | HK 科技指数 2x leveraged (HSTECH 标的) | -1.70% | 09988 阿里巴巴-W -0.45% | -1.25pp | HSI 9/7 -0.93% / HSTECH -0.92%, 07226 = HSTECH 2x 放大 |
-| CRCL | 稳定币 + agent 支付 | -1.14% | BKKT Bakkt, Inc. -0.60% | -0.54pp | COIN 9/7 未确认, CRCL 5d +17.1% 是 peer leader |
-| RKLX | RKLB 2x leveraged | +1.27% | RKLB Rocket Lab +0.71% | +0.56pp | RKLB 5d -0.2% 自身较弱, RKLX = 2x 放大 |
-| SKHY | 存储芯片 / HBM (AI 内存) | +8.14% | STX 希捷科技 +6.34% | +1.80pp | STX 9/4 +6.34% / MU +6.1% / WDC +5.86% 集体强, SKHY 5d +9.9% 是 peer leader |
-| SPCH | SpaceX 2x leveraged (商业航天) | -2.57% | RKLX 2倍做多Rocket Lab ETF-Defiance +1.27% | -3.84pp | RKLB 5d -0.2% vs SPCH 5d +8.2% 反映 2x chop drag |
-| SPCX | 商业航天 (火箭发射 + Starlink 卫星互联网) | -1.20% | RKLB Rocket Lab +0.71% | -1.91pp | RKLB 5d -0.2% 是同业 leader |
+<div class="brief-entries" markdown="1">
+
+- **00100** · 今日 -2.93% · 差距 -4.02pp
+
+  <span class="entry-meta">HK AI 大模型 · 最强同行 03317 迅策 +1.09%</span>
+
+  **判断**　AI 大模型同业智谱 02513 / 商汤 00020 9/7 表现未确认, 00100 与板块同步
+
+- **02208** · 今日 +0.33% · 差距 -1.05pp
+
+  <span class="entry-meta">风电 · 最强同行 01798 大唐新能源 +1.38%</span>
+
+  **判断**　龙源 00916 / 大唐新能源 01798 / 新天绿色 00956 同板块, 9/7 表现未确认
+
+- **03032** · 今日 -0.66% · 差距 +0.27pp
+
+  <span class="entry-meta">HK 科技指数 1x (HSTECH 标的) · 最强同行 03067 安硕恒生科技 -0.93%</span>
+
+  **判断**　03033 跟踪同 HSTECH 5d -2.1% 同步
+
+- **03033** · 今日 -1.03% · 差距 -0.37pp
+
+  <span class="entry-meta">HK 科技指数 1x (HSTECH 标的) · 最强同行 03032 恒生科技ETF -0.66%</span>
+
+  **判断**　03032 跟踪同 HSTECH, 5d -1.9% 同步
+
+- **07226** · 今日 -1.70% · 差距 -1.25pp
+
+  <span class="entry-meta">HK 科技指数 2x leveraged (HSTECH 标的) · 最强同行 09988 阿里巴巴-W -0.45%</span>
+
+  **判断**　HSI 9/7 -0.93% / HSTECH -0.92%, 07226 = HSTECH 2x 放大
+
+- **CRCL** · 今日 -1.14% · 差距 -0.54pp
+
+  <span class="entry-meta">稳定币 + agent 支付 · 最强同行 BKKT Bakkt, Inc. -0.60%</span>
+
+  **判断**　COIN 9/7 未确认, CRCL 5d +17.1% 是 peer leader
+
+- **RKLX** · 今日 +1.27% · 差距 +0.56pp
+
+  <span class="entry-meta">RKLB 2x leveraged · 最强同行 RKLB Rocket Lab +0.71%</span>
+
+  **判断**　RKLB 5d -0.2% 自身较弱, RKLX = 2x 放大
+
+- **SKHY** · 今日 +8.14% · 差距 +1.80pp
+
+  <span class="entry-meta">存储芯片 / HBM (AI 内存) · 最强同行 STX 希捷科技 +6.34%</span>
+
+  **判断**　STX 9/4 +6.34% / MU +6.1% / WDC +5.86% 集体强, SKHY 5d +9.9% 是 peer leader
+
+- **SPCH** · 今日 -2.57% · 差距 -3.84pp
+
+  <span class="entry-meta">SpaceX 2x leveraged (商业航天) · 最强同行 RKLX 2倍做多Rocket Lab ETF-Defiance +1.27%</span>
+
+  **判断**　RKLB 5d -0.2% vs SPCH 5d +8.2% 反映 2x chop drag
+
+- **SPCX** · 今日 -1.20% · 差距 -1.91pp
+
+  <span class="entry-meta">商业航天 (火箭发射 + Starlink 卫星互联网) · 最强同行 RKLB Rocket Lab +0.71%</span>
+
+  **判断**　RKLB 5d -0.2% 是同业 leader
+
+</div>
+
+</div>
+
+<div class="brief-card" markdown="1">
 
 ### 板块全景
 
 HK AI 大模型: 9/7 5d +0.5% 跟随 HSTECH -0.92%, 00100 跑输 HSTECH +0.5pp 个股 alpha 缺失. 国泰海通 增持 + Aug ARR > 800M 是 supporting 已价. US 半导体 SOXX: 9/7 持稳, 5d +0.5%, HBM 板块 9/4 STX +6.34% / MU +6.1% / WDC +5.86% 集体强, SKHY 5d +9.9% 顶部属追高低质. 商业航天: 02208 5d -4% 受 JPM 减持 1.08% 软利空 + 中兴四号失败拖累; SPCX 5d +4.6% 反弹但 Scott Galloway 悲观预测 + Risk Reward Never Worse disconfirming. HK 1x 03032+03033 合计 8.6% 跟踪 HSTECH 趋势 off 已破吊灯止损, 仍下行.
+
+</div>
+
+<div class="brief-card" markdown="1">
 
 ### 大盘速读
 
@@ -255,20 +559,99 @@ VIX **15.30** (+5.30%) · HSI **25,413.12** (-0.93%) · HSTECH **4,527.71** (-0.
 
 VIX 15.3 +5.3% 仍 calm, F&G 41.9 fear 但从 35.2 升 6.7pp, SPX 7718.6 -0.38% / NDX 26507 -0.29% 同向下行, HSI 25413 -0.93% / HSTECH 4527 -0.92% 同步跌. 10Y 4.784% 利率持稳, DXY 99.176 持稳. 9/11 CPI 是本周最大 catalyst, 软 (<= 2.8%) = risk_on 利好降息预期, 硬 (>= 3.0%) = 继续降 beta. 9/16 FOMC 是次要 catalyst.
 
+</div>
+
+<div class="brief-card" markdown="1">
+
 ### 社交舆情
 
-| 票 | Reddit 7d | 新闻关键词 | 近 5 日 | 信号判断 |
-|---|---|---|---|---|
-| CRCL | 0 mentions | What Is Driving Circle Internet Grou、CRCL Stock Slips Overnight After Miz、Circle: Arc's Launch Is Real, But It | — | Mizuho downgrade 是 disconfirming 软利空, 21 家国际机构 2027 H1 稳定币是长期软利空 |
-| RKLX | 0 mentions | Technical Reactions to RKLX Trends i、RKLX: Benefits And Risks Of Leveragi、Defiance Daily Target 2X Long RKLB E | — | 无 held 关联新闻, Musk SpaceX 太空数据中心是 sector hit 利好但 RKLX 是 RKLB 不是 SpaceX |
-| SPCX | 1 mentions | Should You Forget SpaceX (SPCX) Stoc、Scott Galloway issues grim SpaceX st、SpaceX: The Risk Reward Has Never Be | — | UNC endowment 30% return 含 SpaceX 投资是 supporting, Scott Galloway 悲观预测 disconfirming |
-| SPCH | 1 mentions | SPCH ETF Price and Chart — CBOE:SPCH、SPCH - Leverage Shares 2X Long SPCX 、$Leverage Shares 2X Long SpaceX Dail | — | 新闻 SPCX 跌 +8.2% 后 Scott Galloway 悲观预测 + Risk Reward Never Worse 是 disconfirming |
-| SKHY | 0 mentions | SKHY Stock Gives Back Some Of Its 27、Is SK Hynix (NasdaqGS:SKHY) Underval、$SK hynix (SKHY.US)$ $Micron Technol | — | Musk 太空数据中心构想是 sector hit 利好 SKHY, 长鑫 IPO 是软利空 |
-| 00100 | 0 mentions | HK Stock Market Watch \| MINIMAX-W (0、[Major Brokerage] Guotai Haitong mai、Hong Kong Stocks in Focus \| MINIMAX- | — | 南向资金 4 天连续净买入 + 沙特 Humain 阿拉伯语 AI 模型引入 MiniMax 是 supporting 已价 |
-| 02208 | 0 mentions | Zhitong Statistics on Significant Ch、Hong Kong Stock Market Movement \| Co、Jinfeng Technology's Hong Kong-liste | — | JPM 减持 1.08% 至 9.77% 软利空 |
-| 03032 | 0 mentions | Year-End Review \| The Strongest ETF 、Zhitong HK Stock Connect Holdings Ra、New funds are channeling into the Ho | — | 9/7 硬件龙头新品发布是 supporting 已价 |
-| 07226 | 0 mentions | ETF Market Movement \| CSOP FTSE Chin、Hang Seng Tech Index Surges, Souther、What signal? Significant inflows of  | — | 南向资金 9/3 净买 33.95 亿港元是 supporting 已价, 9/7 弱市 |
-| 03033 | 0 mentions | Zhitong HK Stock Connect Holdings An、Zhitong HK Stock Connect Holdings Ra、Zhito Hong Kong Stock Connect Holdin | — | 南向资金 9/3 净买 33.95 亿港元是 supporting |
+<div class="brief-entries" markdown="1">
+
+- **CRCL** · 近 5 日 —
+
+  <span class="entry-meta">Reddit 7d 0 mentions</span>
+
+  **新闻**　What Is Driving Circle Internet Grou、CRCL Stock Slips Overnight After Miz、Circle: Arc's Launch Is Real, But It
+
+  **信号判断**　Mizuho downgrade 是 disconfirming 软利空, 21 家国际机构 2027 H1 稳定币是长期软利空
+
+- **RKLX** · 近 5 日 —
+
+  <span class="entry-meta">Reddit 7d 0 mentions</span>
+
+  **新闻**　Technical Reactions to RKLX Trends i、RKLX: Benefits And Risks Of Leveragi、Defiance Daily Target 2X Long RKLB E
+
+  **信号判断**　无 held 关联新闻, Musk SpaceX 太空数据中心是 sector hit 利好但 RKLX 是 RKLB 不是 SpaceX
+
+- **SPCX** · 近 5 日 —
+
+  <span class="entry-meta">Reddit 7d 1 mentions</span>
+
+  **新闻**　Should You Forget SpaceX (SPCX) Stoc、Scott Galloway issues grim SpaceX st、SpaceX: The Risk Reward Has Never Be
+
+  **信号判断**　UNC endowment 30% return 含 SpaceX 投资是 supporting, Scott Galloway 悲观预测 disconfirming
+
+- **SPCH** · 近 5 日 —
+
+  <span class="entry-meta">Reddit 7d 1 mentions</span>
+
+  **新闻**　SPCH ETF Price and Chart — CBOE:SPCH、SPCH - Leverage Shares 2X Long SPCX 、$Leverage Shares 2X Long SpaceX Dail
+
+  **信号判断**　新闻 SPCX 跌 +8.2% 后 Scott Galloway 悲观预测 + Risk Reward Never Worse 是 disconfirming
+
+- **SKHY** · 近 5 日 —
+
+  <span class="entry-meta">Reddit 7d 0 mentions</span>
+
+  **新闻**　SKHY Stock Gives Back Some Of Its 27、Is SK Hynix (NasdaqGS:SKHY) Underval、$SK hynix (SKHY.US)$ $Micron Technol
+
+  **信号判断**　Musk 太空数据中心构想是 sector hit 利好 SKHY, 长鑫 IPO 是软利空
+
+- **00100** · 近 5 日 —
+
+  <span class="entry-meta">Reddit 7d 0 mentions</span>
+
+  **新闻**　HK Stock Market Watch \| MINIMAX-W (0、\[Major Brokerage\] Guotai Haitong mai、Hong Kong Stocks in Focus \| MINIMAX-
+
+  **信号判断**　南向资金 4 天连续净买入 + 沙特 Humain 阿拉伯语 AI 模型引入 MiniMax 是 supporting 已价
+
+- **02208** · 近 5 日 —
+
+  <span class="entry-meta">Reddit 7d 0 mentions</span>
+
+  **新闻**　Zhitong Statistics on Significant Ch、Hong Kong Stock Market Movement \| Co、Jinfeng Technology's Hong Kong-liste
+
+  **信号判断**　JPM 减持 1.08% 至 9.77% 软利空
+
+- **03032** · 近 5 日 —
+
+  <span class="entry-meta">Reddit 7d 0 mentions</span>
+
+  **新闻**　Year-End Review \| The Strongest ETF 、Zhitong HK Stock Connect Holdings Ra、New funds are channeling into the Ho
+
+  **信号判断**　9/7 硬件龙头新品发布是 supporting 已价
+
+- **07226** · 近 5 日 —
+
+  <span class="entry-meta">Reddit 7d 0 mentions</span>
+
+  **新闻**　ETF Market Movement \| CSOP FTSE Chin、Hang Seng Tech Index Surges, Souther、What signal? Significant inflows of 
+
+  **信号判断**　南向资金 9/3 净买 33.95 亿港元是 supporting 已价, 9/7 弱市
+
+- **03033** · 近 5 日 —
+
+  <span class="entry-meta">Reddit 7d 0 mentions</span>
+
+  **新闻**　Zhitong HK Stock Connect Holdings An、Zhitong HK Stock Connect Holdings Ra、Zhito Hong Kong Stock Connect Holdin
+
+  **信号判断**　南向资金 9/3 净买 33.95 亿港元是 supporting
+
+</div>
+
+</div>
+
+<div class="brief-card" markdown="1">
 
 ### 名人异动 / 政策风向（0.4h 前）
 
@@ -280,6 +663,10 @@ VIX 15.3 +5.3% 仍 calm, F&G 41.9 fear 但从 35.2 升 6.7pp, SPX 7718.6 -0.38% 
 - [板块相关] Musk（neutral）：报道称SpaceX投资者可能低估'无人可替代马斯克'的风险，对SPCX/SPCH持仓为关键集中度警示。
 - [板块相关] Trump（endorse）：特朗普力推SEC主席削减ETF税负，称是储蓄者'全面革命'，对恒生科技ETF及美股ETF均偏利好。
 - [板块相关] Musk（endorse）：马斯克提出'太空数据中心'构想并给出激进时间表，长期利好SpaceX持仓与半导体需求叙事。
+
+</div>
+
+<div class="brief-card" markdown="1">
 
 ### 决策校准
 
@@ -293,6 +680,10 @@ VIX 15.3 +5.3% 仍 calm, F&G 41.9 fear 但从 35.2 升 6.7pp, SPX 7718.6 -0.38% 
 
 40 settled episodes / 191 raw decisions, Brier 0.3223 LOSES to constant baseline 0.3061 (overconfident: mean_conf 0.89 vs 实际 62.5% base rate); active 8 eps cluster CI [-2.59%, 2.10%] 跨 0 = 0 edge-supported, 51 abstentions; passive hold 32 eps 75% 胜率 cluster [0.36, 3.44] significant. 主动 call 信心值需大幅下调 (calibrated probability < 0.6), passive hold 默认可靠. Active execution rate 0/56 = 所有纪律 cut 从未执行, 9/4 plan 3 个 9/8 重发, 这是第 2 次发同一纪律 swap. execution 单独维度: 主动 0% 反映 0% 决心执行纪律, 7 breach 5x 反复提醒 = 团队认知到风险, 执行到仓位是另一回事.
 
+</div>
+
+<div class="brief-card" markdown="1">
+
 ### 待补
 
 - US 报价 0/5 from Nasdaq primary (5/5 from Finnhub), US 数据 stale through 9/4, 9/8 开盘才能刷新
@@ -300,5 +691,7 @@ VIX 15.3 +5.3% 仍 calm, F&G 41.9 fear 但从 35.2 升 6.7pp, SPX 7718.6 -0.38% 
 - integrity_report.json 1 WARN 详情未知
 - 03033 9/8 packet 无 technical setup, 1x 替代 buy 腿暂缓, 9/8 后观察新 setup 信号
 - 5 bar conflicts need --repair
+
+</div>
 
 </details>

--- a/memory/2026-09-09-pre-open.md
+++ b/memory/2026-09-09-pre-open.md
@@ -6,41 +6,157 @@ description: "clawock 盘前深度简报 2026-09-09：港股 + 美股真实持�
 
 # 盘前深度简报｜2026-09-09 周三 08:03 HKT
 
+<div class="brief-card brief-lede" markdown="1">
+
 Book 双 leg 都高 HHI 危险集中 (HK 0.43 / US 0.68), 9/9 preflight 仍 4 breach + 2 hard stop, 主动 call 必须由 risk_rule 驱动; 1d 港股普跌 (-5.6% 00100) + 美股 SPX/NDX -0.58/-0.32% 同步, 5d SPCH +12.6% 反弹给了纪律性 cut 的好窗口.
 
 **反方**：Decision v2 Brier 0.4111 LOSES baseline 0.3086 = 信心 calibration 不合格 (overconfident), mean_conf 0.886 vs 实际 50% base rate. 5d breach 站 27-56d, 9/4 + 9/7 + 9/8 三轮 risk_rebalance plan 全部 0 执行, 今天第 4 次重发等于写而不砍. 切完的钱 95% 变现金, swap_mandate 1:1 实际 patch 0.05:1, 1 lot = 0.0125 position tranche 解决不了 86% 单名集中.
 
+</div>
+
 ## 今天做什么
+
+<div class="brief-card" markdown="1">
 
 ### 今日动作
 
-| Ticker | Action | Frame | Strategy | driven_by | 理由 |
-|---|---|---|---|---|---|
-| 07226 | **cut** | technical_breakdown + relative_strength | risk_rebalance | risk_rule | 硬止损 -30.5% ≤ -18% 线 critical 站 27d decision_overdue；HK 杠杆 ETF 27.9% > 25% amber cap；lev_regime amber 基准 50% ×0.5=25%。breach risk-4ab7eff27f15 + risk-da9861ae6562 双闸并发。9/4 + 9/7 (Labor Day) + 9/8 连续 3 日 cut 计划皆未执行，今日第 4 次重发，不动即默认继续承担 -30% 浮亏 + 1.29%/月 chop drag。cut 释放 18,811 HKD 留现金；9/9 packet 03033 无 technical setup → 1x 替代的 buy 腿 blocked, swap_mandate 仅授权无 setup 兑现, 真 1x 承接需后续 packet 出 setup 才能 add, cut 完成 → cash 暂存等下一窗口。 |
-| SPCH | **cut** | technical_breakdown + relative_strength | risk_rebalance | risk_rule | 硬止损 -18% 线 critical 站 56d decision_overdue；单名 82.17% > 35% mandatory；US 杠杆 ETF 86.3% > 50%；US β 5.14 > 3.0 四闸并发。9/4 + 9/8 两次 cut 计划皆未执行，今日第 3 次重发。9/8 SPCH 单日 +7.4% (5d +12.6%)，如果现在 cut 是反弹窗口不是新低日（=规则允许），breakeven 13.8% 5-sigma 不可达。cut 释放 3,180 USD 配同 group_id add SPCX 1 股。9/9 packet SPCX allowed_actions = hold_and_watch/watch, 1x 替代的 buy 腿 blocked, cut 完成 → cash 暂存等下一窗口。 |
-| RKLX | **cut** | technical_breakdown + relative_strength | risk_rebalance | risk_rule | 硬止损 -68.1% ≤ -18% 线 critical 站 54d decision_overdue；breakeven 需 +213.1% (5-sigma 不可达)；chop drag 1.29%/月每天烧钱；RKLB 6/13 已清仓 swap_mandate = null 无 1x 替代，纯 cut 释放 158.7 USD 现金。9/4 + 9/8 两次 cut 计划皆未执行，今日第 3 次重发。RKLX 5d +5.2% 反弹段 cut 比新低日 cut 对 breach_return 伤害更小。 |
-| 00100 | **hold_and_watch** | mean_reversion + relative_strength | core_position | technical | 9/9 收 331.2 低于 9/4 trim 触发价 365，9/4 trim 已过窗口；现 00100 120 股 / 39,744 HKD = 58.89% HK，刚跌破 60% mandatory cap 进入 35-60% review band 不再 breach。reflections 持×12 胜6 (50%) + 减×10 胜8 (80%) = 减胜率高于持，下次反弹 350+ 应主动 trim 1 lot 摊 single_name 风险。5d -1.7% 同行 智谱 -22% / 迅策 -8.3% = 同行更弱，00100 相对抗跌；今日 1d -5.6% 同行 智谱 -10% / 迅策 -7.4% 仍领先大盘。 |
-| 03032 | **hold_and_watch** | mean_reversion + sector_rotation | core_position | technical | 03032 9/9 收 4.462 -1.54% 跟随 HSTECH 同步；200 股 892.4 HKD 占 book 1.32% 太小不值得动；与 03033 合计 HSTECH 1x 敞口 9% HK (cut 07226 后)；5d -2.0% 与 HSTECH 同步无独立 alpha。9/9 packet max_add 200 股 892 HKD 但无 technical setup, add 暂缓, 1x 替代已 saturated。 |
-| 03033 | **hold_and_watch** | sector_rotation + mean_reversion | core_position | technical | 03033 9/9 收 4.372 -1.49% 跟随 HSTECH 同步；1000 股 4,372 HKD 占 book 6.48% HK；9/8 财联社 / moomoo 显示南向资金 9/8 净流入 03033 1.79 亿 HKD 是 1x 板块少有的正资金流；5d -2.1% 与 HSTECH 一致。9/9 packet allowed_actions 含 add_only_on_trigger 但无 technical setup, swap buy 腿 blocked, 仅维持 hold。 |
-| 02208 | **hold_and_watch** | mean_reversion + earnings_setup | core_position | technical | 02208 9/9 收 9.165 +0.22% 微涨；400 股 3,666 HKD 占 book 5.43% HK；9/8 财联社 / 海鲸社确认半年报：H1 营收 337.39 亿元 +18.23% YoY, 净利 18.55 亿元 +24.67% YoY, 风机毛利率修复近 4pp, 海上装机 +48%。reflections 持×18 胜5 (28%) 是 book 最低，但 1-7 月装机 +19.5% + 累计回购 1302 万股 是 supporting 已价；5d -1.8% 同行 龙源 +1.4% / 新天 +0.8% 略强，02208 落后是 JPM 减持 1.08% 软利空未消化。 |
-| CRCL | **hold_and_watch** | mean_reversion + sentiment_shift | core_position | technical | CRCL 9/8 收 96.18 -5.75% (high 100.8 / low 95.85)；2 股 192.36 USD 占 book 4.97% US；9/4 (fx168) 报道 Circle 高管 Heath Tarbert 9 月国会听证警告 GENIUS Act 推进紧迫性 = 硬催化 confirming 已价；9/8 新闻 (Benzinga) multimillion stock sale 计划 = insider sell 软利空是 1d -5.75% 主因。reflections 持×16 胜10 (63%) book 第三高；5d +0.7% 同行 BKKT 5d +7.7% / COIN -4.9% / PYPL +1.0% 略弱；2 股 1 股加减不抵交易成本。 |
-| SKHY | **hold_and_watch** | relative_strength + mean_reversion | core_position | technical | SKHY 9/8 收 185.55 +4.83% (high 189.815 / low 182.405)；1 股 185.55 USD 占 book 4.79% US；5d +12.7% 顶位 z+2.63σ 极端；同行 STX 5d +9.2% / WDC +5.9% / MU +4.3% 集体强 SKHY 仍是 peer leader；9/8 美光收复 $1000 (华尔街见闻) 是板块反转信号，但 9/30 美光财报 30 天内才是真硬催化。reflections 持×10 胜6 (60%) 中位；1 股加减不抵交易成本。 |
-| SPCX | **hold_and_watch** | sector_rotation + mean_reversion | core_position | technical | SPCX 9/8 收 153.47 +3.73% (high 155.0 / low 145.14); 1 股 153.47 USD 占 book 3.97% US; 9/8 站上前 20 日高 152.3, alpha_confirmation setup 已存在但 9/9 packet allowed_actions = hold_and_watch/watch, add_only_on_trigger 不在 allowed 列表, SPCH cut 配套 1x 替代 buy 腿 blocked. Pivotal $2T target + Musk 9/8 endorse 是信息面强化, 但 buy 腿受 packet 约束暂缓. 现 1 股持有, 浮盈 +4.05% 已确认. |
+<div class="brief-entries" markdown="1">
+
+- **07226** · **cut**
+
+  <span class="entry-meta">technical_breakdown + relative_strength · risk_rebalance · risk_rule</span>
+
+  **理由**　硬止损 -30.5% ≤ -18% 线 critical 站 27d decision_overdue；HK 杠杆 ETF 27.9% > 25% amber cap；lev_regime amber 基准 50% ×0.5=25%。breach risk-4ab7eff27f15 + risk-da9861ae6562 双闸并发。9/4 + 9/7 (Labor Day) + 9/8 连续 3 日 cut 计划皆未执行，今日第 4 次重发，不动即默认继续承担 -30% 浮亏 + 1.29%/月 chop drag。cut 释放 18,811 HKD 留现金；9/9 packet 03033 无 technical setup → 1x 替代的 buy 腿 blocked, swap_mandate 仅授权无 setup 兑现, 真 1x 承接需后续 packet 出 setup 才能 add, cut 完成 → cash 暂存等下一窗口。
+
+- **SPCH** · **cut**
+
+  <span class="entry-meta">technical_breakdown + relative_strength · risk_rebalance · risk_rule</span>
+
+  **理由**　硬止损 -18% 线 critical 站 56d decision_overdue；单名 82.17% > 35% mandatory；US 杠杆 ETF 86.3% > 50%；US β 5.14 > 3.0 四闸并发。9/4 + 9/8 两次 cut 计划皆未执行，今日第 3 次重发。9/8 SPCH 单日 +7.4% (5d +12.6%)，如果现在 cut 是反弹窗口不是新低日（=规则允许），breakeven 13.8% 5-sigma 不可达。cut 释放 3,180 USD 配同 group_id add SPCX 1 股。9/9 packet SPCX allowed_actions = hold_and_watch/watch, 1x 替代的 buy 腿 blocked, cut 完成 → cash 暂存等下一窗口。
+
+- **RKLX** · **cut**
+
+  <span class="entry-meta">technical_breakdown + relative_strength · risk_rebalance · risk_rule</span>
+
+  **理由**　硬止损 -68.1% ≤ -18% 线 critical 站 54d decision_overdue；breakeven 需 +213.1% (5-sigma 不可达)；chop drag 1.29%/月每天烧钱；RKLB 6/13 已清仓 swap_mandate = null 无 1x 替代，纯 cut 释放 158.7 USD 现金。9/4 + 9/8 两次 cut 计划皆未执行，今日第 3 次重发。RKLX 5d +5.2% 反弹段 cut 比新低日 cut 对 breach_return 伤害更小。
+
+- **00100** · **hold_and_watch**
+
+  <span class="entry-meta">mean_reversion + relative_strength · core_position · technical</span>
+
+  **理由**　9/9 收 331.2 低于 9/4 trim 触发价 365，9/4 trim 已过窗口；现 00100 120 股 / 39,744 HKD = 58.89% HK，刚跌破 60% mandatory cap 进入 35-60% review band 不再 breach。reflections 持×12 胜6 (50%) + 减×10 胜8 (80%) = 减胜率高于持，下次反弹 350+ 应主动 trim 1 lot 摊 single_name 风险。5d -1.7% 同行 智谱 -22% / 迅策 -8.3% = 同行更弱，00100 相对抗跌；今日 1d -5.6% 同行 智谱 -10% / 迅策 -7.4% 仍领先大盘。
+
+- **03032** · **hold_and_watch**
+
+  <span class="entry-meta">mean_reversion + sector_rotation · core_position · technical</span>
+
+  **理由**　03032 9/9 收 4.462 -1.54% 跟随 HSTECH 同步；200 股 892.4 HKD 占 book 1.32% 太小不值得动；与 03033 合计 HSTECH 1x 敞口 9% HK (cut 07226 后)；5d -2.0% 与 HSTECH 同步无独立 alpha。9/9 packet max_add 200 股 892 HKD 但无 technical setup, add 暂缓, 1x 替代已 saturated。
+
+- **03033** · **hold_and_watch**
+
+  <span class="entry-meta">sector_rotation + mean_reversion · core_position · technical</span>
+
+  **理由**　03033 9/9 收 4.372 -1.49% 跟随 HSTECH 同步；1000 股 4,372 HKD 占 book 6.48% HK；9/8 财联社 / moomoo 显示南向资金 9/8 净流入 03033 1.79 亿 HKD 是 1x 板块少有的正资金流；5d -2.1% 与 HSTECH 一致。9/9 packet allowed_actions 含 add_only_on_trigger 但无 technical setup, swap buy 腿 blocked, 仅维持 hold。
+
+- **02208** · **hold_and_watch**
+
+  <span class="entry-meta">mean_reversion + earnings_setup · core_position · technical</span>
+
+  **理由**　02208 9/9 收 9.165 +0.22% 微涨；400 股 3,666 HKD 占 book 5.43% HK；9/8 财联社 / 海鲸社确认半年报：H1 营收 337.39 亿元 +18.23% YoY, 净利 18.55 亿元 +24.67% YoY, 风机毛利率修复近 4pp, 海上装机 +48%。reflections 持×18 胜5 (28%) 是 book 最低，但 1-7 月装机 +19.5% + 累计回购 1302 万股 是 supporting 已价；5d -1.8% 同行 龙源 +1.4% / 新天 +0.8% 略强，02208 落后是 JPM 减持 1.08% 软利空未消化。
+
+- **CRCL** · **hold_and_watch**
+
+  <span class="entry-meta">mean_reversion + sentiment_shift · core_position · technical</span>
+
+  **理由**　CRCL 9/8 收 96.18 -5.75% (high 100.8 / low 95.85)；2 股 192.36 USD 占 book 4.97% US；9/4 (fx168) 报道 Circle 高管 Heath Tarbert 9 月国会听证警告 GENIUS Act 推进紧迫性 = 硬催化 confirming 已价；9/8 新闻 (Benzinga) multimillion stock sale 计划 = insider sell 软利空是 1d -5.75% 主因。reflections 持×16 胜10 (63%) book 第三高；5d +0.7% 同行 BKKT 5d +7.7% / COIN -4.9% / PYPL +1.0% 略弱；2 股 1 股加减不抵交易成本。
+
+- **SKHY** · **hold_and_watch**
+
+  <span class="entry-meta">relative_strength + mean_reversion · core_position · technical</span>
+
+  **理由**　SKHY 9/8 收 185.55 +4.83% (high 189.815 / low 182.405)；1 股 185.55 USD 占 book 4.79% US；5d +12.7% 顶位 z+2.63σ 极端；同行 STX 5d +9.2% / WDC +5.9% / MU +4.3% 集体强 SKHY 仍是 peer leader；9/8 美光收复 $1000 (华尔街见闻) 是板块反转信号，但 9/30 美光财报 30 天内才是真硬催化。reflections 持×10 胜6 (60%) 中位；1 股加减不抵交易成本。
+
+- **SPCX** · **hold_and_watch**
+
+  <span class="entry-meta">sector_rotation + mean_reversion · core_position · technical</span>
+
+  **理由**　SPCX 9/8 收 153.47 +3.73% (high 155.0 / low 145.14); 1 股 153.47 USD 占 book 3.97% US; 9/8 站上前 20 日高 152.3, alpha_confirmation setup 已存在但 9/9 packet allowed_actions = hold_and_watch/watch, add_only_on_trigger 不在 allowed 列表, SPCH cut 配套 1x 替代 buy 腿 blocked. Pivotal $2T target + Musk 9/8 endorse 是信息面强化, 但 buy 腿受 packet 约束暂缓. 现 1 股持有, 浮盈 +4.05% 已确认.
+
+</div>
+
+</div>
+
+<div class="brief-card" markdown="1">
 
 ### 信心与判定
 
-| Ticker | Action | Confidence | Verdict | 理由 | 证伪条件 |
-|---|---|---|---|---|---|
-| 07226 | cut | 95% | <span class="verdict verdict-bearish">🔴 看空</span> | 硬止损 -18% + 27d decision_overdue + swap_mandate 早授权 = cut 不是预测是政策. 9/4 + 9/7 + 9/8 三轮 cut 计划 0 执行, 9/9 第 4 次重发. 9/9 packet 03033 无 technical setup, 1x 替代 buy 腿 blocked, swap 1:1 兑现不了, 仅 cut 释放 18,811 HKD 现金. | 若 HSTECH 5d 内反弹 +8% 触发 03033 add 1x 顶位、且 lev_regime 转 green → cut 节奏可放慢但 swap 仍要执行 |
-| SPCH | cut | 95% | <span class="verdict verdict-bearish">🔴 看空</span> | chop drag 1.2%/月 + breakeven 13.8% 5-sigma 不可达 + 86% US 单名集中 = 一次 -3% SPX 即可炸 book -5%. 9/4 + 9/8 两次 cut 计划 0 执行, 9/9 第 3 次重发, 9/8 单日 +7.4% 是反弹窗口不是新低日, 规则允许 cut. 9/9 packet SPCX allowed_actions = hold/watch, 1x 替代 buy 腿 blocked. | 若 SPCH 仓位已 0 (cut settlement 已成) 本条不再执行, 或若 SPCH 9/9 开盘再涨 +10% (4-sigma) 触发反弹持有观察 |
-| RKLX | cut | 95% | <span class="verdict verdict-bearish">🔴 看空</span> | 无 1x 替代 (RKLB 6/13 已清仓 swap_mandate=null) + breakeven 5-sigma 不可达 + 54d overdue 站岗烧钱 = 三条独立清仓理由任意一条都够. 9/4 + 9/8 两次 cut 计划 0 执行, 9/9 第 3 次重发. | 若 9/9 开盘 RKLX > $20 (1d +26%) + RKLB 突破 $130 触发新一轮反弹 → 暂缓 cut 但概率极低 (5-sigma 不可达) |
-| 00100 | hold_and_watch | 55% | <span class="verdict verdict-neutral">⚪ 中性</span> | 持仓 5d 持 win rate 50% 中位, 减 win rate 80% 是 book 最高之一, 但 9/4 trim 1 lot @365 9/7 high 393 已 fire, 9/9 收 331 < 365 触发价, 9/4 trim 计划 settlement 回报未知. 现价 < 触发价不是 trim 时机, 反弹 350+ 才是. | 若 9/8 trim settlement 失败 + 9/9 00100 仍 > 60% HK → 重发 trim open @350, 或 9/10 起底跌穿 320 触发 1x 重新评估 |
-| 03032 | hold_and_watch | 50% | <span class="verdict verdict-neutral">⚪ 中性</span> | 07226 cut 完后的 1x 替代已经够 (03032+03033 7 lots), 不催主动 add. 1x 替代 saturated 后任何 add 都是 1x 进一步集中度上升, 不解决单名 35% review band 的核心问题 | 若 HSTECH 跌破 4400 触发新一轮下行 → 03032+03033 1x 替代不足问题暴露, 考虑 add 03033 替代 03032 (流动性更好) |
-| 03033 | hold_and_watch | 50% | <span class="verdict verdict-neutral">⚪ 中性</span> | 9/8 packet 无 add setup 暂缓买腿, 9/9 packet add_only_on_trigger 已 authorized 但无 technical setup, swap buy 腿 blocked, 仅维持 hold. 1 lot 不够但纪律先动, 剩余资金留现金等下一个 03033 add setup 或 HSTECH 反弹后改 add 03032 | 若 07226 cut 未成交则 03033 add 自动作废; 若 03033 add 成交但 03032+03033 7 lots 仍 < 9% HK 则 1x 替代 saturated 不催主动 add |
-| 02208 | hold_and_watch | 50% | <span class="verdict verdict-neutral">⚪ 中性</span> | 半年报硬数据已 price-in 1 个月, 5d 跑输同行是 JPM 减持 + 商业航天回调拖累新能源板块的双重影响, 基本面无新增 alpha, hold 不催主动 call | 若 JPM 继续减持至 <8% 触发被动卖压或风电政策超预期转空 → 反弹 9.5+ 减 200 股 (1 lot) 摊 single_name 风险 |
-| CRCL | hold_and_watch | 55% | <span class="verdict verdict-neutral">⚪ 中性</span> | 2 股 1 股加减不抵交易成本, 1d -5.75% 已 price-in insider sell 软利空, hold 不催 call. GENIUS Act 国会听证是 confirming 硬催化但已价, 9/8 insider sell 是新 disconfirming 软利空但未升级硬催化 | 若 USDC 监管超预期收紧 / Arc 实际 launch 推迟 / insider sell 文件显示 >$50M 抛压 → 反弹 100+ 减 1 股 |
-| SKHY | hold_and_watch | 50% | <span class="verdict verdict-neutral">⚪ 中性</span> | 1 股加减不抵交易成本, 5d +12.7% 顶位不催加, 反弹 195+ 是 trim 触发位不是 hold 理由. 9/30 MU 财报是 30 天内硬催化, 9/9-9/13 5d 内可能回踩不破 180 确认支撑 | 若 9/30 MU 财报 miss 或 HBM 价格反转或长鑫 IPO 抢市占 >15% → trim 1 股 全部 |
-| SPCX | hold_and_watch | 55% | <span class="verdict verdict-neutral">⚪ 中性</span> | SPCH cut 配套 buy 腿由 swap_mandate 授权, packet max_add 1 股 = 153.47 USD, 但 9/9 packet allowed_actions = hold_and_watch/watch, add_only_on_trigger 不在 allowed 列表, buy 腿 blocked. SPCX 9/8 收 153.47 站上前 20 日高 152.3, Pivotal T target + Musk 9/8 endorse 是信息面 + 价格面双确认, 仅维持 hold. | 若 SPCH cut 未成交则本条 add 自动作废; 若 SPCX 9/9 开盘 ≥152.3 但当天回踩 ≤141.68 触发 invalidation 则 1 股不上车 |
+<div class="brief-entries" markdown="1">
+
+- **07226** · cut · 信心 95% · <span class="verdict verdict-bearish">🔴 看空</span>
+
+  **理由**　硬止损 -18% + 27d decision_overdue + swap_mandate 早授权 = cut 不是预测是政策. 9/4 + 9/7 + 9/8 三轮 cut 计划 0 执行, 9/9 第 4 次重发. 9/9 packet 03033 无 technical setup, 1x 替代 buy 腿 blocked, swap 1:1 兑现不了, 仅 cut 释放 18,811 HKD 现金.
+
+  **证伪条件**　若 HSTECH 5d 内反弹 +8% 触发 03033 add 1x 顶位、且 lev_regime 转 green → cut 节奏可放慢但 swap 仍要执行
+
+- **SPCH** · cut · 信心 95% · <span class="verdict verdict-bearish">🔴 看空</span>
+
+  **理由**　chop drag 1.2%/月 + breakeven 13.8% 5-sigma 不可达 + 86% US 单名集中 = 一次 -3% SPX 即可炸 book -5%. 9/4 + 9/8 两次 cut 计划 0 执行, 9/9 第 3 次重发, 9/8 单日 +7.4% 是反弹窗口不是新低日, 规则允许 cut. 9/9 packet SPCX allowed_actions = hold/watch, 1x 替代 buy 腿 blocked.
+
+  **证伪条件**　若 SPCH 仓位已 0 (cut settlement 已成) 本条不再执行, 或若 SPCH 9/9 开盘再涨 +10% (4-sigma) 触发反弹持有观察
+
+- **RKLX** · cut · 信心 95% · <span class="verdict verdict-bearish">🔴 看空</span>
+
+  **理由**　无 1x 替代 (RKLB 6/13 已清仓 swap_mandate=null) + breakeven 5-sigma 不可达 + 54d overdue 站岗烧钱 = 三条独立清仓理由任意一条都够. 9/4 + 9/8 两次 cut 计划 0 执行, 9/9 第 3 次重发.
+
+  **证伪条件**　若 9/9 开盘 RKLX > $20 (1d +26%) + RKLB 突破 $130 触发新一轮反弹 → 暂缓 cut 但概率极低 (5-sigma 不可达)
+
+- **00100** · hold_and_watch · 信心 55% · <span class="verdict verdict-neutral">⚪ 中性</span>
+
+  **理由**　持仓 5d 持 win rate 50% 中位, 减 win rate 80% 是 book 最高之一, 但 9/4 trim 1 lot @365 9/7 high 393 已 fire, 9/9 收 331 < 365 触发价, 9/4 trim 计划 settlement 回报未知. 现价 < 触发价不是 trim 时机, 反弹 350+ 才是.
+
+  **证伪条件**　若 9/8 trim settlement 失败 + 9/9 00100 仍 > 60% HK → 重发 trim open @350, 或 9/10 起底跌穿 320 触发 1x 重新评估
+
+- **03032** · hold_and_watch · 信心 50% · <span class="verdict verdict-neutral">⚪ 中性</span>
+
+  **理由**　07226 cut 完后的 1x 替代已经够 (03032+03033 7 lots), 不催主动 add. 1x 替代 saturated 后任何 add 都是 1x 进一步集中度上升, 不解决单名 35% review band 的核心问题
+
+  **证伪条件**　若 HSTECH 跌破 4400 触发新一轮下行 → 03032+03033 1x 替代不足问题暴露, 考虑 add 03033 替代 03032 (流动性更好)
+
+- **03033** · hold_and_watch · 信心 50% · <span class="verdict verdict-neutral">⚪ 中性</span>
+
+  **理由**　9/8 packet 无 add setup 暂缓买腿, 9/9 packet add_only_on_trigger 已 authorized 但无 technical setup, swap buy 腿 blocked, 仅维持 hold. 1 lot 不够但纪律先动, 剩余资金留现金等下一个 03033 add setup 或 HSTECH 反弹后改 add 03032
+
+  **证伪条件**　若 07226 cut 未成交则 03033 add 自动作废; 若 03033 add 成交但 03032+03033 7 lots 仍 < 9% HK 则 1x 替代 saturated 不催主动 add
+
+- **02208** · hold_and_watch · 信心 50% · <span class="verdict verdict-neutral">⚪ 中性</span>
+
+  **理由**　半年报硬数据已 price-in 1 个月, 5d 跑输同行是 JPM 减持 + 商业航天回调拖累新能源板块的双重影响, 基本面无新增 alpha, hold 不催主动 call
+
+  **证伪条件**　若 JPM 继续减持至 <8% 触发被动卖压或风电政策超预期转空 → 反弹 9.5+ 减 200 股 (1 lot) 摊 single_name 风险
+
+- **CRCL** · hold_and_watch · 信心 55% · <span class="verdict verdict-neutral">⚪ 中性</span>
+
+  **理由**　2 股 1 股加减不抵交易成本, 1d -5.75% 已 price-in insider sell 软利空, hold 不催 call. GENIUS Act 国会听证是 confirming 硬催化但已价, 9/8 insider sell 是新 disconfirming 软利空但未升级硬催化
+
+  **证伪条件**　若 USDC 监管超预期收紧 / Arc 实际 launch 推迟 / insider sell 文件显示 >$50M 抛压 → 反弹 100+ 减 1 股
+
+- **SKHY** · hold_and_watch · 信心 50% · <span class="verdict verdict-neutral">⚪ 中性</span>
+
+  **理由**　1 股加减不抵交易成本, 5d +12.7% 顶位不催加, 反弹 195+ 是 trim 触发位不是 hold 理由. 9/30 MU 财报是 30 天内硬催化, 9/9-9/13 5d 内可能回踩不破 180 确认支撑
+
+  **证伪条件**　若 9/30 MU 财报 miss 或 HBM 价格反转或长鑫 IPO 抢市占 >15% → trim 1 股 全部
+
+- **SPCX** · hold_and_watch · 信心 55% · <span class="verdict verdict-neutral">⚪ 中性</span>
+
+  **理由**　SPCH cut 配套 buy 腿由 swap_mandate 授权, packet max_add 1 股 = 153.47 USD, 但 9/9 packet allowed_actions = hold_and_watch/watch, add_only_on_trigger 不在 allowed 列表, buy 腿 blocked. SPCX 9/8 收 153.47 站上前 20 日高 152.3, Pivotal T target + Musk 9/8 endorse 是信息面 + 价格面双确认, 仅维持 hold.
+
+  **证伪条件**　若 SPCH cut 未成交则本条 add 自动作废; 若 SPCX 9/9 开盘 ≥152.3 但当天回踩 ≤141.68 触发 invalidation 则 1 股不上车
+
+</div>
+
+</div>
+
+<div class="brief-card" markdown="1">
 
 ### 下一节点
 
@@ -50,7 +166,11 @@ Book 双 leg 都高 HHI 危险集中 (HK 0.43 / US 0.68), 9/9 preflight 仍 4 br
 4. 09:30 ET 重发 RKLX cut 10 (无 1x 替代, hard stop 54d decision_overdue, breakeven 5-sigma 不可达)
 5. EOD 检查 9/9 breach 状态, 理想 4 breach 全清 (4 cuts executed), US beta 5.14→~1.5, HK 杠杆 0%, US 杠杆 0%, book 单名最大 SPCX 2 股 ≈ 7.9% US
 
+</div>
+
 ## 我的看法
+
+<div class="brief-card" markdown="1">
 
 ### 多空对辩
 
@@ -66,6 +186,10 @@ Book 双 leg 都高 HHI 危险集中 (HK 0.43 / US 0.68), 9/9 preflight 仍 4 br
 
 攻击当前最强共识: 切 2x 换 1x = 降 beta 同时保敞口 (KCNyu 9/3 定的解套口径). 但 9/4 + 9/7 + 9/8 三轮 plan 全部 0 执行, 9/9 第 4 次重发意味着纪律性 swap 在缺执行通道时只是纸面纪律. 攻击的是 swap-mandate 框架本身, 不是反对换仓动作.
 
+</div>
+
+<div class="brief-card" markdown="1">
+
 ### 风险官三票
 
 **Aggressive（抓 upside） · 今日首位表态**
@@ -80,22 +204,121 @@ Book 双 leg 都高 HHI 危险集中 (HK 0.43 / US 0.68), 9/9 preflight 仍 4 br
 
 每个争议票必须拍边: 00100 hold (等 trim 窗口); 03032 + 03033 hold (1x 替代已饱和); 02208 hold (5d 跑输同行但 H1 硬数据 price-in); CRCL hold (1 股加减不抵成本); SKHY hold (5d +12.7% 顶位不催加). 主动 call 仅在 07226 / SPCH / RKLX 三个 hard stop, 配套 03033 / SPCX 1 lot add 由 swap_mandate 授权.
 
+</div>
+
+<div class="brief-card" markdown="1">
+
 ### 分析师四格
 
-| 票 | Market（harness 计算） | Fundamentals | Sentiment | Cross-Market |
-|---|---|---|---|---|
-| 00100 | -40.12% / RSI 51.4 / 趋势OFF | H1 估值锚在 ARR 800 亿港币 + 算力紧缺 9-10 月 M3 Pro 是中期催化, 但财联社 9/8 报道智谱估值中枢被机构下调暗示行业估值重估开始, 00100 不豁免 | 9/8 财联社 / moomoo / fx168 智谱估值下调是软情绪 → 硬催化过渡 (评级机构正式下调是 hard, 媒体猜测是 soft). 标记为 disconfirming 软利空但未升级, 不驱动主动 cut, 仅 hold + 设 trim 触发 | 9/8 美股 SPX -0.58% / NDX -0.12% / HSI -0.38% / HSTECH -1.61% 同向下行, 1d 大盘共振, 5d 板块共振 - AI 板块是 9/8 港股最弱板块, 1d 跌幅 1.6% 跑输 HSI |
-| 02208 | -34.93% / RSI 40.2 / 趋势OFF · 已破吊灯止损 / 距 MA200 -30.20% | H1 净利 18.55 亿 +24.67% YoY 是硬数据, 但 18.55 vs 2025 全年 25.9 GW 装机基数低, YoY 改善可解读为低基数修复不是趋势反转; 1-7 月累计 +19.5% + 累计回购 1302 万股是 supporting | JPM 减持 1.08% 是软利空未消化, 财联社 / 海鲸社 9/2 半年报硬数据已 confirming; 9/8 软情绪偏弱, 不驱动 cut | 9/8 HSI -0.38% / HSTECH -1.61%, 02208 +0.22% 跑赢 HSI 0.6pp 是同行新天 +2.5% / 龙源 +1.2% 跟随; 5d -1.8% 仍弱于 HSI 5d -2% 但跑输 HSI 0.2pp 几近持平 |
-| 03032 | -17.45% / RSI 37.8 / 趋势OFF · 已破吊灯止损 / 距 MA200 -11.70% | 03032 跟踪 HSTECH 100%, 1x 无主动 alpha, 被动跟踪, 适合作为 1x 替代但不适合加仓超配 | 南向资金 9/8 净流入 1.79 亿 HKD 至 03033 (不是 03032), 03032 缺乏南向资金数据是流动性劣势 | 9/8 HSTECH -1.61% 同步拖累 03032 -1.54%, 跨市场无独立信号 |
-| 03033 | -14.94% / RSI 37.5 / 趋势OFF · 已破吊灯止损 / 距 MA200 -12.00% | 03033 跟踪 HSTECH 100%, 流动性优于 03032, 适合作为 1x 替代首选 | 南向资金 9/8 净流入 1.79 亿 HKD 03033 是软情绪偏强信号, 不驱动主动 add, 仅作为 1x 替代选择依据 | 9/8 HSTECH -1.61% 同步拖累 03033 -1.49%, 跨市场无独立信号 |
-| 07226 | -30.46% / RSI 37.5 / 趋势OFF · 已破吊灯止损 / 距 MA200 -12.20% | 07226 是 HSTECH 2x 杠杆 ETF, 跟踪 HSTECH 100% × 2, 无主动 alpha, 持有目的是 HSTECH 上行 leverage, 当前 HSTECH -12.2% 距 200MA + chop drag 双向不友好 | 无独立 sentiment 信号, 2x 杠杆 ETF 不适用 sentiment 框架, 由硬止损 + cap breach 驱动 cut | 9/8 HSTECH -1.61% 同步拖累 07226 -3.01% (2x 杠杆 working 1.87x), 5d -4.2% 是 1.99x 杠杆 working 正常范围 |
-| CRCL | +10.55% / RSI 60.6 / 趋势OFF / 距 MA200 +12.90% | GENIUS Act 推进 + stablecoin 全球美元霸权 + agent 支付是长期赛道, 但 1d -5.75% 暗示高估值 + 内部解锁同步信号, Mizuho 9/4 downgrade 是软利空 | 9/4 GENIUS Act 国会听证是硬催化 confirming, 9/8 insider sell 是软利空 disconfirming 未升级, hold 不催 call, 设反弹 100+ trim 触发 | 9/8 NDX -0.12% / COIN -3.1% / PYPL -3.2%, CRCL -5.75% 跑输 NDX 5.6pp, 1d 加密支付板块共振 |
-| RKLX | -68.06% / RSI 40.9 / 趋势OFF · 已破吊灯止损 / 距 MA200 -17.20% | RKLX 跟踪 RKLB 2x, 持有目的是 RKLB 上行 leverage, 当前 RKLB $100.17 距 RKLX 成本 $49.69 已腰斩, breakeven +213.1% 需 RKLB 5d +100% (5-sigma 不可达) | 无独立 sentiment 信号, 2x 杠杆 ETF 不适用 sentiment 框架, 由硬止损 + chop drag 驱动 cut | 9/8 RKLB 5d +3.0% 反弹, RKLX 5d +5.2% 跑赢 RKLB 1.7x (2x 杠杆 working 1.7x), 但绝对收益 +5.2% 远不及回本所需 +213.1% |
-| SKHY | +9.67% / RSI 63.1 / 趋势OFF · z+2.6σ极端 | HBM 短缺到 2030 是长期硬数据, MU 9/30 财报 7.5% 收益预期是短期硬催化, SKHY 1d +4.83% 已 price-in 部分 | Musk 9/8 endorse SPCX 上市路径 + Pivotal $2T target 假设是软情绪偏强, 不直接驱动 SKHY 但板块情绪传导; SKHY 1d +4.83% 9/9 开盘回踩概率高属软情绪降温, hold 不催 call | 9/8 NDX -0.12% / SOXX 未明 / MU 1d -1.6%, SKHY +4.83% 跑赢 NDX 4.95pp + 跑赢 MU 6.4pp, 1d HBM 板块 peer leader |
-| SPCH | -12.11% / RSI 62.3 / 趋势OFF · z+2.3σ极端 | SPCH 跟踪 SPCX 2x, 持有目的是 SPCX 上行 leverage, 当前 SPCX 153.47 已浮盈 +4.05%, 但 SPCH 浮亏 -12.1% 是 chop drag 主导, breakeven 13.8% 需 SPCX 5d +6.4% (4-sigma) | Musk 9/8 endorse SPCX 上市路径是软情绪偏强, Pivotal $2T target 假设是 hard catalyst 升级. 但 软情绪按 SKILL 只能动 confidence 不能翻 bucket, 4 闸并发是政策不需听消息 | 9/8 SPCX +3.73% 同步支撑 SPCH +7.4% (2x 杠杆 working 1.98x), 5d SPCX +6.8% × 2 = 13.6% 区间, SPCH 5d +12.6% 在 1.85x 杠杆范围 |
-| SPCX | +4.05% / RSI 62.3 / 趋势OFF · z+2.3σ极端 | SPCX 跟踪 SpaceX 1x, 持有目的是 SpaceX 上行 beta, 浮盈 +4.05% 已确认, alpha_confirmation setup 授权加仓 | Musk 9/8 endorse SPCX 上市路径是软情绪偏强, Pivotal $2T target 假设是 hard catalyst 升级, 信息面 + 价格面双确认, alpha_confirmation setup 授权加仓 | 9/8 SPX -0.58% / NDX -0.12%, SPCX +3.73% 跑赢 SPX 4.31pp + 跑赢 NDX 3.85pp, 1d 商业航天板块 peer leader (BKSY +7.7% / ASTS +6.1% / RKLB +2.5%) |
+<div class="brief-entries" markdown="1">
+
+- **00100**
+
+  <span class="entry-meta">-40.12% / RSI 51.4 / 趋势OFF</span>
+
+  **Fundamentals**　H1 估值锚在 ARR 800 亿港币 + 算力紧缺 9-10 月 M3 Pro 是中期催化, 但财联社 9/8 报道智谱估值中枢被机构下调暗示行业估值重估开始, 00100 不豁免
+
+  **Sentiment**　9/8 财联社 / moomoo / fx168 智谱估值下调是软情绪 → 硬催化过渡 (评级机构正式下调是 hard, 媒体猜测是 soft). 标记为 disconfirming 软利空但未升级, 不驱动主动 cut, 仅 hold + 设 trim 触发
+
+  **Cross-Market**　9/8 美股 SPX -0.58% / NDX -0.12% / HSI -0.38% / HSTECH -1.61% 同向下行, 1d 大盘共振, 5d 板块共振 - AI 板块是 9/8 港股最弱板块, 1d 跌幅 1.6% 跑输 HSI
+
+- **02208**
+
+  <span class="entry-meta">-34.93% / RSI 40.2 / 趋势OFF · 已破吊灯止损 / 距 MA200 -30.20%</span>
+
+  **Fundamentals**　H1 净利 18.55 亿 +24.67% YoY 是硬数据, 但 18.55 vs 2025 全年 25.9 GW 装机基数低, YoY 改善可解读为低基数修复不是趋势反转; 1-7 月累计 +19.5% + 累计回购 1302 万股是 supporting
+
+  **Sentiment**　JPM 减持 1.08% 是软利空未消化, 财联社 / 海鲸社 9/2 半年报硬数据已 confirming; 9/8 软情绪偏弱, 不驱动 cut
+
+  **Cross-Market**　9/8 HSI -0.38% / HSTECH -1.61%, 02208 +0.22% 跑赢 HSI 0.6pp 是同行新天 +2.5% / 龙源 +1.2% 跟随; 5d -1.8% 仍弱于 HSI 5d -2% 但跑输 HSI 0.2pp 几近持平
+
+- **03032**
+
+  <span class="entry-meta">-17.45% / RSI 37.8 / 趋势OFF · 已破吊灯止损 / 距 MA200 -11.70%</span>
+
+  **Fundamentals**　03032 跟踪 HSTECH 100%, 1x 无主动 alpha, 被动跟踪, 适合作为 1x 替代但不适合加仓超配
+
+  **Sentiment**　南向资金 9/8 净流入 1.79 亿 HKD 至 03033 (不是 03032), 03032 缺乏南向资金数据是流动性劣势
+
+  **Cross-Market**　9/8 HSTECH -1.61% 同步拖累 03032 -1.54%, 跨市场无独立信号
+
+- **03033**
+
+  <span class="entry-meta">-14.94% / RSI 37.5 / 趋势OFF · 已破吊灯止损 / 距 MA200 -12.00%</span>
+
+  **Fundamentals**　03033 跟踪 HSTECH 100%, 流动性优于 03032, 适合作为 1x 替代首选
+
+  **Sentiment**　南向资金 9/8 净流入 1.79 亿 HKD 03033 是软情绪偏强信号, 不驱动主动 add, 仅作为 1x 替代选择依据
+
+  **Cross-Market**　9/8 HSTECH -1.61% 同步拖累 03033 -1.49%, 跨市场无独立信号
+
+- **07226**
+
+  <span class="entry-meta">-30.46% / RSI 37.5 / 趋势OFF · 已破吊灯止损 / 距 MA200 -12.20%</span>
+
+  **Fundamentals**　07226 是 HSTECH 2x 杠杆 ETF, 跟踪 HSTECH 100% × 2, 无主动 alpha, 持有目的是 HSTECH 上行 leverage, 当前 HSTECH -12.2% 距 200MA + chop drag 双向不友好
+
+  **Sentiment**　无独立 sentiment 信号, 2x 杠杆 ETF 不适用 sentiment 框架, 由硬止损 + cap breach 驱动 cut
+
+  **Cross-Market**　9/8 HSTECH -1.61% 同步拖累 07226 -3.01% (2x 杠杆 working 1.87x), 5d -4.2% 是 1.99x 杠杆 working 正常范围
+
+- **CRCL**
+
+  <span class="entry-meta">+10.55% / RSI 60.6 / 趋势OFF / 距 MA200 +12.90%</span>
+
+  **Fundamentals**　GENIUS Act 推进 + stablecoin 全球美元霸权 + agent 支付是长期赛道, 但 1d -5.75% 暗示高估值 + 内部解锁同步信号, Mizuho 9/4 downgrade 是软利空
+
+  **Sentiment**　9/4 GENIUS Act 国会听证是硬催化 confirming, 9/8 insider sell 是软利空 disconfirming 未升级, hold 不催 call, 设反弹 100+ trim 触发
+
+  **Cross-Market**　9/8 NDX -0.12% / COIN -3.1% / PYPL -3.2%, CRCL -5.75% 跑输 NDX 5.6pp, 1d 加密支付板块共振
+
+- **RKLX**
+
+  <span class="entry-meta">-68.06% / RSI 40.9 / 趋势OFF · 已破吊灯止损 / 距 MA200 -17.20%</span>
+
+  **Fundamentals**　RKLX 跟踪 RKLB 2x, 持有目的是 RKLB 上行 leverage, 当前 RKLB $100.17 距 RKLX 成本 $49.69 已腰斩, breakeven +213.1% 需 RKLB 5d +100% (5-sigma 不可达)
+
+  **Sentiment**　无独立 sentiment 信号, 2x 杠杆 ETF 不适用 sentiment 框架, 由硬止损 + chop drag 驱动 cut
+
+  **Cross-Market**　9/8 RKLB 5d +3.0% 反弹, RKLX 5d +5.2% 跑赢 RKLB 1.7x (2x 杠杆 working 1.7x), 但绝对收益 +5.2% 远不及回本所需 +213.1%
+
+- **SKHY**
+
+  <span class="entry-meta">+9.67% / RSI 63.1 / 趋势OFF · z+2.6σ极端</span>
+
+  **Fundamentals**　HBM 短缺到 2030 是长期硬数据, MU 9/30 财报 7.5% 收益预期是短期硬催化, SKHY 1d +4.83% 已 price-in 部分
+
+  **Sentiment**　Musk 9/8 endorse SPCX 上市路径 + Pivotal $2T target 假设是软情绪偏强, 不直接驱动 SKHY 但板块情绪传导; SKHY 1d +4.83% 9/9 开盘回踩概率高属软情绪降温, hold 不催 call
+
+  **Cross-Market**　9/8 NDX -0.12% / SOXX 未明 / MU 1d -1.6%, SKHY +4.83% 跑赢 NDX 4.95pp + 跑赢 MU 6.4pp, 1d HBM 板块 peer leader
+
+- **SPCH**
+
+  <span class="entry-meta">-12.11% / RSI 62.3 / 趋势OFF · z+2.3σ极端</span>
+
+  **Fundamentals**　SPCH 跟踪 SPCX 2x, 持有目的是 SPCX 上行 leverage, 当前 SPCX 153.47 已浮盈 +4.05%, 但 SPCH 浮亏 -12.1% 是 chop drag 主导, breakeven 13.8% 需 SPCX 5d +6.4% (4-sigma)
+
+  **Sentiment**　Musk 9/8 endorse SPCX 上市路径是软情绪偏强, Pivotal $2T target 假设是 hard catalyst 升级. 但 软情绪按 SKILL 只能动 confidence 不能翻 bucket, 4 闸并发是政策不需听消息
+
+  **Cross-Market**　9/8 SPCX +3.73% 同步支撑 SPCH +7.4% (2x 杠杆 working 1.98x), 5d SPCX +6.8% × 2 = 13.6% 区间, SPCH 5d +12.6% 在 1.85x 杠杆范围
+
+- **SPCX**
+
+  <span class="entry-meta">+4.05% / RSI 62.3 / 趋势OFF · z+2.3σ极端</span>
+
+  **Fundamentals**　SPCX 跟踪 SpaceX 1x, 持有目的是 SpaceX 上行 beta, 浮盈 +4.05% 已确认, alpha_confirmation setup 授权加仓
+
+  **Sentiment**　Musk 9/8 endorse SPCX 上市路径是软情绪偏强, Pivotal $2T target 假设是 hard catalyst 升级, 信息面 + 价格面双确认, alpha_confirmation setup 授权加仓
+
+  **Cross-Market**　9/8 SPX -0.58% / NDX -0.12%, SPCX +3.73% 跑赢 SPX 4.31pp + 跑赢 NDX 3.85pp, 1d 商业航天板块 peer leader (BKSY +7.7% / ASTS +6.1% / RKLB +2.5%)
+
+</div>
+
+</div>
 
 ## 这本账现在什么样
+
+<div class="brief-card" markdown="1">
 
 ### 双币账本（HK + USD 不能直接相加）
 
@@ -110,12 +333,20 @@ Book 双 leg 都高 HHI 危险集中 (HK 0.43 / US 0.68), 9/9 preflight 仍 4 br
 HK 现金: 17,597 HKD | US 现金: 264.28 USD
 ```
 
+</div>
+
+<div class="brief-card" markdown="1">
+
 ### 集中度
 
 | Leg | HHI | 判定 | Top2 | 腿总值 |
 |---|---|---|---|---|
 | HK | 0.432 | 🔴 危险集中 | 86.80% | 67,485 |
 | US | 0.683 | 🔴 危险集中 | 87.10% | 3,870 |
+
+</div>
+
+<div class="brief-card" markdown="1">
 
 ### 风控硬闸
 
@@ -133,6 +364,10 @@ open **6** / overridden 0 / unacknowledged 6 / oldest 56d / decision_overdue 5
 | beta | US | high | US β vs S&P = 5.1413 (cap 3.0) — 大盘 −1% 本子约 −5.1% | risk-66b800a6afe2 |
 
 **directive**: ⛔ 4 仓位硬闸 + 2 杠杆止损触发。每条必须在 Judge 段出一个对应动作(driven_by=risk_rule,纪律性再平衡,不算听消息、不受 risk_on HOLD 默认约束)；其余主动 call 仍按 regime guard。杠杆ETF解套口径=2x→1x 同因子换仓而非清仓(见各 action)。
+
+</div>
+
+<div class="brief-card" markdown="1">
 
 ### 加仓面（收盘确认）
 
@@ -162,6 +397,10 @@ candidate **0** / wait 5 / reject 2　·　技术突破(收盘站上前 20 日�
 
 _冷启动期：单族 + 价格确认 + 非杠杆 ⇒ 半个试探仓（policy `cold_start_single_family_enabled`）；计数器填满后此例外自动失效_
 
+</div>
+
+<div class="brief-card" markdown="1">
+
 ### 回本测算
 
 | Ticker | 浮% | 2x chop drag/月 | 回本需 | 半年窗含 drag 等效标的需 |
@@ -175,6 +414,10 @@ _冷启动期：单族 + 价格确认 + 非杠杆 ⇒ 半个试探仓（policy `
 | SPCH | -12.10% | — | +13.80% | — |
 
 注：回本涨幅=成本/现价−1。2x 行加印：标的σ、横盘 decay≈σ²/12 每月、半年窗含 drag 的等效标的涨幅。解读纪律：直线涨→2x 回本更快；横盘→2x 每月白付 decay；再跌→2x 双倍挨打。换 1x 买的是后两种情景的保护，不是回本速度。
+
+</div>
+
+<div class="brief-card" markdown="1">
 
 ### 仓位明细
 
@@ -200,6 +443,10 @@ _冷启动期：单族 + 价格确认 + 非杠杆 ⇒ 半个试探仓（policy `
 | SKHY SK海力士 ADR | 1 | 169.19 | 185.55 | +4.83% | +9.67% | 16 |
 | **小计 US** |  |  |  | 229 | -15.97% | **-736** |
 
+</div>
+
+<div class="brief-card" markdown="1">
+
 ### 大盘趋势（两条腿各自的读数）
 
 | 腿 | 窗口 | 距均线/动量 | 趋势 | 读数 |
@@ -211,8 +458,12 @@ _regime3=近10日动量分 牛(>+3%)/熊(<-3%)/震荡；trend_on=200日线；US 
 
 _HK 的趋势闸只收紧 HK 杠杆腿的上限；US 杠杆腿走它自己的 per-name dial_
 
+</div>
+
 <details class="brief-appendix" markdown="1">
 <summary>背景与校准</summary>
+
+<div class="brief-card" markdown="1">
 
 ### 昨日兑现（2026-09-08 的 plan）
 
@@ -228,20 +479,79 @@ _HK 的趋势闸只收紧 HK 杠杆腿的上限；US 杠杆腿走它自己的 pe
 | CRCL | hold_and_watch | core_position | — | 55% | pending |
 | SKHY | hold_and_watch | core_position | — | 50% | pending |
 
+</div>
+
+<div class="brief-card" markdown="1">
+
 ### 同行扫描
 
-| 持仓 | 主题 | 今日 self | 最强同行 | 差距 | 判断 |
-|---|---|---|---|---|---|
-| 00100 | HK AI 大模型 | -5.59% | 09678 云知声 +6.63% | -12.22pp | 9/8 1d 同行 智谱 -10% / 迅策 -7.4% / 商汤 -2.5% / 云知声 +6.6% / 范式 +0.9%, 00100 -5.6% 排第 4, 5d 智谱 -22% 仍最弱, 00100 5d -1.7% 相对抗跌是 peer leader 但绝对收益 -1.7% 仍负 |
-| 02208 | 风电 | +0.22% | 00956 新天绿色能源 +2.47% | -2.25pp | 9/8 1d 同行 新天 +2.5% / 龙源 +1.2% / 东方电气 +0.6%, 02208 +0.22% 排末位; 5d 1.4% / 0.8% / -1.7%, 02208 -1.8% 排末位, 落后大盘 0-1.4pp 不是入场信号 |
-| 03032 | HK 科技指数 1x (HSTECH 标的) | -1.54% | 03033 南方恒生科技 -1.49% | -0.05pp | 1d 同行 03033 -1.5% / 03067 -1.5%, 03032 同步, 5d -2.0% / -2.1% / -2.0% 三只几乎一致, 同 underlying = 同走势 |
-| 03033 | HK 科技指数 1x (HSTECH 标的) | -1.49% | 03032 恒生科技ETF -1.54% | +0.05pp | 1d 同行 03032 -1.5% / 03067 -1.5%, 03033 同步, 5d -2.1% / -2.0% / -2.0% 几乎一致 |
-| 07226 | HK 科技指数 2x leveraged (HSTECH 标的) | -3.01% | 03690 美团-W +0.69% | -3.70pp | 5d 同行 09988 阿里 -0.8% / 00700 腾讯 -0.5% / 09999 网易 -0.3% / 03690 美团 +5.2% / 09618 京东 -1.5%, 07226 -4.2% 跑输大票 1.7-9.4pp, 2x 杠杆放大 HSTECH 弱势 |
-| CRCL | 稳定币 + agent 支付 | -5.75% | BKKT Bakkt, Inc. -0.84% | -4.91pp | 9/8 1d 同行 BKKT -0.8% / COIN -3.1% / PYPL -3.2%, CRCL -5.75% 跑输 2.6-5.0pp, 5d BKKT +7.7% / COIN -4.9% / PYPL +1.0% 暗示 CRCL 5d 区间震荡无独立 alpha |
-| RKLX | RKLB 2x leveraged | +4.89% | RKLB Rocket Lab +2.51% | +2.38pp | 5d RKLB +3.0% / ASTS +11.9%, RKLX +5.2% 跑输 ASTS 6.7pp, 商业航天板块 RKLX 杠杆未充分 working 因为 RKLB 反弹幅度小 |
-| SKHY | 存储芯片 / HBM (AI 内存) | +4.83% | STX 希捷科技 +6.49% | -1.66pp | 9/8 1d 同行 STX +6.5% / WDC +2.1% / MU -1.6%, SKHY +4.83% 排第 2 跑输 STX 1.7pp, 5d STX +9.2% / WDC +5.9% / MU +4.3%, SKHY +12.7% 仍是 5d peer leader |
-| SPCH | SpaceX 2x leveraged (商业航天) | +7.40% | ASTS AST SpaceMobile +6.11% | +1.29pp | 5d 同行 SPCX +6.8% / ASTS +11.9% / RKLB +3.0%, SPCH +12.6% 是 1.85x 杠杆 working, 跑输 ASTS 0.7pp 暗示 2x 杠杆未充分 working 因为 SPCX 反弹幅度有限 |
-| SPCX | 商业航天 (火箭发射 + Starlink 卫星互联网) | +3.73% | BKSY Blacksky Technology Inc. +7.71% | -3.98pp | 9/8 1d 同行 BKSY +7.7% / ASTS +6.1% / RKLB +2.5%, SPCX +3.73% 排第 3 跑输 BKSY 4.0pp, 5d ASTS +11.9% / SPCX +6.8% / RKLB +3.0%, SPCX 5d 排第 2 是 peer leader |
+<div class="brief-entries" markdown="1">
+
+- **00100** · 今日 -5.59% · 差距 -12.22pp
+
+  <span class="entry-meta">HK AI 大模型 · 最强同行 09678 云知声 +6.63%</span>
+
+  **判断**　9/8 1d 同行 智谱 -10% / 迅策 -7.4% / 商汤 -2.5% / 云知声 +6.6% / 范式 +0.9%, 00100 -5.6% 排第 4, 5d 智谱 -22% 仍最弱, 00100 5d -1.7% 相对抗跌是 peer leader 但绝对收益 -1.7% 仍负
+
+- **02208** · 今日 +0.22% · 差距 -2.25pp
+
+  <span class="entry-meta">风电 · 最强同行 00956 新天绿色能源 +2.47%</span>
+
+  **判断**　9/8 1d 同行 新天 +2.5% / 龙源 +1.2% / 东方电气 +0.6%, 02208 +0.22% 排末位; 5d 1.4% / 0.8% / -1.7%, 02208 -1.8% 排末位, 落后大盘 0-1.4pp 不是入场信号
+
+- **03032** · 今日 -1.54% · 差距 -0.05pp
+
+  <span class="entry-meta">HK 科技指数 1x (HSTECH 标的) · 最强同行 03033 南方恒生科技 -1.49%</span>
+
+  **判断**　1d 同行 03033 -1.5% / 03067 -1.5%, 03032 同步, 5d -2.0% / -2.1% / -2.0% 三只几乎一致, 同 underlying = 同走势
+
+- **03033** · 今日 -1.49% · 差距 +0.05pp
+
+  <span class="entry-meta">HK 科技指数 1x (HSTECH 标的) · 最强同行 03032 恒生科技ETF -1.54%</span>
+
+  **判断**　1d 同行 03032 -1.5% / 03067 -1.5%, 03033 同步, 5d -2.1% / -2.0% / -2.0% 几乎一致
+
+- **07226** · 今日 -3.01% · 差距 -3.70pp
+
+  <span class="entry-meta">HK 科技指数 2x leveraged (HSTECH 标的) · 最强同行 03690 美团-W +0.69%</span>
+
+  **判断**　5d 同行 09988 阿里 -0.8% / 00700 腾讯 -0.5% / 09999 网易 -0.3% / 03690 美团 +5.2% / 09618 京东 -1.5%, 07226 -4.2% 跑输大票 1.7-9.4pp, 2x 杠杆放大 HSTECH 弱势
+
+- **CRCL** · 今日 -5.75% · 差距 -4.91pp
+
+  <span class="entry-meta">稳定币 + agent 支付 · 最强同行 BKKT Bakkt, Inc. -0.84%</span>
+
+  **判断**　9/8 1d 同行 BKKT -0.8% / COIN -3.1% / PYPL -3.2%, CRCL -5.75% 跑输 2.6-5.0pp, 5d BKKT +7.7% / COIN -4.9% / PYPL +1.0% 暗示 CRCL 5d 区间震荡无独立 alpha
+
+- **RKLX** · 今日 +4.89% · 差距 +2.38pp
+
+  <span class="entry-meta">RKLB 2x leveraged · 最强同行 RKLB Rocket Lab +2.51%</span>
+
+  **判断**　5d RKLB +3.0% / ASTS +11.9%, RKLX +5.2% 跑输 ASTS 6.7pp, 商业航天板块 RKLX 杠杆未充分 working 因为 RKLB 反弹幅度小
+
+- **SKHY** · 今日 +4.83% · 差距 -1.66pp
+
+  <span class="entry-meta">存储芯片 / HBM (AI 内存) · 最强同行 STX 希捷科技 +6.49%</span>
+
+  **判断**　9/8 1d 同行 STX +6.5% / WDC +2.1% / MU -1.6%, SKHY +4.83% 排第 2 跑输 STX 1.7pp, 5d STX +9.2% / WDC +5.9% / MU +4.3%, SKHY +12.7% 仍是 5d peer leader
+
+- **SPCH** · 今日 +7.40% · 差距 +1.29pp
+
+  <span class="entry-meta">SpaceX 2x leveraged (商业航天) · 最强同行 ASTS AST SpaceMobile +6.11%</span>
+
+  **判断**　5d 同行 SPCX +6.8% / ASTS +11.9% / RKLB +3.0%, SPCH +12.6% 是 1.85x 杠杆 working, 跑输 ASTS 0.7pp 暗示 2x 杠杆未充分 working 因为 SPCX 反弹幅度有限
+
+- **SPCX** · 今日 +3.73% · 差距 -3.98pp
+
+  <span class="entry-meta">商业航天 (火箭发射 + Starlink 卫星互联网) · 最强同行 BKSY Blacksky Technology Inc. +7.71%</span>
+
+  **判断**　9/8 1d 同行 BKSY +7.7% / ASTS +6.1% / RKLB +2.5%, SPCX +3.73% 排第 3 跑输 BKSY 4.0pp, 5d ASTS +11.9% / SPCX +6.8% / RKLB +3.0%, SPCX 5d 排第 2 是 peer leader
+
+</div>
+
+</div>
+
+<div class="brief-card" markdown="1">
 
 ### 板块全景
 
@@ -260,26 +570,109 @@ _HK 的趋势闸只收紧 HK 杠杆腿的上限；US 杠杆腿走它自己的 pe
 
 港股 AI 板块 9/8 普跌: 智谱 -10.02% (估值中枢下调) / 迅策 -7.42% / 00100 -5.59% / 商汤 -2.5%; 同行云知声 +6.63% / 范式 +0.89% 是 1d 涨幅榜, 00100 落后 12.2pp 是板块共振拖累不是 alpha 弱化. 风电板块 9/8 集体稳: 02208 +0.22% / 新天绿色 +2.5% / 龙源 +1.2%, 02208 跑输同行是 JPM 减持 1.08% 软利空未消化. 商业航天 9/8 集体反弹: SPCX +3.73% / BKSY +7.7% / ASTS +6.1% / RKLB +2.5%, 你是 peer leader 不是落后. HBM 板块 9/8 集体强: SKHY +4.83% / STX +6.5% / WDC +2.1%, 美光 -1.6% 落后是 9/30 财报前获利兑现, 你 5d +12.7% 仍是 peer leader.
 
+</div>
+
+<div class="brief-card" markdown="1">
+
 ### 大盘速读
 
 VIX **15.72** (+8.19%) · HSI **25,317.18** (-0.38%) · HSTECH **4,454.85** (-1.61%) · SPX **7,673.52** (-0.58%) · 纳指 **26,421.41** (-0.32%) · DXY **98.84** (+0.05%) · F&G **40.8** fear · 10Y **4.81%**（as_of 2026-09-08T23:43:25.925048+00:00, age 0.4h）
 
 VIX 15.72 +8.19% 单日升 + F&G 40.8 fear (前周 30.9) + 10Y 4.806% 高位 = 表面平静底下 trend_off 风险. SPX 7673.52 -0.58% / NDX 29507.7 -0.12% / HSI 25317.18 -0.38% / HSTECH 4454.85 -1.61% 同向下行, 大盘不是 risk_on 也不是 risk_off, 是 chop. 对你意味: leveraged 仓位 (07226 / SPCH / RKLX) 借反弹日 cut 优于观望, 现金保留 18,811 HKD + 3,180 USD 应对 9/11 CPI + 9/16 FOMC.
 
+</div>
+
+<div class="brief-card" markdown="1">
+
 ### 社交舆情
 
-| 票 | Reddit 7d | 新闻关键词 | 近 5 日 | 信号判断 |
-|---|---|---|---|---|
-| CRCL | 0 mentions | CRCL Stock Slides Despite Analysts’ 、$CRCL stock is down 3% today. Here's、A multimillion stock sale is planned | — | 9/4 GENIUS Act 国会听证是硬催化 confirming, 9/8 insider sell 是软利空 disconfirming 未升级, hold 不催 call, 设反弹 100+ trim 触发 |
-| RKLX | 0 mentions | Technical Reactions to RKLX Trends i、RKLX: Benefits And Risks Of Leveragi、RKLX - Defiance Daily Target 2X Long | — | 无独立 sentiment 信号, 2x 杠杆 ETF 不适用 sentiment 框架, 由硬止损 + chop drag 驱动 cut |
-| SPCX | 0 mentions | What SpaceX CEO Elon Musk needs to d、SpaceX is a buy as the rocket compan、SpaceX’s $2 Trillion Valuation Hinge | — | Musk 9/8 endorse SPCX 上市路径是软情绪偏强, Pivotal $2T target 假设是 hard catalyst 升级, 信息面 + 价格面双确认, alpha_confirmation setup 授权加仓 |
-| SPCH | 0 mentions | Liquidity Mapping Around (SPCH) Pric、SPCH ETF Price and Chart — CBOE:SPCH、SPCH - Leverage Shares 2X Long SPCX  | — | Musk 9/8 endorse SPCX 上市路径是软情绪偏强, Pivotal $2T target 假设是 hard catalyst 升级. 但 软情绪按 SKILL 只能动 confidence 不能翻 bucket, 4 闸并发是政策不需听消息 |
-| SKHY | 0 mentions | SK hynix(SKHY) Stock Price Today \| Q、symbol__ Stock Quote Price and Forec、Top SK hynix (SKHY) Competitors 2026 | — | Musk 9/8 endorse SPCX 上市路径 + Pivotal $2T target 假设是软情绪偏强, 不直接驱动 SKHY 但板块情绪传导; SKHY 1d +4.83% 9/9 开盘回踩概率高属软情绪降温, hold 不催 call |
-| 00100 | 0 mentions | HK Stock Market Watch \| MINIMAX-W (0、Hong Kong Stocks in Focus \| MINIMAX-、MINIMAX GROUP INC. - W (100) - stock | — | 9/8 财联社 / moomoo / fx168 智谱估值下调是软情绪 → 硬催化过渡 (评级机构正式下调是 hard, 媒体猜测是 soft). 标记为 disconfirming 软利空但未升级, 不驱动主动 cut, 仅 hold + 设 trim 触发 |
-| 02208 | 0 mentions | Zhitong Statistics on Significant Ch、Hong Kong Stock Market Movement \| Co、Jinfeng Technology's Hong Kong-liste | — | JPM 减持 1.08% 是软利空未消化, 财联社 / 海鲸社 9/2 半年报硬数据已 confirming; 9/8 软情绪偏弱, 不驱动 cut |
-| 03032 | 0 mentions | Year-End Review \| The Strongest ETF 、Zhitong HK Stock Connect Holdings Ra、New funds are channeling into the Ho | — | 南向资金 9/8 净流入 1.79 亿 HKD 至 03033 (不是 03032), 03032 缺乏南向资金数据是流动性劣势 |
-| 07226 | 0 mentions | ETF Market Movement \| CSOP FTSE Chin、7226 ETF Price and Chart — HKEX:7226、Hang Seng Tech Index Surges, Souther | — | 无独立 sentiment 信号, 2x 杠杆 ETF 不适用 sentiment 框架, 由硬止损 + cap breach 驱动 cut |
-| 03033 | 0 mentions | Zhitong HK Stock Connect Holdings An、Zhitong HK Stock Connect Holdings Ra、Zhito Hong Kong Stock Connect Holdin | — | 南向资金 9/8 净流入 1.79 亿 HKD 03033 是软情绪偏强信号, 不驱动主动 add, 仅作为 1x 替代选择依据 |
+<div class="brief-entries" markdown="1">
+
+- **CRCL** · 近 5 日 —
+
+  <span class="entry-meta">Reddit 7d 0 mentions</span>
+
+  **新闻**　CRCL Stock Slides Despite Analysts’ 、$CRCL stock is down 3% today. Here's、A multimillion stock sale is planned
+
+  **信号判断**　9/4 GENIUS Act 国会听证是硬催化 confirming, 9/8 insider sell 是软利空 disconfirming 未升级, hold 不催 call, 设反弹 100+ trim 触发
+
+- **RKLX** · 近 5 日 —
+
+  <span class="entry-meta">Reddit 7d 0 mentions</span>
+
+  **新闻**　Technical Reactions to RKLX Trends i、RKLX: Benefits And Risks Of Leveragi、RKLX - Defiance Daily Target 2X Long
+
+  **信号判断**　无独立 sentiment 信号, 2x 杠杆 ETF 不适用 sentiment 框架, 由硬止损 + chop drag 驱动 cut
+
+- **SPCX** · 近 5 日 —
+
+  <span class="entry-meta">Reddit 7d 0 mentions</span>
+
+  **新闻**　What SpaceX CEO Elon Musk needs to d、SpaceX is a buy as the rocket compan、SpaceX’s $2 Trillion Valuation Hinge
+
+  **信号判断**　Musk 9/8 endorse SPCX 上市路径是软情绪偏强, Pivotal $2T target 假设是 hard catalyst 升级, 信息面 + 价格面双确认, alpha_confirmation setup 授权加仓
+
+- **SPCH** · 近 5 日 —
+
+  <span class="entry-meta">Reddit 7d 0 mentions</span>
+
+  **新闻**　Liquidity Mapping Around (SPCH) Pric、SPCH ETF Price and Chart — CBOE:SPCH、SPCH - Leverage Shares 2X Long SPCX 
+
+  **信号判断**　Musk 9/8 endorse SPCX 上市路径是软情绪偏强, Pivotal $2T target 假设是 hard catalyst 升级. 但 软情绪按 SKILL 只能动 confidence 不能翻 bucket, 4 闸并发是政策不需听消息
+
+- **SKHY** · 近 5 日 —
+
+  <span class="entry-meta">Reddit 7d 0 mentions</span>
+
+  **新闻**　SK hynix(SKHY) Stock Price Today \| Q、symbol\_\_ Stock Quote Price and Forec、Top SK hynix (SKHY) Competitors 2026
+
+  **信号判断**　Musk 9/8 endorse SPCX 上市路径 + Pivotal $2T target 假设是软情绪偏强, 不直接驱动 SKHY 但板块情绪传导; SKHY 1d +4.83% 9/9 开盘回踩概率高属软情绪降温, hold 不催 call
+
+- **00100** · 近 5 日 —
+
+  <span class="entry-meta">Reddit 7d 0 mentions</span>
+
+  **新闻**　HK Stock Market Watch \| MINIMAX-W (0、Hong Kong Stocks in Focus \| MINIMAX-、MINIMAX GROUP INC. - W (100) - stock
+
+  **信号判断**　9/8 财联社 / moomoo / fx168 智谱估值下调是软情绪 → 硬催化过渡 (评级机构正式下调是 hard, 媒体猜测是 soft). 标记为 disconfirming 软利空但未升级, 不驱动主动 cut, 仅 hold + 设 trim 触发
+
+- **02208** · 近 5 日 —
+
+  <span class="entry-meta">Reddit 7d 0 mentions</span>
+
+  **新闻**　Zhitong Statistics on Significant Ch、Hong Kong Stock Market Movement \| Co、Jinfeng Technology's Hong Kong-liste
+
+  **信号判断**　JPM 减持 1.08% 是软利空未消化, 财联社 / 海鲸社 9/2 半年报硬数据已 confirming; 9/8 软情绪偏弱, 不驱动 cut
+
+- **03032** · 近 5 日 —
+
+  <span class="entry-meta">Reddit 7d 0 mentions</span>
+
+  **新闻**　Year-End Review \| The Strongest ETF 、Zhitong HK Stock Connect Holdings Ra、New funds are channeling into the Ho
+
+  **信号判断**　南向资金 9/8 净流入 1.79 亿 HKD 至 03033 (不是 03032), 03032 缺乏南向资金数据是流动性劣势
+
+- **07226** · 近 5 日 —
+
+  <span class="entry-meta">Reddit 7d 0 mentions</span>
+
+  **新闻**　ETF Market Movement \| CSOP FTSE Chin、7226 ETF Price and Chart — HKEX:7226、Hang Seng Tech Index Surges, Souther
+
+  **信号判断**　无独立 sentiment 信号, 2x 杠杆 ETF 不适用 sentiment 框架, 由硬止损 + cap breach 驱动 cut
+
+- **03033** · 近 5 日 —
+
+  <span class="entry-meta">Reddit 7d 0 mentions</span>
+
+  **新闻**　Zhitong HK Stock Connect Holdings An、Zhitong HK Stock Connect Holdings Ra、Zhito Hong Kong Stock Connect Holdin
+
+  **信号判断**　南向资金 9/8 净流入 1.79 亿 HKD 03033 是软情绪偏强信号, 不驱动主动 add, 仅作为 1x 替代选择依据
+
+</div>
+
+</div>
+
+<div class="brief-card" markdown="1">
 
 ### 名人异动 / 政策风向（0.4h 前）
 
@@ -289,6 +682,10 @@ VIX 15.72 +8.19% 单日升 + F&G 40.8 fear (前周 30.9) + 10Y 4.806% 高位 = �
 - [新机会] Musk（endorse）：特斯拉无稀土电机或削弱中国贸易筹码，看多特斯拉/电动车供应链独立化。
 - [新机会] Trump（attack）：特朗普抨击Google/Apple/Visa/高盛/花旗/富国/美银/沃尔玛/丰田/T-Mobile等资助左翼智库。
 - [板块相关] Trump（endorse）：特朗普赞扬SEC主席Atkins削减ETF税负，提振ETF板块(含其恒生科技ETF持仓)。
+
+</div>
+
+<div class="brief-card" markdown="1">
 
 ### 决策校准
 
@@ -302,6 +699,10 @@ VIX 15.72 +8.19% 单日升 + F&G 40.8 fear (前周 30.9) + 10Y 4.806% 高位 = �
 
 Decision v2 过去 30d settled 12 episodes, 12 partial, 2 unresolved (87.5% graded). by_driver: technical 28 episodes 71% win rate edge_significant true, sentiment 7 episodes 71% win rate 但 cluster CI null, risk_rule 10 episodes 50% win rate cluster CI [-2.59, -0.07] edge_significant false = 纪律性 cut 历史上是负 edge, 因为恐慌割肉后容易踏空反弹. Brier 0.4111 vs baseline 0.3086 = 信心 calibration 不合格 (overconfident), mean_conf 0.886 vs 实际 50% base rate. active execution: 0/58 (known) = 0% 主动 call 跟进率, 0 edge-supported predictions = 当前样本不支持任何 confidence > 50% 的主动 call. 这条不是说 95% 风险纪律不能标, 是说别把高 confidence 错当 alpha 标签.
 
+</div>
+
+<div class="brief-card" markdown="1">
+
 ### 待补
 
 - 9/4 + 9/7 + 9/8 三轮 risk_rebalance plan 全部 execution_status=unknown, broker integration 未实现, 真实成交回报缺失, breach 状态完全靠 portfolio.json 静态推测
@@ -309,5 +710,7 @@ Decision v2 过去 30d settled 12 episodes, 12 partial, 2 unresolved (87.5% grad
 - RKLX 9/9 packet 缺 swap_mandate (RKLB 6/13 已清仓) 但 RKLX 浮亏 -68.1% breakeven +213.1% 5-sigma 不可达, 1x 替代需要重新筛选 (PLTR/SOXX/SMH 等) 而非纯 cut
 - SPCX 9/9 packet alpha_confirmation setup valid_for_sessions 5 = 9/9-9/13 共 5 个本地交易日, 若 SPCH cut 未成交则配套 add 自动作废
 - 5 bar conflicts need --repair
+
+</div>
 
 </details>

--- a/memory/2026-09-10-pre-open.md
+++ b/memory/2026-09-10-pre-open.md
@@ -6,39 +6,145 @@ description: "clawock 盘前深度简报 2026-09-10：港股 + 美股真实持�
 
 # 盘前深度简报｜2026-09-10 周四 08:03 HKT
 
+<div class="brief-card brief-lede" markdown="1">
+
 HK 0.428 / US 0.746 双 leg 危险集中, 5 仓位硬闸 + 3 杠杆止损并发 — 第 5 轮 cut 计划 (07226 第 5 次, RKLX/SPCH 第 4 次), 9/16 FOMC 是制度切换硬催化. book 真实浮亏 USD-base -6,039 / HKD-base -47,362 (USDHKD 7.8423).
 
 **反方**：reflections 显示 cut 在 9 场 episode 中 5 胜 4 负 (55.6%), 不是铁赢; 9/9 SPCH 反弹 6.5% + 9/8 RKLX 反弹 1.6% 给了更好 cut 窗口, 但 4 轮 0 执行的执行疲劳是真实风险, 第 5 轮继续是写而不砍的话纪律性失效 + 每月 1.29-1.39% chop drag 持续烧钱. active decisions 11 场 cluster CI [-2.72, 1.79] 跨 0 = 无择时 edge, signal_size_multiplier 全 0, 今日 call 是纪律而非预测.
 
+</div>
+
 ## 今天做什么
+
+<div class="brief-card" markdown="1">
 
 ### 今日动作
 
-| Ticker | Action | Frame | Strategy | driven_by | 理由 |
-|---|---|---|---|---|---|
-| 07226 | **cut** | technical_breakdown + relative_strength | risk_rebalance | risk_rule | 硬止损 -31.6% ≤ -18% 线 critical 站 28d decision_overdue；HK 杠杆 ETF 28.1% > 25% amber cap；lev_regime amber 基准 50% ×0.5=25%。breach risk-4ab7eff27f15 (leveraged_hard_stop) + risk-da9861ae6562 (leveraged_exposure:HK) 双闸并发。9/4 + 9/7 + 9/8 + 9/9 连续 4 日 cut 计划皆未执行，今日第 5 次重发。cut 释放 18,500 HKD 留现金；9/10 packet 03033 仍无 technical setup → 1x 替代的 buy 腿 blocked, swap_mandate 仅授权无 setup 兑现, 真 1x 承接需后续 packet 出 setup 才能 add, cut 完成 → cash 暂存等下一窗口。 |
-| RKLX | **cut** | technical_breakdown + mean_reversion | risk_rebalance | risk_rule | 硬止损 -70.8% ≤ -18% 线 critical 站 55d decision_overdue；breakeven 需 +242.9% (5-sigma 不可达)；chop drag 1.39%/月每天烧钱；RKLB 6/13 已清仓 swap_mandate = null 无 1x 替代，纯 cut 释放 ~158 USD 现金。9/4 + 9/8 + 9/9 三次 cut 计划皆未执行，今日第 4 次重发。RKLX 5d +0.8% 反弹段 cut 比新低日 cut 对 breach_return 伤害更小。 |
-| SPCH | **cut** | technical_breakdown + relative_strength | risk_rebalance | risk_rule | 硬止损 -18.8% ≤ -18% 线 critical 站 57d decision_overdue；单名 85.99% > 35% mandatory；US 杠杆 ETF 90.2% > 50%；US β 5.54 > 3.0 四闸并发。9/4 + 9/8 + 9/9 三次 cut 计划皆未执行，今日第 4 次重发。9/9 SPCH 单日 +6.5% 反弹段 cut 比新低日 cut 对 breach_return 伤害更小。cut 释放 ~$2,937 配同 transaction_group_id add SPCX 1 股 — swap_mandate 授权的 1x 同因子换仓。 |
-| SPCX | **add_only_on_trigger** | relative_strength + sector_rotation | risk_rebalance | risk_rule | swap_mandate 授权（breach_id risk-95ac7f6cd591, max_value $2,937, driven_by=risk_rule, 规则非择时）：SPCH 触发硬止损 → 换 1x 同因子 SPCX, 敞口保留、停 decay。packet allowed_actions 含 add_only_on_trigger + technical_setup_ids 含 alpha_confirmation, 双重授权。9/9 SPCX 收 147.55 < 155.0 触发价 = 单纯 alpha_confirmation 触发未达，但 swap_mandate 是规则型硬授权 override 该触发，需与 SPCH cut 配 transaction_group_id 同步执行。packet max_add_shares=1, 故加 1 股 $147.55；剩余 $2,789 cut 释放的现金暂存等 SPCX 出 technical setup 后续分批 add。 |
-| 00100 | **hold_and_watch** | sector_rotation + mean_reversion | core_position | technical | 00100 9/9 收 320.8 +0.07%, 120 股 / 38,496 HKD = 58.4% HK (单一仓位); 5d -6.4% 同行 智谱 -10% / 迅策 -7.4% = 同行更弱, 00100 相对抗跌但绝对仍弱; 1d -5.59% 同行 智谱 -10.02% / 迅策 -7.42% 仍领先大盘。packet allowed_actions=[hold_and_watch, watch] 限制 trim, 即便 reflections 减×10 胜8 (80% WR) 优于持×12 胜6 (50% WR), 只能维持 hold_and_watch 等待反弹 350+ 的 trim 窗口。AI 板块 9/9 全面回调 智谱 -10% / 迅策 -7% / 00100 -5.6% 是核心信号 — 行业竞争 + 估值重估, 资金从独立大模型流向云平台。9/4 沙特 HUMAIN 基于 MiniMax M3 发布 Arabic 大模型是 confirming 已价; 8/28 招股说明书模型版权风险仍未消化。 |
-| 02208 | **hold_and_watch** | earnings_setup + sector_rotation | core_position | technical | 02208 9/9 收 9.27 +0.22%, 400 股 / 3,708 HKD = 5.62% HK; 9/8 财联社 / 海鲸社半年报：H1 营收 337.39 亿元 +18.23% YoY, 净利 18.55 亿元 +24.67% YoY, 风机毛利率修复近 4pp, 海上装机 +48%。reflections 持×18 胜6 (35%) 是 book 最低, 但 1-7 月装机 +19.5% + 累计回购 1302 万股 + JPM/BlackRock 9 月加仓 0.28% / 0.09% 是 supporting 已价。5d +2.7% 同行 龙源 +1.4% / 新天 +0.8% 略强, 02208 落后是 JPM 减持 1.08% (已) + 风电出口预期受 Trump 关税施压 (sector_hits) 软利空未消化。packet allowed_actions=[hold_and_watch, watch] 限制主动 call, 维持 hold。 |
-| 03032 | **hold_and_watch** | technical_breakdown | core_position | technical | 03032 9/9 收 4.422 -1.49% 跟随 HSTECH 同步; 200 股 884.4 HKD 占 book 1.34% HK 太小不值得动; 与 03033 合计 HSTECH 1x 敞口 9% HK (cut 07226 后)。5d -2.0% 与 HSTECH 同步无独立 alpha。9/10 packet max_add 200 股 892 HKD 但无 technical setup, add 暂缓; 1x 替代已 saturated。HSTECH 9/9 收 4420.79 (前期支撑 4800 跌破), 制度 amber, 1x 持仓不放大下行。 |
-| 03033 | **hold_and_watch** | sector_rotation | core_position | technical | 03033 9/9 收 4.332 -1.49% 跟随 HSTECH 同步; 1000 股 4,332 HKD 占 book 6.57% HK; 9/3 财联社 / moomoo 显示南向资金 9/3 净流入 03033 1.79 亿 HKD 是 1x 板块少有的正资金流; 5d -2.3% 与 HSTECH 一致。9/10 packet allowed_actions=[hold_and_watch, watch, add_only_on_trigger] 但无 technical setup, swap buy 腿 (07226 → 03033) blocked。仅维持 hold。 |
-| CRCL | **hold_and_watch** | earnings_setup + sentiment_shift | core_position | technical | CRCL 9/8 收 96.18 -5.75% (high 100.8 / low 95.85), 9/9 收 92.99 续跌 3.3%; 2 股 185.98 USD 占 book 5.45% US。9/4 (fx168) 报道 Circle 高管 Heath Tarbert 9 月国会听证警告 GENIUS Act 推进紧迫性 = 硬催化 confirming 已价; 9/8 新闻 (Benzinga) multimillion stock sale 计划 + 9/9 CTO 减持 pre-set trading plan = insider sell 软利空是 1d -5.75% / -3.3% 主因。reflections 持×17 胜10 (58%) book 中位; 5d +3.9% 同行 BKKT +7.7% / COIN -4.9% / PYPL +1.0% 略弱。2 股 1 股加减不抵交易成本。9/8 报道 Circle $400M Tazapay acquisition all-stock 2027 close, 利好但已价。 |
+<div class="brief-entries" markdown="1">
+
+- **07226** · **cut**
+
+  <span class="entry-meta">technical_breakdown + relative_strength · risk_rebalance · risk_rule</span>
+
+  **理由**　硬止损 -31.6% ≤ -18% 线 critical 站 28d decision_overdue；HK 杠杆 ETF 28.1% > 25% amber cap；lev_regime amber 基准 50% ×0.5=25%。breach risk-4ab7eff27f15 (leveraged_hard_stop) + risk-da9861ae6562 (leveraged_exposure:HK) 双闸并发。9/4 + 9/7 + 9/8 + 9/9 连续 4 日 cut 计划皆未执行，今日第 5 次重发。cut 释放 18,500 HKD 留现金；9/10 packet 03033 仍无 technical setup → 1x 替代的 buy 腿 blocked, swap_mandate 仅授权无 setup 兑现, 真 1x 承接需后续 packet 出 setup 才能 add, cut 完成 → cash 暂存等下一窗口。
+
+- **RKLX** · **cut**
+
+  <span class="entry-meta">technical_breakdown + mean_reversion · risk_rebalance · risk_rule</span>
+
+  **理由**　硬止损 -70.8% ≤ -18% 线 critical 站 55d decision_overdue；breakeven 需 +242.9% (5-sigma 不可达)；chop drag 1.39%/月每天烧钱；RKLB 6/13 已清仓 swap_mandate = null 无 1x 替代，纯 cut 释放 ~158 USD 现金。9/4 + 9/8 + 9/9 三次 cut 计划皆未执行，今日第 4 次重发。RKLX 5d +0.8% 反弹段 cut 比新低日 cut 对 breach_return 伤害更小。
+
+- **SPCH** · **cut**
+
+  <span class="entry-meta">technical_breakdown + relative_strength · risk_rebalance · risk_rule</span>
+
+  **理由**　硬止损 -18.8% ≤ -18% 线 critical 站 57d decision_overdue；单名 85.99% > 35% mandatory；US 杠杆 ETF 90.2% > 50%；US β 5.54 > 3.0 四闸并发。9/4 + 9/8 + 9/9 三次 cut 计划皆未执行，今日第 4 次重发。9/9 SPCH 单日 +6.5% 反弹段 cut 比新低日 cut 对 breach_return 伤害更小。cut 释放 ~$2,937 配同 transaction_group_id add SPCX 1 股 — swap_mandate 授权的 1x 同因子换仓。
+
+- **SPCX** · **add_only_on_trigger**
+
+  <span class="entry-meta">relative_strength + sector_rotation · risk_rebalance · risk_rule</span>
+
+  **理由**　swap_mandate 授权（breach_id risk-95ac7f6cd591, max_value $2,937, driven_by=risk_rule, 规则非择时）：SPCH 触发硬止损 → 换 1x 同因子 SPCX, 敞口保留、停 decay。packet allowed_actions 含 add_only_on_trigger + technical_setup_ids 含 alpha_confirmation, 双重授权。9/9 SPCX 收 147.55 < 155.0 触发价 = 单纯 alpha_confirmation 触发未达，但 swap_mandate 是规则型硬授权 override 该触发，需与 SPCH cut 配 transaction_group_id 同步执行。packet max_add_shares=1, 故加 1 股 $147.55；剩余 $2,789 cut 释放的现金暂存等 SPCX 出 technical setup 后续分批 add。
+
+- **00100** · **hold_and_watch**
+
+  <span class="entry-meta">sector_rotation + mean_reversion · core_position · technical</span>
+
+  **理由**　00100 9/9 收 320.8 +0.07%, 120 股 / 38,496 HKD = 58.4% HK (单一仓位); 5d -6.4% 同行 智谱 -10% / 迅策 -7.4% = 同行更弱, 00100 相对抗跌但绝对仍弱; 1d -5.59% 同行 智谱 -10.02% / 迅策 -7.42% 仍领先大盘。packet allowed_actions=[hold_and_watch, watch] 限制 trim, 即便 reflections 减×10 胜8 (80% WR) 优于持×12 胜6 (50% WR), 只能维持 hold_and_watch 等待反弹 350+ 的 trim 窗口。AI 板块 9/9 全面回调 智谱 -10% / 迅策 -7% / 00100 -5.6% 是核心信号 — 行业竞争 + 估值重估, 资金从独立大模型流向云平台。9/4 沙特 HUMAIN 基于 MiniMax M3 发布 Arabic 大模型是 confirming 已价; 8/28 招股说明书模型版权风险仍未消化。
+
+- **02208** · **hold_and_watch**
+
+  <span class="entry-meta">earnings_setup + sector_rotation · core_position · technical</span>
+
+  **理由**　02208 9/9 收 9.27 +0.22%, 400 股 / 3,708 HKD = 5.62% HK; 9/8 财联社 / 海鲸社半年报：H1 营收 337.39 亿元 +18.23% YoY, 净利 18.55 亿元 +24.67% YoY, 风机毛利率修复近 4pp, 海上装机 +48%。reflections 持×18 胜6 (35%) 是 book 最低, 但 1-7 月装机 +19.5% + 累计回购 1302 万股 + JPM/BlackRock 9 月加仓 0.28% / 0.09% 是 supporting 已价。5d +2.7% 同行 龙源 +1.4% / 新天 +0.8% 略强, 02208 落后是 JPM 减持 1.08% (已) + 风电出口预期受 Trump 关税施压 (sector_hits) 软利空未消化。packet allowed_actions=[hold_and_watch, watch] 限制主动 call, 维持 hold。
+
+- **03032** · **hold_and_watch**
+
+  <span class="entry-meta">technical_breakdown · core_position · technical</span>
+
+  **理由**　03032 9/9 收 4.422 -1.49% 跟随 HSTECH 同步; 200 股 884.4 HKD 占 book 1.34% HK 太小不值得动; 与 03033 合计 HSTECH 1x 敞口 9% HK (cut 07226 后)。5d -2.0% 与 HSTECH 同步无独立 alpha。9/10 packet max_add 200 股 892 HKD 但无 technical setup, add 暂缓; 1x 替代已 saturated。HSTECH 9/9 收 4420.79 (前期支撑 4800 跌破), 制度 amber, 1x 持仓不放大下行。
+
+- **03033** · **hold_and_watch**
+
+  <span class="entry-meta">sector_rotation · core_position · technical</span>
+
+  **理由**　03033 9/9 收 4.332 -1.49% 跟随 HSTECH 同步; 1000 股 4,332 HKD 占 book 6.57% HK; 9/3 财联社 / moomoo 显示南向资金 9/3 净流入 03033 1.79 亿 HKD 是 1x 板块少有的正资金流; 5d -2.3% 与 HSTECH 一致。9/10 packet allowed_actions=[hold_and_watch, watch, add_only_on_trigger] 但无 technical setup, swap buy 腿 (07226 → 03033) blocked。仅维持 hold。
+
+- **CRCL** · **hold_and_watch**
+
+  <span class="entry-meta">earnings_setup + sentiment_shift · core_position · technical</span>
+
+  **理由**　CRCL 9/8 收 96.18 -5.75% (high 100.8 / low 95.85), 9/9 收 92.99 续跌 3.3%; 2 股 185.98 USD 占 book 5.45% US。9/4 (fx168) 报道 Circle 高管 Heath Tarbert 9 月国会听证警告 GENIUS Act 推进紧迫性 = 硬催化 confirming 已价; 9/8 新闻 (Benzinga) multimillion stock sale 计划 + 9/9 CTO 减持 pre-set trading plan = insider sell 软利空是 1d -5.75% / -3.3% 主因。reflections 持×17 胜10 (58%) book 中位; 5d +3.9% 同行 BKKT +7.7% / COIN -4.9% / PYPL +1.0% 略弱。2 股 1 股加减不抵交易成本。9/8 报道 Circle $400M Tazapay acquisition all-stock 2027 close, 利好但已价。
+
+</div>
+
+</div>
+
+<div class="brief-card" markdown="1">
 
 ### 信心与判定
 
-| Ticker | Action | Confidence | Verdict | 理由 | 证伪条件 |
-|---|---|---|---|---|---|
-| 07226 | cut | 95% | <span class="verdict verdict-bearish">🔴 看空</span> | 硬止损线 + 制度 amber + 双 breach 站 28d = 不再是预测, 是纪律; 不 cut 默认每月 -1.29% chop drag 烧钱. 9/15 仍 hold 浮亏未收窄到 -25% 内, 强制 cut 不再等下一窗口. | 无 — packet 锁 cut, 4 闸并发, breach 已站 28d, 任何反弹都是逃命窗口. |
-| RKLX | cut | 95% | <span class="verdict verdict-bearish">🔴 看空</span> | breakeven 242.9% 5-sigma 不可达 + 月 1.39% chop drag + 硬止损已站 55d; hold 的每一天都在烧钱. 无 1x 替代时纯 cut 是纪律性唯一出口. | 无 — RKLB 已清仓无 1x 替代; cut 是唯一选项. 任何反弹都是逃命窗口. |
-| SPCH | cut | 95% | <span class="verdict verdict-bearish">🔴 看空</span> | 4 闸并发 + 硬止损站 57d + 单名 86% > 35% mandatory 是纪律性硬约束, cut 同步配 SPCX 1x 同因子换仓保留敞口. | 无 — 4 闸并发, packet 锁 cut, 任何反弹都是逃命窗口. SPCX 1x 替代 buy 腿 (1 股 $147.55) 配 transaction_group_id 同步执行是唯一执行结构. |
-| SPCX | add_only_on_trigger | 65% | <span class="verdict verdict-neutral">⚪ 中性</span> | swap_mandate 授权存在, packet 允许 1 股 add, 1 股 0.0125 position tranche 是 harness 设计的最小兑现单元. 砍执行 = 5% 换仓, 砍不执行 = 0%. | 若 SPCH cut 未执行 / transaction_group_id 不匹配, 1x 替代 buy 腿无效, 暂停 add 等 cut 落地. SPCX 跌破 142.396 (invalidation_price) = setup 失效, 暂停 add. |
-| 00100 | hold_and_watch | 50% | <span class="verdict verdict-neutral">⚪ 中性</span> | packet 锁死 trim, 仅 hold_and_watch; 9/15 若反弹至 350+ 且 packet 解锁 = 强 trim 触发 (1 lot 20 股), 9/15 跌破 320 走 manual 路径执行 trim. | 若 9/15 同行智谱 / 迅策反弹但 00100 仍弱 320 之下, alpha 耗尽信号; 9/16 FOMC 若意外鹰派 (加 25bp) = 估值进一步承压. |
-| 02208 | hold_and_watch | 50% | <span class="verdict verdict-neutral">⚪ 中性</span> | packet 锁 hold_and_watch, 6 重基本面支撑支持维持; 9/15 同行 龙源/新天 反弹但 02208 跟不动 = 结构性弱信号, 走 manual trim 路径. | 若 9/15 同行 龙源/新天 反弹但 02208 仍弱, alpha 落后进入减持区; Trump 关税施压风电出口 9 月内兑现 = 硬催化, 走 manual trim. |
-| 03032 | hold_and_watch | 50% | <span class="verdict verdict-neutral">⚪ 中性</span> | size 1.34% 不值 cut, 维持 hold_and_watch; 9/16 FOMC 后 HSTECH 4600+ 反弹才是 trim/add 窗口. | 若 HSTECH 跌破 4200 (= 03032 4.2), 1x 持仓承压但无杠杆, 不影响 60% mandatory cap; 9/16 FOMC 是制度切换观察窗. |
-| 03033 | hold_and_watch | 50% | <span class="verdict verdict-neutral">⚪ 中性</span> | 今日无 setup = 仅 hold; 9/16 FOMC 后若 03033 出 setup + HSTECH 反弹, 是 07226 cut 释放 HKD 承接的窗口. | 若 9/16 FOMC 后 HSTECH 反弹至 4600+ + 03033 出 technical setup, 转 add_only_on_trigger 用 07226 cut 释放的 HKD 现金承接 1x 替代. |
-| CRCL | hold_and_watch | 50% | <span class="verdict verdict-neutral">⚪ 中性</span> | 2 股 1 股加减不抵交易成本, packet 锁 hold_and_watch; 9/16 FOMC 是利率对 stablecoin 估值的硬催化, 关注 insider sell 节奏与 GENIUS Act 9 月是否推进. | 若 GENIUS Act 9 月内未通过 + insider sell 持续放大 = thesis 弱化, 9/16 FOMC 鹰派 = 估值进一步承压. |
+<div class="brief-entries" markdown="1">
+
+- **07226** · cut · 信心 95% · <span class="verdict verdict-bearish">🔴 看空</span>
+
+  **理由**　硬止损线 + 制度 amber + 双 breach 站 28d = 不再是预测, 是纪律; 不 cut 默认每月 -1.29% chop drag 烧钱. 9/15 仍 hold 浮亏未收窄到 -25% 内, 强制 cut 不再等下一窗口.
+
+  **证伪条件**　无 — packet 锁 cut, 4 闸并发, breach 已站 28d, 任何反弹都是逃命窗口.
+
+- **RKLX** · cut · 信心 95% · <span class="verdict verdict-bearish">🔴 看空</span>
+
+  **理由**　breakeven 242.9% 5-sigma 不可达 + 月 1.39% chop drag + 硬止损已站 55d; hold 的每一天都在烧钱. 无 1x 替代时纯 cut 是纪律性唯一出口.
+
+  **证伪条件**　无 — RKLB 已清仓无 1x 替代; cut 是唯一选项. 任何反弹都是逃命窗口.
+
+- **SPCH** · cut · 信心 95% · <span class="verdict verdict-bearish">🔴 看空</span>
+
+  **理由**　4 闸并发 + 硬止损站 57d + 单名 86% > 35% mandatory 是纪律性硬约束, cut 同步配 SPCX 1x 同因子换仓保留敞口.
+
+  **证伪条件**　无 — 4 闸并发, packet 锁 cut, 任何反弹都是逃命窗口. SPCX 1x 替代 buy 腿 (1 股 $147.55) 配 transaction_group_id 同步执行是唯一执行结构.
+
+- **SPCX** · add_only_on_trigger · 信心 65% · <span class="verdict verdict-neutral">⚪ 中性</span>
+
+  **理由**　swap_mandate 授权存在, packet 允许 1 股 add, 1 股 0.0125 position tranche 是 harness 设计的最小兑现单元. 砍执行 = 5% 换仓, 砍不执行 = 0%.
+
+  **证伪条件**　若 SPCH cut 未执行 / transaction_group_id 不匹配, 1x 替代 buy 腿无效, 暂停 add 等 cut 落地. SPCX 跌破 142.396 (invalidation_price) = setup 失效, 暂停 add.
+
+- **00100** · hold_and_watch · 信心 50% · <span class="verdict verdict-neutral">⚪ 中性</span>
+
+  **理由**　packet 锁死 trim, 仅 hold_and_watch; 9/15 若反弹至 350+ 且 packet 解锁 = 强 trim 触发 (1 lot 20 股), 9/15 跌破 320 走 manual 路径执行 trim.
+
+  **证伪条件**　若 9/15 同行智谱 / 迅策反弹但 00100 仍弱 320 之下, alpha 耗尽信号; 9/16 FOMC 若意外鹰派 (加 25bp) = 估值进一步承压.
+
+- **02208** · hold_and_watch · 信心 50% · <span class="verdict verdict-neutral">⚪ 中性</span>
+
+  **理由**　packet 锁 hold_and_watch, 6 重基本面支撑支持维持; 9/15 同行 龙源/新天 反弹但 02208 跟不动 = 结构性弱信号, 走 manual trim 路径.
+
+  **证伪条件**　若 9/15 同行 龙源/新天 反弹但 02208 仍弱, alpha 落后进入减持区; Trump 关税施压风电出口 9 月内兑现 = 硬催化, 走 manual trim.
+
+- **03032** · hold_and_watch · 信心 50% · <span class="verdict verdict-neutral">⚪ 中性</span>
+
+  **理由**　size 1.34% 不值 cut, 维持 hold_and_watch; 9/16 FOMC 后 HSTECH 4600+ 反弹才是 trim/add 窗口.
+
+  **证伪条件**　若 HSTECH 跌破 4200 (= 03032 4.2), 1x 持仓承压但无杠杆, 不影响 60% mandatory cap; 9/16 FOMC 是制度切换观察窗.
+
+- **03033** · hold_and_watch · 信心 50% · <span class="verdict verdict-neutral">⚪ 中性</span>
+
+  **理由**　今日无 setup = 仅 hold; 9/16 FOMC 后若 03033 出 setup + HSTECH 反弹, 是 07226 cut 释放 HKD 承接的窗口.
+
+  **证伪条件**　若 9/16 FOMC 后 HSTECH 反弹至 4600+ + 03033 出 technical setup, 转 add_only_on_trigger 用 07226 cut 释放的 HKD 现金承接 1x 替代.
+
+- **CRCL** · hold_and_watch · 信心 50% · <span class="verdict verdict-neutral">⚪ 中性</span>
+
+  **理由**　2 股 1 股加减不抵交易成本, packet 锁 hold_and_watch; 9/16 FOMC 是利率对 stablecoin 估值的硬催化, 关注 insider sell 节奏与 GENIUS Act 9 月是否推进.
+
+  **证伪条件**　若 GENIUS Act 9 月内未通过 + insider sell 持续放大 = thesis 弱化, 9/16 FOMC 鹰派 = 估值进一步承压.
+
+</div>
+
+</div>
+
+<div class="brief-card" markdown="1">
 
 ### 下一节点
 
@@ -48,7 +154,11 @@ HK 0.428 / US 0.746 双 leg 危险集中, 5 仓位硬闸 + 3 杠杆止损并发 
 4. 10:00 HKT: 复盘 AI 板块 9/10 表现 (智谱 / 迅策 / 商汤 / 范式), 若 00100 跑赢同业 = alpha 持续, 若再弱 = 行业估值重估未结束
 5. 盘中: 观察 02208 JPM/BlackRock 9 月持仓变化 + 9/16 FOMC 前利率期货隐含路径, 9/15 前若 03033 4.30 站稳 + 出 setup = add_only_on_trigger 窗口
 
+</div>
+
 ## 我的看法
+
+<div class="brief-card" markdown="1">
 
 ### 多空对辩
 
@@ -64,6 +174,10 @@ Book 双 leg 危险集中 (HK 0.428 / US 0.746), 单名 00100 58% HK + SPCH 86% 
 
 本轮最强共识是 'SPCX 1x 同因子换仓是 0 chop drag + 同敞口 = 必胜换仓' — packet max_add_shares=1 + 实际仅 5% 比例换仓, cut 释放的 95% 变现金, 1x 替代实际是 swap_mandate 设计的 5% 兑现, 不是真 1x 替代. 即使 SPCX 反弹 50%, 1 股贡献 vs 300 股 SPCH 全砍的损失, 5% 比例让 swap 名义上有意义实际无效. attack 这条隐含共识.
 
+</div>
+
+<div class="brief-card" markdown="1">
+
 ### 风险官三票
 
 **Aggressive（抓 upside） · 今日首位表态**
@@ -78,21 +192,111 @@ risk_off regime 是减杠杆 + 降集中的黄金窗口, 不是恐慌窗口. 4 �
 
 对 07226 / RKLX / SPCH 三 cut: 中性偏 cut (纪律优先, 站 28-57d 不再是预测); 对 00100: 中性偏 hold (packet 锁, 9/4 trim 365 已过窗口, 9/15 350+ 才重启 trim); 对 02208 / 03032 / 03033: 中性 hold (packet 锁, reflections 持胜率 29-35% 限制主动 call); 对 SPCX: 中性偏 add 1 股 (swap_mandate 5% 比例兑现, 不追高但规则授权); 对 CRCL: 中性 hold (insider sell 软利空, 2 股 1 股加减不抵交易成本).
 
+</div>
+
+<div class="brief-card" markdown="1">
+
 ### 分析师四格
 
-| 票 | Market（harness 计算） | Fundamentals | Sentiment | Cross-Market |
-|---|---|---|---|---|
-| 00100 | -42.00% / RSI 49.3 / 趋势OFF | 招股说明书模型版权风险 (8/28 招股书披露) 仍未消化; 沙特 HUMAIN 合作 9/4 是硬催化 confirming 已价; AI 板块估值重估 9/9 智谱 -10% / 迅策 -7% 是结构性信号非暂时. | 9/3-9/4 南向资金连续 4 天净买入 00100 是软情绪; 9/9 智谱 -10% 板块情绪降温, 资金从独立大模型流向云平台是结构性而非暂时; 软情绪只能动 confidence ±10pp, 不足以驱动 trim (因 packet 锁). | 美股 AI / 中概 AI 9/9 同步回调, 1d -0.64% NDX 与 HK HSTECH -0.76% 同步, US-HK 跨市场无独立 alpha 来源. |
-| 02208 | -34.18% / RSI 42.1 / 趋势OFF · 已破吊灯止损 / 距 MA200 -29.30% | H1 营收 337.39 亿 +18.23% / 净利 18.55 亿 +24.67% / 风机毛利率修复近 4pp / 海上装机 +48% = 基本面无破; 1-7 月装机 +19.5% + 1302 万股回购 = 资金面无破. | JPM 减持 1.08% + BlackRock 加仓 0.09% (净减 0.99%) + Trump 关税施压 = 软情绪主导短期价格; 基本面硬数据未反映在股价, 软情绪不足以驱动 trim. | 新能源板块 A 股 / HK / 全球同步 9/9 弱, 风电同业 (龙源 / 新天 / 东方电气) 5d 走势略强, 02208 跑输同业 0.5-1.3pp 是 alpha 落后信号. |
-| 03032 | -18.19% / RSI 35.8 / 趋势OFF · 已破吊灯止损 / 距 MA200 -12.40% | 1x ETF 被动跟踪 HSTECH, 无独立 alpha 来源; 1.34% size 不影响 book 风险评估. | 无独立情绪信号 (1x ETF 被动跟踪); 南向资金 9/3 净流入 03033 1.79 亿 HKD 略正, 03032 同标的但无显著情绪信号. | HSTECH 与 NDX 9/9 同步 -0.64% / -0.76%, US-HK 跨市场科技股同步承压. |
-| 03033 | -15.72% / RSI 35.5 / 趋势OFF · 已破吊灯止损 / 距 MA200 -12.70% | 1x ETF 被动跟踪 HSTECH; 1x 替代承接窗口 (cut 07226 → add 03033) 是 swap_mandate 设计核心, 但 packet 无 setup 时 buy 腿 blocked. | 9/3 南向资金净流入 1.79 亿 HKD 是软情绪 + 资金信号; 但 reflections 31% 持胜率说明软情绪对历史 alpha 帮助有限. | HSTECH 与 NDX 9/9 同步 -0.64% / -0.76%, 跨市场科技股同步承压, 03033 资金面略正 vs 03032 无显著资金信号. |
-| 07226 | -31.61% / RSI 35.8 / 趋势OFF · 已破吊灯止损 / 距 MA200 -12.70% | 2x HSTECH 杠杆 ETF, 日内重置 decay + chop drag 1.29%/月; 无独立 alpha 来源 (2x 跟踪 HSTECH 4420). | 无独立情绪信号 (2x 杠杆 ETF 被动跟踪); 9/9 HSTECH 4420 跌破 4800 支撑是情绪面 + 技术面同步弱信号. | HSTECH 9/9 -0.76% 与 NDX -0.64% 同步, 杠杆放大 HSTECH 弱势; 9/16 FOMC 是制度切换硬催化, cut 在 FOMC 前是纪律. |
-| CRCL | +6.89% / RSI 57.3 / 趋势OFF / 距 MA200 +9.00% | GENIUS Act 9 月国会推进 + $400M Tazapay all-stock 收购 2027 close + USDC TOTALE50 市值突破 9/8 = 3 重硬催化 confirming 已价; 财报 H1 2026 待 11 月披露. | GENIUS Act 国会推进是软情绪 + 硬催化 (国会听证 = 政策推进); insider sell 是软利空; 2 软情绪抵消, 不足以驱动 trim. | 稳定币板块 9/9 全球同步, BTC 9/3 反弹回 $81K 1 周内 + 7%, COIN 5d -4.9% 略弱, CRCL +3.9% 5d 略强; 跨市场稳定币板块情绪略正. |
-| RKLX | -70.84% / RSI 36.8 / 趋势OFF · 已破吊灯止损 / 距 MA200 -20.90% | 2x RKLB 杠杆 ETF, 日内重置 decay + chop drag 1.39%/月; 底层 RKLB Q2 营收 $234M +62% YoY beat 但 adj EPS -0.08 差于预期 -0.06, 短期股价 -2% 走弱. | 9/9 SPCX lockup selling pressure + RKLB Q2 EPS miss 是软利空; 但 Rocket Lab 8月+37% 跑赢同业 (Voyager Technologies / SpaceX / LUNR) 是历史 alpha 残留; 软情绪不足以驱动 cut (因 packet 锁 cut). | 商业航天 9/9 SPCX lockup selling pressure + RKLB Q2 EPS miss 双重软利空, 跨市场板块情绪弱. |
-| SPCH | -18.82% / RSI 56.3 / 趋势OFF | 2x SPCX 杠杆 ETF, 单名 85.99% > 35% mandatory 是制度性约束; 底层 SPCX 5d +3.7% 反弹, 但 9/9 SPCX lockup selling pressure 是软利空. | Pivotal $2T target + Musk 9/8 endorse 是软情绪 + 硬催化 (Musk 言论无落地), 仅 soft; SPCX 9/9 lockup selling pressure 是软利空; 软情绪无法驱动 cut 单独成立 (因 packet 锁 cut). | 商业航天 9/9 SPCX lockup + RKLB Q2 EPS miss 双重软利空, 跨市场板块情绪弱; SPCH 单日 +6.5% 是 2x 反弹放大. |
-| SPCX | +0.03% / RSI 56.3 / 趋势OFF | 1x SpaceX ETF, 9/9 站前 20 日高 152.3 (5d +3.7%); Pivotal $2T target + Musk 9/8 endorse 是硬催化 confirming 已价; 9/9 SPCX lockup 已释放, 9/10 起新 30 天锁定期. | Pivotal $2T target + Musk 9/8 endorse 是软情绪 + 硬催化 (Musk 言论无落地), 仅 soft; SPCX 9/9 lockup selling pressure 是软利空; 9/10 起新锁定期是软利空; 软情绪无法单独驱动 add (因 packet 锁 swap_mandate). | 商业航天 9/9 SPCX lockup + RKLB Q2 EPS miss 双重软利空, 跨市场板块情绪弱; 但 1x ETF 跟跌 5d -2.1% (vs SPCH 2x +6.5%) 反映 2x 杠杆放大效应. |
+<div class="brief-entries" markdown="1">
+
+- **00100**
+
+  <span class="entry-meta">-42.00% / RSI 49.3 / 趋势OFF</span>
+
+  **Fundamentals**　招股说明书模型版权风险 (8/28 招股书披露) 仍未消化; 沙特 HUMAIN 合作 9/4 是硬催化 confirming 已价; AI 板块估值重估 9/9 智谱 -10% / 迅策 -7% 是结构性信号非暂时.
+
+  **Sentiment**　9/3-9/4 南向资金连续 4 天净买入 00100 是软情绪; 9/9 智谱 -10% 板块情绪降温, 资金从独立大模型流向云平台是结构性而非暂时; 软情绪只能动 confidence ±10pp, 不足以驱动 trim (因 packet 锁).
+
+  **Cross-Market**　美股 AI / 中概 AI 9/9 同步回调, 1d -0.64% NDX 与 HK HSTECH -0.76% 同步, US-HK 跨市场无独立 alpha 来源.
+
+- **02208**
+
+  <span class="entry-meta">-34.18% / RSI 42.1 / 趋势OFF · 已破吊灯止损 / 距 MA200 -29.30%</span>
+
+  **Fundamentals**　H1 营收 337.39 亿 +18.23% / 净利 18.55 亿 +24.67% / 风机毛利率修复近 4pp / 海上装机 +48% = 基本面无破; 1-7 月装机 +19.5% + 1302 万股回购 = 资金面无破.
+
+  **Sentiment**　JPM 减持 1.08% + BlackRock 加仓 0.09% (净减 0.99%) + Trump 关税施压 = 软情绪主导短期价格; 基本面硬数据未反映在股价, 软情绪不足以驱动 trim.
+
+  **Cross-Market**　新能源板块 A 股 / HK / 全球同步 9/9 弱, 风电同业 (龙源 / 新天 / 东方电气) 5d 走势略强, 02208 跑输同业 0.5-1.3pp 是 alpha 落后信号.
+
+- **03032**
+
+  <span class="entry-meta">-18.19% / RSI 35.8 / 趋势OFF · 已破吊灯止损 / 距 MA200 -12.40%</span>
+
+  **Fundamentals**　1x ETF 被动跟踪 HSTECH, 无独立 alpha 来源; 1.34% size 不影响 book 风险评估.
+
+  **Sentiment**　无独立情绪信号 (1x ETF 被动跟踪); 南向资金 9/3 净流入 03033 1.79 亿 HKD 略正, 03032 同标的但无显著情绪信号.
+
+  **Cross-Market**　HSTECH 与 NDX 9/9 同步 -0.64% / -0.76%, US-HK 跨市场科技股同步承压.
+
+- **03033**
+
+  <span class="entry-meta">-15.72% / RSI 35.5 / 趋势OFF · 已破吊灯止损 / 距 MA200 -12.70%</span>
+
+  **Fundamentals**　1x ETF 被动跟踪 HSTECH; 1x 替代承接窗口 (cut 07226 → add 03033) 是 swap_mandate 设计核心, 但 packet 无 setup 时 buy 腿 blocked.
+
+  **Sentiment**　9/3 南向资金净流入 1.79 亿 HKD 是软情绪 + 资金信号; 但 reflections 31% 持胜率说明软情绪对历史 alpha 帮助有限.
+
+  **Cross-Market**　HSTECH 与 NDX 9/9 同步 -0.64% / -0.76%, 跨市场科技股同步承压, 03033 资金面略正 vs 03032 无显著资金信号.
+
+- **07226**
+
+  <span class="entry-meta">-31.61% / RSI 35.8 / 趋势OFF · 已破吊灯止损 / 距 MA200 -12.70%</span>
+
+  **Fundamentals**　2x HSTECH 杠杆 ETF, 日内重置 decay + chop drag 1.29%/月; 无独立 alpha 来源 (2x 跟踪 HSTECH 4420).
+
+  **Sentiment**　无独立情绪信号 (2x 杠杆 ETF 被动跟踪); 9/9 HSTECH 4420 跌破 4800 支撑是情绪面 + 技术面同步弱信号.
+
+  **Cross-Market**　HSTECH 9/9 -0.76% 与 NDX -0.64% 同步, 杠杆放大 HSTECH 弱势; 9/16 FOMC 是制度切换硬催化, cut 在 FOMC 前是纪律.
+
+- **CRCL**
+
+  <span class="entry-meta">+6.89% / RSI 57.3 / 趋势OFF / 距 MA200 +9.00%</span>
+
+  **Fundamentals**　GENIUS Act 9 月国会推进 + $400M Tazapay all-stock 收购 2027 close + USDC TOTALE50 市值突破 9/8 = 3 重硬催化 confirming 已价; 财报 H1 2026 待 11 月披露.
+
+  **Sentiment**　GENIUS Act 国会推进是软情绪 + 硬催化 (国会听证 = 政策推进); insider sell 是软利空; 2 软情绪抵消, 不足以驱动 trim.
+
+  **Cross-Market**　稳定币板块 9/9 全球同步, BTC 9/3 反弹回 $81K 1 周内 + 7%, COIN 5d -4.9% 略弱, CRCL +3.9% 5d 略强; 跨市场稳定币板块情绪略正.
+
+- **RKLX**
+
+  <span class="entry-meta">-70.84% / RSI 36.8 / 趋势OFF · 已破吊灯止损 / 距 MA200 -20.90%</span>
+
+  **Fundamentals**　2x RKLB 杠杆 ETF, 日内重置 decay + chop drag 1.39%/月; 底层 RKLB Q2 营收 $234M +62% YoY beat 但 adj EPS -0.08 差于预期 -0.06, 短期股价 -2% 走弱.
+
+  **Sentiment**　9/9 SPCX lockup selling pressure + RKLB Q2 EPS miss 是软利空; 但 Rocket Lab 8月+37% 跑赢同业 (Voyager Technologies / SpaceX / LUNR) 是历史 alpha 残留; 软情绪不足以驱动 cut (因 packet 锁 cut).
+
+  **Cross-Market**　商业航天 9/9 SPCX lockup selling pressure + RKLB Q2 EPS miss 双重软利空, 跨市场板块情绪弱.
+
+- **SPCH**
+
+  <span class="entry-meta">-18.82% / RSI 56.3 / 趋势OFF</span>
+
+  **Fundamentals**　2x SPCX 杠杆 ETF, 单名 85.99% > 35% mandatory 是制度性约束; 底层 SPCX 5d +3.7% 反弹, 但 9/9 SPCX lockup selling pressure 是软利空.
+
+  **Sentiment**　Pivotal $2T target + Musk 9/8 endorse 是软情绪 + 硬催化 (Musk 言论无落地), 仅 soft; SPCX 9/9 lockup selling pressure 是软利空; 软情绪无法驱动 cut 单独成立 (因 packet 锁 cut).
+
+  **Cross-Market**　商业航天 9/9 SPCX lockup + RKLB Q2 EPS miss 双重软利空, 跨市场板块情绪弱; SPCH 单日 +6.5% 是 2x 反弹放大.
+
+- **SPCX**
+
+  <span class="entry-meta">+0.03% / RSI 56.3 / 趋势OFF</span>
+
+  **Fundamentals**　1x SpaceX ETF, 9/9 站前 20 日高 152.3 (5d +3.7%); Pivotal $2T target + Musk 9/8 endorse 是硬催化 confirming 已价; 9/9 SPCX lockup 已释放, 9/10 起新 30 天锁定期.
+
+  **Sentiment**　Pivotal $2T target + Musk 9/8 endorse 是软情绪 + 硬催化 (Musk 言论无落地), 仅 soft; SPCX 9/9 lockup selling pressure 是软利空; 9/10 起新锁定期是软利空; 软情绪无法单独驱动 add (因 packet 锁 swap_mandate).
+
+  **Cross-Market**　商业航天 9/9 SPCX lockup + RKLB Q2 EPS miss 双重软利空, 跨市场板块情绪弱; 但 1x ETF 跟跌 5d -2.1% (vs SPCH 2x +6.5%) 反映 2x 杠杆放大效应.
+
+</div>
+
+</div>
 
 ## 这本账现在什么样
+
+<div class="brief-card" markdown="1">
 
 ### 双币账本（HK + USD 不能直接相加）
 
@@ -107,12 +311,20 @@ risk_off regime 是减杠杆 + 降集中的黄金窗口, 不是恐慌窗口. 4 �
 HK 现金: 17,597 HKD | US 现金: 461.63 USD
 ```
 
+</div>
+
+<div class="brief-card" markdown="1">
+
 ### 集中度
 
 | Leg | HHI | 判定 | Top2 | 腿总值 |
 |---|---|---|---|---|
 | HK | 0.428 | 🔴 危险集中 | 86.50% | 65,921 |
 | US | 0.746 | 🔴 危险集中 | 91.40% | 3,415 |
+
+</div>
+
+<div class="brief-card" markdown="1">
 
 ### 风控硬闸
 
@@ -132,6 +344,10 @@ open **8** / overridden 0 / unacknowledged 8 / oldest 57d / decision_overdue 5
 | beta | US | high | US β vs S&P = 5.5418 (cap 3.0) — 大盘 −1% 本子约 −5.5% | risk-66b800a6afe2 |
 
 **directive**: ⛔ 5 仓位硬闸 + 3 杠杆止损触发。每条必须在 Judge 段出一个对应动作(driven_by=risk_rule,纪律性再平衡,不算听消息、不受 risk_on HOLD 默认约束)；其余主动 call 仍按 regime guard。杠杆ETF解套口径=2x→1x 同因子换仓而非清仓(见各 action)。
+
+</div>
+
+<div class="brief-card" markdown="1">
 
 ### 加仓面（收盘确认）
 
@@ -159,6 +375,10 @@ candidate **0** / wait 5 / reject 0　·　技术突破(收盘站上前 20 日�
 
 _冷启动期：单族 + 价格确认 + 非杠杆 ⇒ 半个试探仓（policy `cold_start_single_family_enabled`）；计数器填满后此例外自动失效_
 
+</div>
+
+<div class="brief-card" markdown="1">
+
 ### 回本测算
 
 | Ticker | 浮% | 2x chop drag/月 | 回本需 | 半年窗含 drag 等效标的需 |
@@ -172,6 +392,10 @@ _冷启动期：单族 + 价格确认 + 非杠杆 ⇒ 半个试探仓（policy `
 | 03033 | -15.70% | — | +18.70% | — |
 
 注：回本涨幅=成本/现价−1。2x 行加印：标的σ、横盘 decay≈σ²/12 每月、半年窗含 drag 的等效标的涨幅。解读纪律：直线涨→2x 回本更快；横盘→2x 每月白付 decay；再跌→2x 双倍挨打。换 1x 买的是后两种情景的保护，不是回本速度。
+
+</div>
+
+<div class="brief-card" markdown="1">
 
 ### 仓位明细
 
@@ -196,6 +420,10 @@ _冷启动期：单族 + 价格确认 + 非杠杆 ⇒ 半个试探仓（policy `
 | SPCH Leverage Shares 2X Long SpaceX Daily ETF | 300 | 12.06 | 9.79 | -7.64% | -18.82% | -681 |
 | **小计 US** |  |  |  | -269 | -23.01% | **-1,021** |
 
+</div>
+
+<div class="brief-card" markdown="1">
+
 ### 大盘趋势（两条腿各自的读数）
 
 | 腿 | 窗口 | 距均线/动量 | 趋势 | 读数 |
@@ -207,8 +435,12 @@ _regime3=近10日动量分 牛(>+3%)/熊(<-3%)/震荡；trend_on=200日线；US 
 
 _HK 的趋势闸只收紧 HK 杠杆腿的上限；US 杠杆腿走它自己的 per-name dial_
 
+</div>
+
 <details class="brief-appendix" markdown="1">
 <summary>背景与校准</summary>
+
+<div class="brief-card" markdown="1">
 
 ### 昨日兑现（2026-09-09 的 plan）
 
@@ -225,19 +457,73 @@ _HK 的趋势闸只收紧 HK 杠杆腿的上限；US 杠杆腿走它自己的 pe
 | SKHY | hold_and_watch | core_position | — | 50% | pending |
 | SPCX | hold_and_watch | core_position | — | 55% | pending |
 
+</div>
+
+<div class="brief-card" markdown="1">
+
 ### 同行扫描
 
-| 持仓 | 主题 | 今日 self | 最强同行 | 差距 | 判断 |
-|---|---|---|---|---|---|
-| 00100 | HK AI 大模型 | -3.14% | 01384 滴普科技 +0.23% | -3.37pp | HK AI 大模型板块 9/9 全面回调, 智谱 -10.02% / 迅策 -7.42% / 00100 -5.59% = 00100 抗跌 1-4pp, 相对 alpha 仍存但绝对仍弱; 题材+ 自己- → '持有合理, 等题材轮回', 但轮回时间窗口 1 个月内可能不会发生. |
-| 02208 | 风电 | +1.15% | 01072 东方电气 +5.38% | -4.23pp | 题材+ 自己+ → 'alpha 抓住了', 5d 02208 +2.7% vs 龙源 +1.4% / 新天 +0.8% 略强, 但 packet 锁 hold 限制主动 call. |
-| 03032 | HK 科技指数 1x (HSTECH 标的) | -0.90% | 03067 安硕恒生科技 -0.90% | +0.00pp | 题材- 自己- → '持有合理, 等题材轮回'; 与 03033 合计 HSTECH 1x 9% HK, 切完 07226 后此为 HSTECH 主要敞口. |
-| 03033 | HK 科技指数 1x (HSTECH 标的) | -0.91% | 03032 恒生科技ETF -0.90% | -0.01pp | 题材- 自己- → '持有合理, 等题材轮回'; 与 07226 配套 (cut 07226 → add 03033) 是 1x 替代的核心叙事, 但 9/10 packet blocked 仅 hold. |
-| 07226 | HK 科技指数 2x leveraged (HSTECH 标的) | -1.65% | 09988 阿里巴巴-W +0.27% | -1.92pp | 题材- 自己- → '持有合理, 等题材轮回', 但 2x 杠杆不允许等, chop drag 是双倍惩罚; cut 是纪律不是预测. |
-| CRCL | 稳定币 + agent 支付 | -3.32% | BKKT Bakkt, Inc. +0.00% | -3.32pp | 题材+ 自己+ → 'alpha 抓住了', 5d CRCL +3.9% vs BKKT +7.7% / COIN -4.9% / PYPL +1.0% 中位, 题材+ 板块情绪正, 自身略弱. |
-| RKLX | RKLB 2x leveraged | -8.70% | RKLB Rocket Lab -4.25% | -4.45pp | 题材+ 自己- → '考虑切换: peer 比我强', 但无 1x 替代 (RKLB 6/13 已清), 纯 cut 是唯一出口; 等待 RKLB 1x ETF 上线或 RKLB 重新纳入 holdings 才考虑 2x 替代. |
-| SPCH | SpaceX 2x leveraged (商业航天) | -7.64% | RKLB Rocket Lab -4.25% | -3.39pp | 题材+ 自己- → '考虑切换: peer 比我强', SPCH 单名 86% US 是核心问题, 切 SPCX 1x (1 股 $147.55) 配 transaction_group 是唯一换仓结构. |
-| SPCX | 商业航天 (火箭发射 + Starlink 卫星互联网) | -3.86% | IRDM 铱星通讯 -1.55% | -2.31pp | 题材+ 自己+ → 'alpha 抓住了', SPCX 5d +3.7% vs 同行 1x 同业 (无直接 1x SPCX 对标, RKLB 1x 已是基础标的), 1x 替代是敞口保留的核心. |
+<div class="brief-entries" markdown="1">
+
+- **00100** · 今日 -3.14% · 差距 -3.37pp
+
+  <span class="entry-meta">HK AI 大模型 · 最强同行 01384 滴普科技 +0.23%</span>
+
+  **判断**　HK AI 大模型板块 9/9 全面回调, 智谱 -10.02% / 迅策 -7.42% / 00100 -5.59% = 00100 抗跌 1-4pp, 相对 alpha 仍存但绝对仍弱; 题材+ 自己- → '持有合理, 等题材轮回', 但轮回时间窗口 1 个月内可能不会发生.
+
+- **02208** · 今日 +1.15% · 差距 -4.23pp
+
+  <span class="entry-meta">风电 · 最强同行 01072 东方电气 +5.38%</span>
+
+  **判断**　题材+ 自己+ → 'alpha 抓住了', 5d 02208 +2.7% vs 龙源 +1.4% / 新天 +0.8% 略强, 但 packet 锁 hold 限制主动 call.
+
+- **03032** · 今日 -0.90% · 差距 +0.00pp
+
+  <span class="entry-meta">HK 科技指数 1x (HSTECH 标的) · 最强同行 03067 安硕恒生科技 -0.90%</span>
+
+  **判断**　题材- 自己- → '持有合理, 等题材轮回'; 与 03033 合计 HSTECH 1x 9% HK, 切完 07226 后此为 HSTECH 主要敞口.
+
+- **03033** · 今日 -0.91% · 差距 -0.01pp
+
+  <span class="entry-meta">HK 科技指数 1x (HSTECH 标的) · 最强同行 03032 恒生科技ETF -0.90%</span>
+
+  **判断**　题材- 自己- → '持有合理, 等题材轮回'; 与 07226 配套 (cut 07226 → add 03033) 是 1x 替代的核心叙事, 但 9/10 packet blocked 仅 hold.
+
+- **07226** · 今日 -1.65% · 差距 -1.92pp
+
+  <span class="entry-meta">HK 科技指数 2x leveraged (HSTECH 标的) · 最强同行 09988 阿里巴巴-W +0.27%</span>
+
+  **判断**　题材- 自己- → '持有合理, 等题材轮回', 但 2x 杠杆不允许等, chop drag 是双倍惩罚; cut 是纪律不是预测.
+
+- **CRCL** · 今日 -3.32% · 差距 -3.32pp
+
+  <span class="entry-meta">稳定币 + agent 支付 · 最强同行 BKKT Bakkt, Inc. +0.00%</span>
+
+  **判断**　题材+ 自己+ → 'alpha 抓住了', 5d CRCL +3.9% vs BKKT +7.7% / COIN -4.9% / PYPL +1.0% 中位, 题材+ 板块情绪正, 自身略弱.
+
+- **RKLX** · 今日 -8.70% · 差距 -4.45pp
+
+  <span class="entry-meta">RKLB 2x leveraged · 最强同行 RKLB Rocket Lab -4.25%</span>
+
+  **判断**　题材+ 自己- → '考虑切换: peer 比我强', 但无 1x 替代 (RKLB 6/13 已清), 纯 cut 是唯一出口; 等待 RKLB 1x ETF 上线或 RKLB 重新纳入 holdings 才考虑 2x 替代.
+
+- **SPCH** · 今日 -7.64% · 差距 -3.39pp
+
+  <span class="entry-meta">SpaceX 2x leveraged (商业航天) · 最强同行 RKLB Rocket Lab -4.25%</span>
+
+  **判断**　题材+ 自己- → '考虑切换: peer 比我强', SPCH 单名 86% US 是核心问题, 切 SPCX 1x (1 股 $147.55) 配 transaction_group 是唯一换仓结构.
+
+- **SPCX** · 今日 -3.86% · 差距 -2.31pp
+
+  <span class="entry-meta">商业航天 (火箭发射 + Starlink 卫星互联网) · 最强同行 IRDM 铱星通讯 -1.55%</span>
+
+  **判断**　题材+ 自己+ → 'alpha 抓住了', SPCX 5d +3.7% vs 同行 1x 同业 (无直接 1x SPCX 对标, RKLB 1x 已是基础标的), 1x 替代是敞口保留的核心.
+
+</div>
+
+</div>
+
+<div class="brief-card" markdown="1">
 
 ### 板块全景
 
@@ -255,25 +541,101 @@ _HK 的趋势闸只收紧 HK 杠杆腿的上限；US 杠杆腿走它自己的 pe
 
 HK AI 大模型 9/9 全面回调 (智谱 -10.02% / 迅策 -7.42% / 00100 -5.59%) = 行业竞争 + 估值重估, 资金从独立大模型流向云平台, 00100 抗跌但绝对仍弱, 1 个月内 alpha 可能耗尽. HSTECH 9/9 -0.92% / 9/8 -0.76%, 百度 -4.69% / 美团 -2% / 阿里 -1.61% 普跌, HSTECH 4420 < 4800 支撑 = 趋势 OFF, 07226 杠杆放大 1d -4.3% 5d, cut 优先. 商业航天 RKLB Q2 营收 $234M +62% YoY beat, 但 adj EPS -0.08 差于预期 -0.06, 股价 -2% 短期走弱; Voyager Technologies 8月+37% 击败 SpaceX/RKLB/LUNR 是板块内部强弱信号. 稳定币 USDC TOTALE50 9/8 市值突破 + $400M Tazapay 收购 = 板块利好, CRCL insider sell 软利空主导短期价格.
 
+</div>
+
+<div class="brief-card" markdown="1">
+
 ### 大盘速读
 
 VIX **16.46** (+4.71%) · HSI **25,274.96** (-0.17%) · HSTECH **4,420.79** (-0.76%) · SPX **7,636.36** (-0.48%) · 纳指 **26,253.34** (-0.64%) · DXY **98.78** (-0.03%) · F&G **39.0** fear · 10Y **4.84%**（as_of 2026-09-09T23:33:39.060786+00:00, age 0.5h）
 
 F&G 39 fear (vs 上周 33) + VIX 16.46 +4.71% + 10Y 4.837% 升 5bp + SPX/NDX -0.48/-0.64% + HSTECH -0.76% + HSI -0.17% = 风险偏好降温, 防御板块 (能源 + 黄金) 领涨, 科技 + AI + 商业航天承压. 9/16 FOMC 是 1 周内最大制度切换硬催化, 关注利率路径对高 β 持仓 (00100 / SPCH / 07226) 的估值影响.
 
+</div>
+
+<div class="brief-card" markdown="1">
+
 ### 社交舆情
 
-| 票 | Reddit 7d | 新闻关键词 | 近 5 日 | 信号判断 |
-|---|---|---|---|---|
-| CRCL | 0 mentions | Nikhil Chandhok Sells 26,666 Shares 、Circle Internet (CRCL) CTO sells sto、What Is Driving Circle Internet Grou | — | GENIUS Act 国会推进是软情绪 + 硬催化 (国会听证 = 政策推进); insider sell 是软利空; 2 软情绪抵消, 不足以驱动 trim. |
-| RKLX | 1 mentions | Technical Reactions to RKLX Trends i、RKLX: Benefits And Risks Of Leveragi、RKLX: A Tactical Buy On Rocket Lab's | — | 9/9 SPCX lockup selling pressure + RKLB Q2 EPS miss 是软利空; 但 Rocket Lab 8月+37% 跑赢同业 (Voyager Technologies / SpaceX / LUNR) 是历史 alpha 残留; 软情绪不足以驱动 cut (因 packet 锁 cut). |
-| SPCX | 1 mentions | SpaceX Stock (SPCX): 2 ETFs With 25%、SpaceX Stock Is Still Below Its Open、GE Aerospace Buys Turbine Maker in B | — | Pivotal $2T target + Musk 9/8 endorse 是软情绪 + 硬催化 (Musk 言论无落地), 仅 soft; SPCX 9/9 lockup selling pressure 是软利空; 9/10 起新锁定期是软利空; 软情绪无法单独驱动 add (因 packet 锁 swap_mandate). |
-| SPCH | 1 mentions | Liquidity Mapping Around (SPCH) Pric、SPCH ETF Price and Chart — CBOE:SPCH、MY 2026 Mid-Autumn Festival | — | Pivotal $2T target + Musk 9/8 endorse 是软情绪 + 硬催化 (Musk 言论无落地), 仅 soft; SPCX 9/9 lockup selling pressure 是软利空; 软情绪无法驱动 cut 单独成立 (因 packet 锁 cut). |
-| 00100 | 0 mentions | HK Stock Market Watch \| MINIMAX-W (0、HK Stock Market Watch \| MINIMAX-W (0、MINIMAX GROUP INC. - W (100) - stock | — | 9/3-9/4 南向资金连续 4 天净买入 00100 是软情绪; 9/9 智谱 -10% 板块情绪降温, 资金从独立大模型流向云平台是结构性而非暂时; 软情绪只能动 confidence ±10pp, 不足以驱动 trim (因 packet 锁). |
-| 02208 | 0 mentions | Hong Kong Stock Market Movement \| Co、Zhitong Statistics on Significant Ch、Jinfeng Technology's Hong Kong-liste | — | JPM 减持 1.08% + BlackRock 加仓 0.09% (净减 0.99%) + Trump 关税施压 = 软情绪主导短期价格; 基本面硬数据未反映在股价, 软情绪不足以驱动 trim. |
-| 03032 | 0 mentions | Year-End Review \| The Strongest ETF 、Zhitong HK Stock Connect Holdings Ra、New funds are channeling into the Ho | — | 无独立情绪信号 (1x ETF 被动跟踪); 南向资金 9/3 净流入 03033 1.79 亿 HKD 略正, 03032 同标的但无显著情绪信号. |
-| 07226 | 0 mentions | Hang Seng Tech Index Surges, Souther、The Hang Seng Index rebounded by 437、What signal? Significant inflows of  | — | 无独立情绪信号 (2x 杠杆 ETF 被动跟踪); 9/9 HSTECH 4420 跌破 4800 支撑是情绪面 + 技术面同步弱信号. |
-| 03033 | 0 mentions | Zhitong HK Stock Connect Holdings An、Zhitong HK Stock Connect Holdings Ra、Zhito Hong Kong Stock Connect Holdin | — | 9/3 南向资金净流入 1.79 亿 HKD 是软情绪 + 资金信号; 但 reflections 31% 持胜率说明软情绪对历史 alpha 帮助有限. |
+<div class="brief-entries" markdown="1">
+
+- **CRCL** · 近 5 日 —
+
+  <span class="entry-meta">Reddit 7d 0 mentions</span>
+
+  **新闻**　Nikhil Chandhok Sells 26,666 Shares 、Circle Internet (CRCL) CTO sells sto、What Is Driving Circle Internet Grou
+
+  **信号判断**　GENIUS Act 国会推进是软情绪 + 硬催化 (国会听证 = 政策推进); insider sell 是软利空; 2 软情绪抵消, 不足以驱动 trim.
+
+- **RKLX** · 近 5 日 —
+
+  <span class="entry-meta">Reddit 7d 1 mentions</span>
+
+  **新闻**　Technical Reactions to RKLX Trends i、RKLX: Benefits And Risks Of Leveragi、RKLX: A Tactical Buy On Rocket Lab's
+
+  **信号判断**　9/9 SPCX lockup selling pressure + RKLB Q2 EPS miss 是软利空; 但 Rocket Lab 8月+37% 跑赢同业 (Voyager Technologies / SpaceX / LUNR) 是历史 alpha 残留; 软情绪不足以驱动 cut (因 packet 锁 cut).
+
+- **SPCX** · 近 5 日 —
+
+  <span class="entry-meta">Reddit 7d 1 mentions</span>
+
+  **新闻**　SpaceX Stock (SPCX): 2 ETFs With 25%、SpaceX Stock Is Still Below Its Open、GE Aerospace Buys Turbine Maker in B
+
+  **信号判断**　Pivotal $2T target + Musk 9/8 endorse 是软情绪 + 硬催化 (Musk 言论无落地), 仅 soft; SPCX 9/9 lockup selling pressure 是软利空; 9/10 起新锁定期是软利空; 软情绪无法单独驱动 add (因 packet 锁 swap_mandate).
+
+- **SPCH** · 近 5 日 —
+
+  <span class="entry-meta">Reddit 7d 1 mentions</span>
+
+  **新闻**　Liquidity Mapping Around (SPCH) Pric、SPCH ETF Price and Chart — CBOE:SPCH、MY 2026 Mid-Autumn Festival
+
+  **信号判断**　Pivotal $2T target + Musk 9/8 endorse 是软情绪 + 硬催化 (Musk 言论无落地), 仅 soft; SPCX 9/9 lockup selling pressure 是软利空; 软情绪无法驱动 cut 单独成立 (因 packet 锁 cut).
+
+- **00100** · 近 5 日 —
+
+  <span class="entry-meta">Reddit 7d 0 mentions</span>
+
+  **新闻**　HK Stock Market Watch \| MINIMAX-W (0、HK Stock Market Watch \| MINIMAX-W (0、MINIMAX GROUP INC. - W (100) - stock
+
+  **信号判断**　9/3-9/4 南向资金连续 4 天净买入 00100 是软情绪; 9/9 智谱 -10% 板块情绪降温, 资金从独立大模型流向云平台是结构性而非暂时; 软情绪只能动 confidence ±10pp, 不足以驱动 trim (因 packet 锁).
+
+- **02208** · 近 5 日 —
+
+  <span class="entry-meta">Reddit 7d 0 mentions</span>
+
+  **新闻**　Hong Kong Stock Market Movement \| Co、Zhitong Statistics on Significant Ch、Jinfeng Technology's Hong Kong-liste
+
+  **信号判断**　JPM 减持 1.08% + BlackRock 加仓 0.09% (净减 0.99%) + Trump 关税施压 = 软情绪主导短期价格; 基本面硬数据未反映在股价, 软情绪不足以驱动 trim.
+
+- **03032** · 近 5 日 —
+
+  <span class="entry-meta">Reddit 7d 0 mentions</span>
+
+  **新闻**　Year-End Review \| The Strongest ETF 、Zhitong HK Stock Connect Holdings Ra、New funds are channeling into the Ho
+
+  **信号判断**　无独立情绪信号 (1x ETF 被动跟踪); 南向资金 9/3 净流入 03033 1.79 亿 HKD 略正, 03032 同标的但无显著情绪信号.
+
+- **07226** · 近 5 日 —
+
+  <span class="entry-meta">Reddit 7d 0 mentions</span>
+
+  **新闻**　Hang Seng Tech Index Surges, Souther、The Hang Seng Index rebounded by 437、What signal? Significant inflows of 
+
+  **信号判断**　无独立情绪信号 (2x 杠杆 ETF 被动跟踪); 9/9 HSTECH 4420 跌破 4800 支撑是情绪面 + 技术面同步弱信号.
+
+- **03033** · 近 5 日 —
+
+  <span class="entry-meta">Reddit 7d 0 mentions</span>
+
+  **新闻**　Zhitong HK Stock Connect Holdings An、Zhitong HK Stock Connect Holdings Ra、Zhito Hong Kong Stock Connect Holdin
+
+  **信号判断**　9/3 南向资金净流入 1.79 亿 HKD 是软情绪 + 资金信号; 但 reflections 31% 持胜率说明软情绪对历史 alpha 帮助有限.
+
+</div>
+
+</div>
+
+<div class="brief-card" markdown="1">
 
 ### 名人异动 / 政策风向（0.6h 前）
 
@@ -281,6 +643,10 @@ F&G 39 fear (vs 上周 33) + VIX 16.46 +4.71% + 10Y 4.837% 升 5bp + SPX/NDX -0.
 
 - [板块相关] Trump（neutral）：特朗普抨击加拿大长期在乳制品、汽车、政府采购上对美国不公，暗示可能再加关税施压——汽车与贸易摩擦升温，间接利空风电出口预期（02208 金风科技面向全球市场，含北美项目）。
 - [板块相关] Musk（attack）：马斯克怒骂 Alex Gibney 纪录片为'人身攻击'，媒体形象承压，对 SpaceX 系未上市资产（SPCX/SPCH）有间接情绪面影响。
+
+</div>
+
+<div class="brief-card" markdown="1">
 
 ### 决策校准
 
@@ -294,6 +660,10 @@ F&G 39 fear (vs 上周 33) + VIX 16.46 +4.71% + 10Y 4.837% 升 5bp + SPX/NDX -0.
 
 Decision v2 30 天 45 settled episodes, Brier 0.3758 LOSES baseline 0.3 (overconfident, mean_conf 0.88 vs 实际 54%); active 11 场 cluster CI [-2.72, 1.79] 跨 0 = 无择时 edge, signal_size_multiplier 全 0. risk_rule 12 场 50% WR 同样无 edge. 主动 call 靠纪律 (risk_rule) 不靠预测, 校准器对 active cut 已 abstain (39 省略, 0 edge-supported), 这与本 plan 5 闸并发纯纪律一致.
 
+</div>
+
+<div class="brief-card" markdown="1">
+
 ### 待补
 
 - 9/10 南向资金净流入未到 (08:03 HKT, 港股未开)
@@ -301,5 +671,7 @@ Decision v2 30 天 45 settled episodes, Brier 0.3758 LOSES baseline 0.3 (overcon
 - SPCX 1x ETF 9/10 当日成交价待 09:30 ET 开盘后确认, 当前 close $147.55 < setup 触发价 $155
 - 商业航天 9/10 板块早盘是否跟跌 9/9 SPCX lockup selling pressure 待盘中观察
 - 2 bar conflicts need --repair
+
+</div>
 
 </details>

--- a/memory/2026-09-11-pre-open.md
+++ b/memory/2026-09-11-pre-open.md
@@ -6,39 +6,145 @@ description: "clawock 盘前深度简报 2026-09-11：港股 + 美股真实持�
 
 # 盘前深度简报｜2026-09-11 周五 08:03 HKT
 
+<div class="brief-card brief-lede" markdown="1">
+
 Book 双 leg 危险集中 (HK HHI 0.416 危险 / US HHI 0.752 极危险), 5 仓位硬闸 + 3 杠杆止损并发, 8 条 breach 中 5 条 decision_overdue 站 10-58d 远超阈值. 今日不是预测日是纪律日: cut 三杠杆 ETF + 1x 同因子换仓 SPCX, hold 5 现货票等待 9/16 FOMC. cut 是规则不是择时 (Decision v2 cluster CI 跨 0, Brier 0.3031 LOSES baseline 0.28, signal_size_multiplier 全 0). 真实浮亏 USD-base -6,586 / HKD-base -51,643 (USDHKD 7.8412 Frankfurter).
 
 **反方**：4 轮 cut 计划连续 0 执行的执行疲劳 + reflections 持胜率 29-35% (02208/03032/03033) 倒数三名 + 4 个 decision_overdue breach (RKLX 58d, SPCH 57d, 07226 29d, 单名/杠杆 58d) = ledger 读起来像'有人每天看、每天决定不做'. 今日第 5 轮重发 cut 仍是 ritual 而非行动 — Judge 段已明确要求三选一关闭: execute / risk ack / risk override, 不可再沉默跳过. 同时 active decisions n=11 cluster CI [-2.72, 3.37] 跨 0 + Brier 0.3031 > baseline 0.28 + 8 个 calibrator 全部 edge_supported=false = 今日所有 call 是纪律而非择时, signal_size_multiplier=0 让今天的 alpha 期望是 0% (统计噪声).
 
+</div>
+
 ## 今天做什么
+
+<div class="brief-card" markdown="1">
 
 ### 今日动作
 
-| Ticker | Action | Frame | Strategy | driven_by | 理由 |
-|---|---|---|---|---|---|
-| 07226 | **cut** | technical_breakdown + relative_strength | risk_rebalance | risk_rule | 硬止损 -34.5% ≤ -18% 线 critical 站 29d decision_overdue；HK 杠杆 ETF 28.8% > 25% amber cap；lev_regime amber 基准 50% ×0.5=25%。breach risk-4ab7eff27f15 (leveraged_hard_stop) + risk-da9861ae6562 (leveraged_exposure:HK) 双闸并发。今日第 5 次重发, 已站 29d 远超 threshold_days=10 仍未执行 — Judge 段明确要求: 今日必须用 execute / risk ack / risk override 三选一关闭, 不再写第 N 遍。cut 释放 17,707 HKD 留现金；03033 1x 替代 buy 腿 blocked (无 technical setup) → 现金暂存等下一窗口, 不得自创 add 授权。 |
-| RKLX | **cut** | technical_breakdown + mean_reversion | risk_rebalance | risk_rule | 硬止损 -71.8% ≤ -18% 线 critical 站 58d decision_overdue, 是 ledger 中最老的一条 breach; breakeven 需 +255.2% (5-sigma 不可达); chop drag 1.31%/月每天烧钱; RKLB 6/13 已清仓 swap_mandate = null 无 1x 替代, 纯 cut 释放 139.9 USD 现金。今日第 4 次重发, 站 58d 远超 10d 阈值 — Judge 段明确要求三选一关闭。 |
-| SPCH | **cut** | technical_breakdown + relative_strength + sector_rotation | risk_rebalance | risk_rule | 硬止损 -18.2% ≤ -18% 线 critical + 单名 86.33% > 35% mandatory + US 杠杆 ETF 90.4% > 50% + US β 5.45 > 3.0 + regime_delever (5日均线偏离 -0.8% = 制度切 cut) 5 闸并发; breach 站 57d 远超 10d 阈值。今日第 4 次重发。cut 释放 2,961 USD 配同 transaction_group_id add SPCX 1 股 — swap_mandate risk_rule 授权的 1x 同因子换仓保留敞口 + 停 decay; SPCH 5d +9.7% 反弹段 cut 比新低日 cut 对 breach_return 伤害更小。 |
-| SPCX | **add_only_on_trigger** | relative_strength + sector_rotation | risk_rebalance | risk_rule | swap_mandate 授权 (breach_id risk-95ac7f6cd591, max_value $2,961, currency=USD, requires_action=add_only_on_trigger, requires_transaction_group_id=true): SPCH 触发硬止损 → 换 1x 同因子 SPCX, 敞口保留 + 停 decay。packet allowed_actions 含 add_only_on_trigger + technical_setup_ids 含 alpha_confirmation, 双重授权。9/10 SPCX 收 148.18 < 155.0 触发价 = 单纯 alpha_confirmation 触发未达, 但 swap_mandate 是规则型硬授权 override 该触发。max_add_shares=1 + max_add_value=$148.18, 故加 1 股; 剩余 $2,813 cut 释放的现金暂存等 SPCX 出独立 technical setup 后续分批 add。注: execution.blockers 含 'open_add_order' — 若今日不可 add, SPCH cut 释放的现金暂存, 1x 替代延后到 open_add 关闭后兑现。 |
-| 00100 | **hold_and_watch** | — | core_position | technical | 00100 9/10 收 292.0 (-8.98% 1d, -17.7% 5d), 单仓 56.95% HK; mom 1m -18.3% / 3m -32.9% / 6m -70.7% 趋势全下; 趋势未知短历史 (chinese A50 short_history); packet allowed_actions=[hold_and_watch, watch] 限制 trim。AI 板块分化: 9/10 智谱 -10.34% (基本面 +399.7% revenue 但估值重估) / 范式智能 +14.66% (API +860% 领涨) / 邁富時 +13.52% (应用层) / 阅文 +8.36%, 板块轮动到 API/应用层而非 LLM 底座; 00100 仍在 LLM 阵营承压。9/4 沙特 HUMAIN 基于 MiniMax M3 Arabic LLM 是 confirming 已价, 8/28 招股书模型版权风险仍未消化。reflections 24 场胜率 62% (book 第二高, 仅次 07226 65%), 持×13 胜6 (46%) 逊于减×10 胜8 (80%), 但 packet 不允许 trim → 仅维持 hold 等待 350+ 反弹 trim 窗口或 packet 解锁。决策 invalid: trim 必须等 packet 解锁; 当前 hold 是被迫选择不是主动看好。 |
-| 02208 | **hold_and_watch** | — | core_position | technical | 02208 9/10 收 9.16 (-1.19% 1d, +0.2% 5d); 趋势 OFF 已破吊灯止损 (chandelier 10.51, stop_distance -12.8%); MA20 9.692 / MA50 9.963 / MA200 13.096 全部上方; packet allowed_actions=[hold_and_watch, watch] 限制主动 call。9/8 半年报: H1 营收 337.39 亿 +18.23% YoY, 净利 18.55 亿 +24.67% YoY, 风机毛利率修复近 4pp, 海上装机 +48% 是 6 重基本面支撑。1-7 月装机 +19.5% + 累计回购 1302 万股 + JPM/BlackRock 9 月加仓是 supporting 已价; 但 5d 同行 龙源 +4.11% / 新天 +1.67% / 大唐 +4.21% 全部强于 02208 +0.2%, 落后是 JPM 减持 1.08% (已) + Trump 关税施压风电出口 (sector_hits) 软利空未消化。reflections 持×18 胜6 (35%) 是 book 最低, 主动 call 多半跑输持有, 维持 hold 等待 9.50+ 反弹 (manual trim 路径)。 |
-| 03032 | **hold_and_watch** | — | core_position | technical | 03032 9/10 收 4.33 (-2.08% 1d, -3.1% 5d); 趋势 OFF, z=-2.28 极端, 已破吊灯止损 (chandelier 4.544, stop_distance -4.7%); 200 股 866 HKD 占 book 1.34% HK 太小不值得动; 与 03033 合计 HSTECH 1x 敞口 8.32% HK (cut 07226 后, 不再含 2x)。packet allowed_actions=[hold_and_watch, watch] 限制 add; max_add 200 股 866 HKD 但无 technical setup, add 暂缓; 9/16 FOMC 前 HSTECH 4200 守稳是 1x 持有底线, 跌破则 1x 持仓承压但无杠杆不影响 60% mandatory cap。reflections 持×17 胜5 (29%) book 倒数第二, 主动 call 跑赢持有概率低, 维持 hold。 |
-| 03033 | **hold_and_watch** | — | core_position | technical | 03033 9/10 收 4.25 (-1.89% 1d, -3.0% 5d); 趋势 OFF, z=-2.24 极端, 已破吊灯止损; 1000 股 4,250 HKD 占 book 6.91% HK。9/3 南向资金净流入 03033 1.79 亿 HKD 是 1x 板块少有正资金流; 5d -3.0% 与 HSTECH 一致无独立 alpha; peer_residual 显示 03033 是 leader_continuation 候选, 但 packet 无 technical setup 阻止 add。07226 cut 释放 17,707 HKD 后理论上可承接 03033 1x 替代, 但 swap_mandate buy 腿 blocked (无 technical setup) → 现金暂存, 1x 替代延后到 packet 出 setup 才能兑现。reflections 持×15 胜4 (27%) book 倒数第三, 主动 call 跑赢持有概率低, 维持 hold。 |
-| CRCL | **hold_and_watch** | — | core_position | technical | CRCL 9/10 收 90.32 (-2.87% 1d, +1.9% 5d); RSI 54.7 中性, 在 alpha_confirmation invalidation 87.65 之上; 2 股 180.64 USD 占 book 5.27% US; packet allowed_actions=[hold_and_watch, watch, add_only_on_trigger]。新闻面 mixed: 9/9 报道 140 家 fintech 巨头 (Visa/Mastercard/BlackRock/Coinbase) 联合推出 Open USD (OUSD) 共享收益稳定币, 直击 CRCL 独占储备收益命门, 当日 -17% — 硬催化 disconfirming (OUSD 竞争结构性威胁 USDC 模型); ARK Invest 抄底 328 万美元是反向信号; 9/8 CEO Heath Tarbert 9 月国会听证推 GENIUS Act 紧迫性是 confirming 已价; CEO 减持 56,200 股是软利空。reflections 持×17 胜10 (58%) book 中位, 2 股 1 股加减不抵交易成本, packet 不允许 trim → 维持 hold。决策 invalid: 95+ 反弹是 trim 唯一窗口, 当前 90.32 距离 95 还有 5% 反弹空间; 跌破 87.65 = alpha_confirmation 失效, 走 manual trim 评估。 |
+<div class="brief-entries" markdown="1">
+
+- **07226** · **cut**
+
+  <span class="entry-meta">technical_breakdown + relative_strength · risk_rebalance · risk_rule</span>
+
+  **理由**　硬止损 -34.5% ≤ -18% 线 critical 站 29d decision_overdue；HK 杠杆 ETF 28.8% > 25% amber cap；lev_regime amber 基准 50% ×0.5=25%。breach risk-4ab7eff27f15 (leveraged_hard_stop) + risk-da9861ae6562 (leveraged_exposure:HK) 双闸并发。今日第 5 次重发, 已站 29d 远超 threshold_days=10 仍未执行 — Judge 段明确要求: 今日必须用 execute / risk ack / risk override 三选一关闭, 不再写第 N 遍。cut 释放 17,707 HKD 留现金；03033 1x 替代 buy 腿 blocked (无 technical setup) → 现金暂存等下一窗口, 不得自创 add 授权。
+
+- **RKLX** · **cut**
+
+  <span class="entry-meta">technical_breakdown + mean_reversion · risk_rebalance · risk_rule</span>
+
+  **理由**　硬止损 -71.8% ≤ -18% 线 critical 站 58d decision_overdue, 是 ledger 中最老的一条 breach; breakeven 需 +255.2% (5-sigma 不可达); chop drag 1.31%/月每天烧钱; RKLB 6/13 已清仓 swap_mandate = null 无 1x 替代, 纯 cut 释放 139.9 USD 现金。今日第 4 次重发, 站 58d 远超 10d 阈值 — Judge 段明确要求三选一关闭。
+
+- **SPCH** · **cut**
+
+  <span class="entry-meta">technical_breakdown + relative_strength + sector_rotation · risk_rebalance · risk_rule</span>
+
+  **理由**　硬止损 -18.2% ≤ -18% 线 critical + 单名 86.33% > 35% mandatory + US 杠杆 ETF 90.4% > 50% + US β 5.45 > 3.0 + regime_delever (5日均线偏离 -0.8% = 制度切 cut) 5 闸并发; breach 站 57d 远超 10d 阈值。今日第 4 次重发。cut 释放 2,961 USD 配同 transaction_group_id add SPCX 1 股 — swap_mandate risk_rule 授权的 1x 同因子换仓保留敞口 + 停 decay; SPCH 5d +9.7% 反弹段 cut 比新低日 cut 对 breach_return 伤害更小。
+
+- **SPCX** · **add_only_on_trigger**
+
+  <span class="entry-meta">relative_strength + sector_rotation · risk_rebalance · risk_rule</span>
+
+  **理由**　swap_mandate 授权 (breach_id risk-95ac7f6cd591, max_value $2,961, currency=USD, requires_action=add_only_on_trigger, requires_transaction_group_id=true): SPCH 触发硬止损 → 换 1x 同因子 SPCX, 敞口保留 + 停 decay。packet allowed_actions 含 add_only_on_trigger + technical_setup_ids 含 alpha_confirmation, 双重授权。9/10 SPCX 收 148.18 < 155.0 触发价 = 单纯 alpha_confirmation 触发未达, 但 swap_mandate 是规则型硬授权 override 该触发。max_add_shares=1 + max_add_value=$148.18, 故加 1 股; 剩余 $2,813 cut 释放的现金暂存等 SPCX 出独立 technical setup 后续分批 add。注: execution.blockers 含 'open_add_order' — 若今日不可 add, SPCH cut 释放的现金暂存, 1x 替代延后到 open_add 关闭后兑现。
+
+- **00100** · **hold_and_watch**
+
+  <span class="entry-meta">core_position · technical</span>
+
+  **理由**　00100 9/10 收 292.0 (-8.98% 1d, -17.7% 5d), 单仓 56.95% HK; mom 1m -18.3% / 3m -32.9% / 6m -70.7% 趋势全下; 趋势未知短历史 (chinese A50 short_history); packet allowed_actions=[hold_and_watch, watch] 限制 trim。AI 板块分化: 9/10 智谱 -10.34% (基本面 +399.7% revenue 但估值重估) / 范式智能 +14.66% (API +860% 领涨) / 邁富時 +13.52% (应用层) / 阅文 +8.36%, 板块轮动到 API/应用层而非 LLM 底座; 00100 仍在 LLM 阵营承压。9/4 沙特 HUMAIN 基于 MiniMax M3 Arabic LLM 是 confirming 已价, 8/28 招股书模型版权风险仍未消化。reflections 24 场胜率 62% (book 第二高, 仅次 07226 65%), 持×13 胜6 (46%) 逊于减×10 胜8 (80%), 但 packet 不允许 trim → 仅维持 hold 等待 350+ 反弹 trim 窗口或 packet 解锁。决策 invalid: trim 必须等 packet 解锁; 当前 hold 是被迫选择不是主动看好。
+
+- **02208** · **hold_and_watch**
+
+  <span class="entry-meta">core_position · technical</span>
+
+  **理由**　02208 9/10 收 9.16 (-1.19% 1d, +0.2% 5d); 趋势 OFF 已破吊灯止损 (chandelier 10.51, stop_distance -12.8%); MA20 9.692 / MA50 9.963 / MA200 13.096 全部上方; packet allowed_actions=[hold_and_watch, watch] 限制主动 call。9/8 半年报: H1 营收 337.39 亿 +18.23% YoY, 净利 18.55 亿 +24.67% YoY, 风机毛利率修复近 4pp, 海上装机 +48% 是 6 重基本面支撑。1-7 月装机 +19.5% + 累计回购 1302 万股 + JPM/BlackRock 9 月加仓是 supporting 已价; 但 5d 同行 龙源 +4.11% / 新天 +1.67% / 大唐 +4.21% 全部强于 02208 +0.2%, 落后是 JPM 减持 1.08% (已) + Trump 关税施压风电出口 (sector_hits) 软利空未消化。reflections 持×18 胜6 (35%) 是 book 最低, 主动 call 多半跑输持有, 维持 hold 等待 9.50+ 反弹 (manual trim 路径)。
+
+- **03032** · **hold_and_watch**
+
+  <span class="entry-meta">core_position · technical</span>
+
+  **理由**　03032 9/10 收 4.33 (-2.08% 1d, -3.1% 5d); 趋势 OFF, z=-2.28 极端, 已破吊灯止损 (chandelier 4.544, stop_distance -4.7%); 200 股 866 HKD 占 book 1.34% HK 太小不值得动; 与 03033 合计 HSTECH 1x 敞口 8.32% HK (cut 07226 后, 不再含 2x)。packet allowed_actions=[hold_and_watch, watch] 限制 add; max_add 200 股 866 HKD 但无 technical setup, add 暂缓; 9/16 FOMC 前 HSTECH 4200 守稳是 1x 持有底线, 跌破则 1x 持仓承压但无杠杆不影响 60% mandatory cap。reflections 持×17 胜5 (29%) book 倒数第二, 主动 call 跑赢持有概率低, 维持 hold。
+
+- **03033** · **hold_and_watch**
+
+  <span class="entry-meta">core_position · technical</span>
+
+  **理由**　03033 9/10 收 4.25 (-1.89% 1d, -3.0% 5d); 趋势 OFF, z=-2.24 极端, 已破吊灯止损; 1000 股 4,250 HKD 占 book 6.91% HK。9/3 南向资金净流入 03033 1.79 亿 HKD 是 1x 板块少有正资金流; 5d -3.0% 与 HSTECH 一致无独立 alpha; peer_residual 显示 03033 是 leader_continuation 候选, 但 packet 无 technical setup 阻止 add。07226 cut 释放 17,707 HKD 后理论上可承接 03033 1x 替代, 但 swap_mandate buy 腿 blocked (无 technical setup) → 现金暂存, 1x 替代延后到 packet 出 setup 才能兑现。reflections 持×15 胜4 (27%) book 倒数第三, 主动 call 跑赢持有概率低, 维持 hold。
+
+- **CRCL** · **hold_and_watch**
+
+  <span class="entry-meta">core_position · technical</span>
+
+  **理由**　CRCL 9/10 收 90.32 (-2.87% 1d, +1.9% 5d); RSI 54.7 中性, 在 alpha_confirmation invalidation 87.65 之上; 2 股 180.64 USD 占 book 5.27% US; packet allowed_actions=[hold_and_watch, watch, add_only_on_trigger]。新闻面 mixed: 9/9 报道 140 家 fintech 巨头 (Visa/Mastercard/BlackRock/Coinbase) 联合推出 Open USD (OUSD) 共享收益稳定币, 直击 CRCL 独占储备收益命门, 当日 -17% — 硬催化 disconfirming (OUSD 竞争结构性威胁 USDC 模型); ARK Invest 抄底 328 万美元是反向信号; 9/8 CEO Heath Tarbert 9 月国会听证推 GENIUS Act 紧迫性是 confirming 已价; CEO 减持 56,200 股是软利空。reflections 持×17 胜10 (58%) book 中位, 2 股 1 股加减不抵交易成本, packet 不允许 trim → 维持 hold。决策 invalid: 95+ 反弹是 trim 唯一窗口, 当前 90.32 距离 95 还有 5% 反弹空间; 跌破 87.65 = alpha_confirmation 失效, 走 manual trim 评估。
+
+</div>
+
+</div>
+
+<div class="brief-card" markdown="1">
 
 ### 信心与判定
 
-| Ticker | Action | Confidence | Verdict | 理由 | 证伪条件 |
-|---|---|---|---|---|---|
-| 07226 | cut | 95% | <span class="verdict verdict-bearish">🔴 看空</span> | breach 站 29d 远超 10d 阈值, 是规则而非预测; 4 轮 0 执行的执行疲劳让纪律性失效, 继续承担每月 0.4% chop drag + 9/16 FOMC 鹰派风险 (CME 隐含 59.4% 加息 25bp 概率) 双重打击; reflections 持×5 胜 2 (40%) 不如 cut 历史胜率. cut 释放 17,707 HKD 留现金; 03033 1x 替代 buy 腿 blocked (无 technical setup) → 现金暂存等下一窗口, 不得自创 add 授权. | 若 9/16 FOMC 鸽派降息 + HSTECH 反弹至 4800+ + 同行指数站稳, 减仓紧迫性降低可重新评估; 但当前 breach 已站 29d 远超 10d 阈值, 减仓是纪律不是预测, 任何反弹都是逃命窗口. |
-| RKLX | cut | 95% | <span class="verdict verdict-bearish">🔴 看空</span> | breach 站 58d 是全 ledger 最老, RKLX 已不是'持仓'是'惩罚'; breakeven 255% 5-sigma 不可达 + 月 1.31% chop drag 是负期望值复利; reflections 清×10 胜 7 (70%) 优于继续持×4 胜 0 (0%), 4 轮 0 执行的执行疲劳让纪律性失效. 纯 cut 释放 139.9 USD 现金. | 无 — RKLB 已清仓无 1x 替代; RKLX breakeven 需 5-sigma 不可达; cut 是唯一选项, 任何反弹都是逃命窗口. |
-| SPCH | cut | 95% | <span class="verdict verdict-bearish">🔴 看空</span> | 5 闸并发 + 站 57d + 单名 86% > 35% mandatory 是纪律性硬约束, US 1 leg 仅 3,429 USD 但 86% 压在 SPCH 一个标的 = 名义分散实为集中; reflections cut×9 胜 6 (66.7%) 优于继续持有 (1 胜 0), cut 配 SPCX 1x 换仓是敞口保留的最优解. cut 释放 2,961 USD 配同 transaction_group_id add SPCX 1 股 — swap_mandate risk_rule 授权的 1x 同因子换仓保留敞口 + 停 decay; SPCH 5d +9.7% 反弹段 cut 比新低日 cut 对 breach_return 伤害更小. | 若 SPCH 反弹至 11.0+ (浮亏收窄到 -10% 内) + US β 回落至 3.0 以下 + SPCX 出独立 technical setup, 减仓紧迫性降低; 但 5 闸并发 + 硬止损站 57d, cut 仍是纪律不是预测. |
-| SPCX | add_only_on_trigger | 65% | <span class="verdict verdict-neutral">⚪ 中性</span> | Swap_mandate 授权 (breach_id risk-95ac7f6cd591, max_value $2,961, currency=USD, requires_action=add_only_on_trigger, requires_transaction_group_id=true): SPCH 触发硬止损 → 换 1x 同因子 SPCX, 敞口保留 + 停 decay. packet allowed_actions 含 add_only_on_trigger + technical_setup_ids 含 alpha_confirmation, 双重授权. 9/10 SPCX 收 148.18 < 155.0 触发价 = 单纯 alpha_confirmation 触发未达, 但 swap_mandate 是规则型硬授权 override 该触发. max_add_shares=1 + max_add_value=$148.18, 故加 1 股; 剩余 $2,813 cut 释放的现金暂存等 SPCX 出独立 technical setup 后续分批 add. | 若 SPCX 跌破 142.498 (alpha_confirmation invalidation_price) = setup 失效, 暂停 add; 若 SPCH cut 未执行, 1x 替代 buy 腿无效, 暂停 add. |
-| 00100 | hold_and_watch | 50% | <span class="verdict verdict-neutral">⚪ 中性</span> | Packet allowed_actions=[hold_and_watch, watch] 锁死 trim, 即便 reflections 减×10 胜 8 (80%) 优于持×13 胜 6 (46%), 只能维持 hold_and_watch 等待反弹 350+ 的 trim 窗口或 packet 解锁. AI 板块 9/10 全面回调 智谱 -10% / 迅策 -7% / 00100 -5.6% 是核心信号 — 行业竞争 + 估值重估, 资金从独立大模型流向云平台/API 层. | 若 9/11 开盘 00100 反弹至 320+ 且 packet 解锁 trim → 强 trim 触发 (1 lot 20 股); 若 9/16 FOMC 鸽派 (no change dovish tilt) + 板块轮动回 LLM → 减仓紧迫性降低, 可持等 350+ 反弹. |
-| 02208 | hold_and_watch | 50% | <span class="verdict verdict-neutral">⚪ 中性</span> | Packet allowed_actions=[hold_and_watch, watch] 限制主动 call, 维持 hold. 半年报 H1 营收 337.39 亿 +18.23% YoY + 净利 18.55 亿 +24.67% YoY + 风机毛利率修复近 4pp + 海上装机 +48% 6 重基本面支撑支持维持; 1-7 月装机 +19.5% + 累计回购 1302 万股 + JPM/BlackRock 9 月加仓是 supporting 已价. | 若 9/11 反弹至 9.50+ 走 manual trim; 若跌破 8.50 走 manual 评估; 若 Trump 关税施压风电出口 9 月内兑现 = 硬催化, 走 manual trim. |
-| 03032 | hold_and_watch | 50% | <span class="verdict verdict-neutral">⚪ 中性</span> | Packet allowed_actions=[hold_and_watch, watch] 限制 add; max_add 200 股 866 HKD 但无 technical setup, add 暂缓; 1x 替代已 saturated. HSTECH 9/10 收 4330.49 (前期支撑 4800 跌破), 制度 amber, 1x 持仓不放大下行. | 若 HSTECH 反弹至 4800+ 9/16 FOMC 后 = 反弹 trim 窗口; 若跌破 4200 = 1x 持仓承压但无杠杆不影响 60% mandatory cap; 若 03032 出独立 technical setup + 1x 替代承接窗口打开 = add_only_on_trigger 触发. |
-| 03033 | hold_and_watch | 50% | <span class="verdict verdict-neutral">⚪ 中性</span> | Packet allowed_actions=[hold_and_watch, watch, add_only_on_trigger] 但无 technical setup, swap buy 腿 (07226 → 03033) blocked. 仅维持 hold. 9/3 南向资金净流入 03033 1.79 亿 HKD 是 1x 板块少有的正资金流; 5d -2.3% 与 HSTECH 一致. | 若 9/16 FOMC 后 HSTECH 反弹至 4600+ + 03033 出 technical setup, 转 add_only_on_trigger 用 07226 cut 释放的 HKD 现金承接 1x 替代; 若跌破 4.15 走 manual 评估. |
-| CRCL | hold_and_watch | 50% | <span class="verdict verdict-neutral">⚪ 中性</span> | Packet allowed_actions=[hold_and_watch, watch, add_only_on_trigger] 不允许 trim; reflections 持×17 胜 10 (58%) book 中位; 2 股 1 股加减不抵交易成本. 当前 hold 是 packet 锁定, 软情绪单独不驱动 trim. CRCL $400M Tazapay all-stock 收购 (2027 close) 利好但已价; 9/16 FOMC 加息 59.4% 概率若兑现, stablecoin 估值承压. | 若 9/16 FOMC 鸽派 + GENIUS Act 9 月内通过 = confirming 硬催化, 反弹至 95+ 走 manual trim; 若跌破 87.65 (alpha_confirmation invalidation) = setup 失效, 走 manual trim 评估; 若 OUSD 持续推进 + 140 fintech 巨头扩大 = 硬催化 disconfirming, packet 解锁时 trim. |
+<div class="brief-entries" markdown="1">
+
+- **07226** · cut · 信心 95% · <span class="verdict verdict-bearish">🔴 看空</span>
+
+  **理由**　breach 站 29d 远超 10d 阈值, 是规则而非预测; 4 轮 0 执行的执行疲劳让纪律性失效, 继续承担每月 0.4% chop drag + 9/16 FOMC 鹰派风险 (CME 隐含 59.4% 加息 25bp 概率) 双重打击; reflections 持×5 胜 2 (40%) 不如 cut 历史胜率. cut 释放 17,707 HKD 留现金; 03033 1x 替代 buy 腿 blocked (无 technical setup) → 现金暂存等下一窗口, 不得自创 add 授权.
+
+  **证伪条件**　若 9/16 FOMC 鸽派降息 + HSTECH 反弹至 4800+ + 同行指数站稳, 减仓紧迫性降低可重新评估; 但当前 breach 已站 29d 远超 10d 阈值, 减仓是纪律不是预测, 任何反弹都是逃命窗口.
+
+- **RKLX** · cut · 信心 95% · <span class="verdict verdict-bearish">🔴 看空</span>
+
+  **理由**　breach 站 58d 是全 ledger 最老, RKLX 已不是'持仓'是'惩罚'; breakeven 255% 5-sigma 不可达 + 月 1.31% chop drag 是负期望值复利; reflections 清×10 胜 7 (70%) 优于继续持×4 胜 0 (0%), 4 轮 0 执行的执行疲劳让纪律性失效. 纯 cut 释放 139.9 USD 现金.
+
+  **证伪条件**　无 — RKLB 已清仓无 1x 替代; RKLX breakeven 需 5-sigma 不可达; cut 是唯一选项, 任何反弹都是逃命窗口.
+
+- **SPCH** · cut · 信心 95% · <span class="verdict verdict-bearish">🔴 看空</span>
+
+  **理由**　5 闸并发 + 站 57d + 单名 86% > 35% mandatory 是纪律性硬约束, US 1 leg 仅 3,429 USD 但 86% 压在 SPCH 一个标的 = 名义分散实为集中; reflections cut×9 胜 6 (66.7%) 优于继续持有 (1 胜 0), cut 配 SPCX 1x 换仓是敞口保留的最优解. cut 释放 2,961 USD 配同 transaction_group_id add SPCX 1 股 — swap_mandate risk_rule 授权的 1x 同因子换仓保留敞口 + 停 decay; SPCH 5d +9.7% 反弹段 cut 比新低日 cut 对 breach_return 伤害更小.
+
+  **证伪条件**　若 SPCH 反弹至 11.0+ (浮亏收窄到 -10% 内) + US β 回落至 3.0 以下 + SPCX 出独立 technical setup, 减仓紧迫性降低; 但 5 闸并发 + 硬止损站 57d, cut 仍是纪律不是预测.
+
+- **SPCX** · add_only_on_trigger · 信心 65% · <span class="verdict verdict-neutral">⚪ 中性</span>
+
+  **理由**　Swap_mandate 授权 (breach_id risk-95ac7f6cd591, max_value $2,961, currency=USD, requires_action=add_only_on_trigger, requires_transaction_group_id=true): SPCH 触发硬止损 → 换 1x 同因子 SPCX, 敞口保留 + 停 decay. packet allowed_actions 含 add_only_on_trigger + technical_setup_ids 含 alpha_confirmation, 双重授权. 9/10 SPCX 收 148.18 < 155.0 触发价 = 单纯 alpha_confirmation 触发未达, 但 swap_mandate 是规则型硬授权 override 该触发. max_add_shares=1 + max_add_value=$148.18, 故加 1 股; 剩余 $2,813 cut 释放的现金暂存等 SPCX 出独立 technical setup 后续分批 add.
+
+  **证伪条件**　若 SPCX 跌破 142.498 (alpha_confirmation invalidation_price) = setup 失效, 暂停 add; 若 SPCH cut 未执行, 1x 替代 buy 腿无效, 暂停 add.
+
+- **00100** · hold_and_watch · 信心 50% · <span class="verdict verdict-neutral">⚪ 中性</span>
+
+  **理由**　Packet allowed_actions=[hold_and_watch, watch] 锁死 trim, 即便 reflections 减×10 胜 8 (80%) 优于持×13 胜 6 (46%), 只能维持 hold_and_watch 等待反弹 350+ 的 trim 窗口或 packet 解锁. AI 板块 9/10 全面回调 智谱 -10% / 迅策 -7% / 00100 -5.6% 是核心信号 — 行业竞争 + 估值重估, 资金从独立大模型流向云平台/API 层.
+
+  **证伪条件**　若 9/11 开盘 00100 反弹至 320+ 且 packet 解锁 trim → 强 trim 触发 (1 lot 20 股); 若 9/16 FOMC 鸽派 (no change dovish tilt) + 板块轮动回 LLM → 减仓紧迫性降低, 可持等 350+ 反弹.
+
+- **02208** · hold_and_watch · 信心 50% · <span class="verdict verdict-neutral">⚪ 中性</span>
+
+  **理由**　Packet allowed_actions=[hold_and_watch, watch] 限制主动 call, 维持 hold. 半年报 H1 营收 337.39 亿 +18.23% YoY + 净利 18.55 亿 +24.67% YoY + 风机毛利率修复近 4pp + 海上装机 +48% 6 重基本面支撑支持维持; 1-7 月装机 +19.5% + 累计回购 1302 万股 + JPM/BlackRock 9 月加仓是 supporting 已价.
+
+  **证伪条件**　若 9/11 反弹至 9.50+ 走 manual trim; 若跌破 8.50 走 manual 评估; 若 Trump 关税施压风电出口 9 月内兑现 = 硬催化, 走 manual trim.
+
+- **03032** · hold_and_watch · 信心 50% · <span class="verdict verdict-neutral">⚪ 中性</span>
+
+  **理由**　Packet allowed_actions=[hold_and_watch, watch] 限制 add; max_add 200 股 866 HKD 但无 technical setup, add 暂缓; 1x 替代已 saturated. HSTECH 9/10 收 4330.49 (前期支撑 4800 跌破), 制度 amber, 1x 持仓不放大下行.
+
+  **证伪条件**　若 HSTECH 反弹至 4800+ 9/16 FOMC 后 = 反弹 trim 窗口; 若跌破 4200 = 1x 持仓承压但无杠杆不影响 60% mandatory cap; 若 03032 出独立 technical setup + 1x 替代承接窗口打开 = add_only_on_trigger 触发.
+
+- **03033** · hold_and_watch · 信心 50% · <span class="verdict verdict-neutral">⚪ 中性</span>
+
+  **理由**　Packet allowed_actions=[hold_and_watch, watch, add_only_on_trigger] 但无 technical setup, swap buy 腿 (07226 → 03033) blocked. 仅维持 hold. 9/3 南向资金净流入 03033 1.79 亿 HKD 是 1x 板块少有的正资金流; 5d -2.3% 与 HSTECH 一致.
+
+  **证伪条件**　若 9/16 FOMC 后 HSTECH 反弹至 4600+ + 03033 出 technical setup, 转 add_only_on_trigger 用 07226 cut 释放的 HKD 现金承接 1x 替代; 若跌破 4.15 走 manual 评估.
+
+- **CRCL** · hold_and_watch · 信心 50% · <span class="verdict verdict-neutral">⚪ 中性</span>
+
+  **理由**　Packet allowed_actions=[hold_and_watch, watch, add_only_on_trigger] 不允许 trim; reflections 持×17 胜 10 (58%) book 中位; 2 股 1 股加减不抵交易成本. 当前 hold 是 packet 锁定, 软情绪单独不驱动 trim. CRCL $400M Tazapay all-stock 收购 (2027 close) 利好但已价; 9/16 FOMC 加息 59.4% 概率若兑现, stablecoin 估值承压.
+
+  **证伪条件**　若 9/16 FOMC 鸽派 + GENIUS Act 9 月内通过 = confirming 硬催化, 反弹至 95+ 走 manual trim; 若跌破 87.65 (alpha_confirmation invalidation) = setup 失效, 走 manual trim 评估; 若 OUSD 持续推进 + 140 fintech 巨头扩大 = 硬催化 disconfirming, packet 解锁时 trim.
+
+</div>
+
+</div>
+
+<div class="brief-card" markdown="1">
 
 ### 下一节点
 
@@ -48,7 +154,11 @@ Book 双 leg 危险集中 (HK HHI 0.416 危险 / US HHI 0.752 极危险), 5 仓�
 4. 10:00 HKT: 复盘 AI 板块 9/11 表现 (智谱 / 范式智能 / 迅策 / 商汤), 若 00100 跑赢同业 = alpha 持续, 若再弱 = 行业估值重估未结束
 5. 盘中: 观察 02208 JPM/BlackRock 9 月持仓变化 + 9/16 FOMC 前利率期货隐含路径, 9/15 前若 03033 4.30 站稳 + 出 setup = add_only_on_trigger 窗口; CRCL 跌破 87.65 (alpha_confirmation invalidation) 走 manual trim 评估
 
+</div>
+
 ## 我的看法
+
+<div class="brief-card" markdown="1">
 
 ### 多空对辩
 
@@ -64,6 +174,10 @@ Book 双 leg 危险集中 (HK 0.416 / US 0.752) 单一事件可炸; 单仓 00100
 
 本轮最强共识是'SPCH→SPCX 1x 同因子换仓是敞口保留 + 停 decay 的最优解, cut 配 1 股 add 是 0 chop drag 换仓' — attack 这点. packet max_add_shares=1 + 实际仅 5% 比例换仓 (1 股 $148.18 vs max_value $2,961), cut 释放的 95% (~$2,813) 变现金暂存. 1x 替代实际是 swap_mandate 设计的最小兑现单元, 不是真 1x 替代. 即使 SPCX 反弹 50%, 1 股贡献 vs 300 股 SPCH 全砍的损失, 不对称敞口保留. 但: 5% 也比 0% 强, 接受名义上的不完美, swap_mandate 是规则非叙事. 替代: 全部切现金等 SPCX 出独立 technical setup 后分批 add, 不在 swap_mandate 框架下凑最低兑现.
 
+</div>
+
+<div class="brief-card" markdown="1">
+
 ### 风险官三票
 
 **Conservative（保本 derisk） · 今日首位表态**
@@ -78,21 +192,111 @@ Book 双 leg 危险集中 (HK 0.416 / US 0.752) 单一事件可炸; 单仓 00100
 
 对 cut 三票: 中性偏 cut (纪律优先, 站 29-58d 不再是预测, 5 闸并发 4 闸叠加 SPCH); 对 SPCX add: 中性偏 hold 1 股 (swap_mandate 5% 兑现, 不扩大); 对 00100: 中性 hold (packet 锁, 浮亏 -47% 反弹中, 板块轮动到 API/应用层承压 LLM); 对 02208 / 03032 / 03033: 中性 hold (packet 锁, reflections 持胜率 29-35% book 倒数限制主动 call); 对 CRCL: 中性 hold (OUSD 硬催化 disconfirming 结构性威胁 USDC 模型, 但 2 股 1 股加减不抵交易成本).
 
+</div>
+
+<div class="brief-card" markdown="1">
+
 ### 分析师四格
 
-| 票 | Market（harness 计算） | Fundamentals | Sentiment | Cross-Market |
-|---|---|---|---|---|
-| 00100 | -47.21% / RSI 44.0 / 趋势OFF | EDGAR 不适用 (港股); 招股说明书 8/28 模型版权风险未消化; 9/4 沙特 HUMAIN 合作 confirming; 8/14 board-meeting notice 业绩结果未公布 (research_surface.hk_results_expected 状态 expected 28d). | Saudi HUMAIN 9/4 合作是硬催化 confirming 已价; 8/28 招股书版权风险未消化是软利空; 板块轮动从 LLM 底座到 API/应用层是结构性软情绪; 软情绪单独不驱动 trim, 仅 confidence ±10pp. 当前 hold 是 packet 锁定, 不是情绪驱动. | US AI 板块: SOXL 5d +4% (随 NDX), NVDA / SMH 中性; 9/16 FOMC 影响全球科技股估值; 9/10 SPX -0.58% / NDX -0.65% 小幅向下, 不构成 regime 切换但 + VIX 升 13.49% = 风险偏好恶化. |
-| 02208 | -34.96% / RSI 40.6 / 趋势OFF · 已破吊灯止损 / 距 MA200 -30.10% | EDGAR 不适用; 9/8 财联社 / 海鲸社半年报: H1 营收 337.39 亿 +18.23% YoY, 净利 18.55 亿 +24.67% YoY, 风机毛利率修复近 4pp, 海上装机 +48%; 1-7 月装机 +19.5%; 累计回购 1302 万股. | JPM/BlackRock 加仓是 supporting 已价; 5d 落后同行是软利空; Trump 关税施压风电出口是软情绪未落地; 软情绪单独不驱动 trim, 仅 confidence ±10pp. 当前 hold 是 packet 锁定. | Trump 关税施压风电出口是软利空; JPM/BlackRock 9 月加仓 0.28% / 0.09% 是 supporting 已价; 9/10 JPM 减持 1.08% 已发生. 同行 龙源 1-8 月累计发电量 5058.37 万兆瓦时 (-1.31% YoY). |
-| 03032 | -19.89% / RSI 31.6 / 趋势OFF · z-2.3σ极端 · 已破吊灯止损 / 距 MA200 -14.10% | ETF 1x 跟踪 HSTECH, 无独立基本面; HSTECH 9/10 -2.04% 跌破 4800 关键支撑, 9/16 FOMC 前 4200 是底线. | HSTECH 跌破 4800 支撑是技术面信号; 南向资金 9/3 净流入 03033 1.79 亿是 1x 板块少有正资金流; 当前 hold 是 packet 锁定. | US 9/10 SPX -0.58% / NDX -0.65% 小幅向下 + VIX 升 13.49% 风险偏好恶化, 拖累 HK 科技股; 9/16 FOMC 加息 59.4% 隐含概率若兑现, 全球科技股估值进一步承压. |
-| 03033 | -17.32% / RSI 31.8 / 趋势OFF · z-2.2σ极端 · 已破吊灯止损 / 距 MA200 -14.20% | ETF 1x 跟踪 HSTECH, 无独立基本面; HSTECH 9/10 -2.04% 跌破 4800 关键支撑. | 9/3 南向资金净流入 1.79 亿是 1x 板块少有正资金流, confirming 已价; 板块轮动从 LLM 到 API/应用层不利 03033 (跟踪 HSTECH 整指). | US 9/10 科技板块小幅向下 + VIX 升 13.49% 风险偏好恶化, 拖累 HK 科技股; 9/16 FOMC 加息 59.4% 隐含概率若兑现, 全球科技股估值进一步承压. |
-| 07226 | -34.54% / RSI 31.7 / 趋势OFF · z-2.3σ极端 · 已破吊灯止损 / 距 MA200 -14.40% | ETF 2x 跟踪 HSTECH, 无独立基本面; HSTECH 9/10 -2.04% 跌破 4800 关键支撑, 4200 是底线. | HSTECH 跌破 4800 支撑是技术面信号; 软情绪单独不驱动 cut, cut 是 risk_rule 纪律; 9/3 南向资金净流入 03033 1.79 亿是 1x 板块少有正资金流, 1x 替代承接窗口可能打开. | US 9/10 SPX -0.58% / NDX -0.65% + VIX 升 13.49% 风险偏好恶化, 9/16 FOMC 加息 59.4% 隐含概率若兑现, 估值进一步承压. |
-| CRCL | +3.82% / RSI 54.7 / 趋势OFF / 距 MA200 +5.70% | EDGAR 10-Q (Q2 2026-06-30, filed 2026-08-05): 资产 771.65 亿 / 现金 17.30 亿 / EPS 0.42 / Revenue 增长中; 9/8 $400M Tazapay all-stock 收购 (2027 close) 利好; 9/8 multimillion stock sale 计划 + 9/9 CTO 减持 pre-set trading plan 是 insider sell 软利空. | OUSD 9/9 报道是硬催化 disconfirming (-17% 单日); CEO 减持 56,200 股是软利空; ARK Invest 抄底 328 万美元是反向信号; 9/8 GENIUS Act 国会听证是 confirming 已价. 软情绪单独不驱动 trim, packet 锁 hold. | OUSD 由 Visa/Mastercard/BlackRock/Coinbase 等 140 fintech 巨头联合推, 是跨市场结构性威胁 USDC 模型; 9/16 FOMC 加息 59.4% 隐含概率若兑现, stablecoin 估值承压. |
-| RKLX | -71.85% / RSI 35.3 / 趋势OFF · 已破吊灯止损 / 距 MA200 -22.40% | ETF 2x 跟踪 RKLB, RKLB 9/10 收 61.96 (距 52 周高 85.55 跌 28%); SpaceX CFO 9/9 透露 $1.11B/yr AI compute 合同 12/1 启动是商业航天最强催化. | SpaceX CFO $1.11B/yr AI compute 合同 12/1 启动是硬催化 confirming 已价; RKLB / ASTS / LUNR 9 月抛售是软情绪; 软情绪单独不驱动 cut, cut 是 risk_rule 纪律. | SPCX 5d +5.3% + SPCH 5d +9.7% 反弹持续, 9 月已'抛售 by SpaceX'信号出现, 9/10 SPCX 148 接近 5d 高 155 是短期阻力. RKLX 跟涨 RKLB 2x 受限. |
-| SPCH | -18.16% / RSI 56.8 / 趋势OFF | ETF 2x 跟踪 SPCX (SpaceX 合成多头), SPCX 9/10 收 148.18; 9/9 SpaceX CFO $1.11B/yr AI compute 合同 12/1 启动; 9/10 SPCX 接近 5d 高 155 是短期阻力; 9 月已'抛售 by SpaceX'信号. | SpaceX CFO $1.11B/yr AI compute 合同 12/1 启动是硬催化 confirming 已价; 9 月'抛售 by SpaceX'是软情绪; 软情绪单独不驱动 cut, cut 是 risk_rule 纪律. | SPCX 5d +5.3% + SPCH 5d +9.7% 反弹持续; 9/16 FOMC 加息 59.4% 隐含概率若兑现, 估值进一步承压; macro 风险偏好恶化, 单一标的集中暴露危险. |
-| SPCX | +0.46% / RSI 56.8 / 趋势OFF | SpaceX 是合成多头敞口, 无独立财报; 9/9 SpaceX CFO $1.11B/yr AI compute 合同 12/1 启动是商业航天最强催化; 9/10 SPCX 148.18 距 5d 高 155 仅 4.4%, 反弹有持续性. | SpaceX CFO $1.11B/yr AI compute 合同 12/1 启动是硬催化 confirming 已价; 9 月'抛售 by SpaceX'是软情绪; 软情绪单独不驱动 add, add 是 risk_rule 纪律. | SPCX 5d +5.3% + SPCH 5d +9.7% 反弹持续; 9/16 FOMC 加息 59.4% 隐含概率若兑现, 估值进一步承压; macro 风险偏好恶化, 单一标的集中暴露危险. |
+<div class="brief-entries" markdown="1">
+
+- **00100**
+
+  <span class="entry-meta">-47.21% / RSI 44.0 / 趋势OFF</span>
+
+  **Fundamentals**　EDGAR 不适用 (港股); 招股说明书 8/28 模型版权风险未消化; 9/4 沙特 HUMAIN 合作 confirming; 8/14 board-meeting notice 业绩结果未公布 (research_surface.hk_results_expected 状态 expected 28d).
+
+  **Sentiment**　Saudi HUMAIN 9/4 合作是硬催化 confirming 已价; 8/28 招股书版权风险未消化是软利空; 板块轮动从 LLM 底座到 API/应用层是结构性软情绪; 软情绪单独不驱动 trim, 仅 confidence ±10pp. 当前 hold 是 packet 锁定, 不是情绪驱动.
+
+  **Cross-Market**　US AI 板块: SOXL 5d +4% (随 NDX), NVDA / SMH 中性; 9/16 FOMC 影响全球科技股估值; 9/10 SPX -0.58% / NDX -0.65% 小幅向下, 不构成 regime 切换但 + VIX 升 13.49% = 风险偏好恶化.
+
+- **02208**
+
+  <span class="entry-meta">-34.96% / RSI 40.6 / 趋势OFF · 已破吊灯止损 / 距 MA200 -30.10%</span>
+
+  **Fundamentals**　EDGAR 不适用; 9/8 财联社 / 海鲸社半年报: H1 营收 337.39 亿 +18.23% YoY, 净利 18.55 亿 +24.67% YoY, 风机毛利率修复近 4pp, 海上装机 +48%; 1-7 月装机 +19.5%; 累计回购 1302 万股.
+
+  **Sentiment**　JPM/BlackRock 加仓是 supporting 已价; 5d 落后同行是软利空; Trump 关税施压风电出口是软情绪未落地; 软情绪单独不驱动 trim, 仅 confidence ±10pp. 当前 hold 是 packet 锁定.
+
+  **Cross-Market**　Trump 关税施压风电出口是软利空; JPM/BlackRock 9 月加仓 0.28% / 0.09% 是 supporting 已价; 9/10 JPM 减持 1.08% 已发生. 同行 龙源 1-8 月累计发电量 5058.37 万兆瓦时 (-1.31% YoY).
+
+- **03032**
+
+  <span class="entry-meta">-19.89% / RSI 31.6 / 趋势OFF · z-2.3σ极端 · 已破吊灯止损 / 距 MA200 -14.10%</span>
+
+  **Fundamentals**　ETF 1x 跟踪 HSTECH, 无独立基本面; HSTECH 9/10 -2.04% 跌破 4800 关键支撑, 9/16 FOMC 前 4200 是底线.
+
+  **Sentiment**　HSTECH 跌破 4800 支撑是技术面信号; 南向资金 9/3 净流入 03033 1.79 亿是 1x 板块少有正资金流; 当前 hold 是 packet 锁定.
+
+  **Cross-Market**　US 9/10 SPX -0.58% / NDX -0.65% 小幅向下 + VIX 升 13.49% 风险偏好恶化, 拖累 HK 科技股; 9/16 FOMC 加息 59.4% 隐含概率若兑现, 全球科技股估值进一步承压.
+
+- **03033**
+
+  <span class="entry-meta">-17.32% / RSI 31.8 / 趋势OFF · z-2.2σ极端 · 已破吊灯止损 / 距 MA200 -14.20%</span>
+
+  **Fundamentals**　ETF 1x 跟踪 HSTECH, 无独立基本面; HSTECH 9/10 -2.04% 跌破 4800 关键支撑.
+
+  **Sentiment**　9/3 南向资金净流入 1.79 亿是 1x 板块少有正资金流, confirming 已价; 板块轮动从 LLM 到 API/应用层不利 03033 (跟踪 HSTECH 整指).
+
+  **Cross-Market**　US 9/10 科技板块小幅向下 + VIX 升 13.49% 风险偏好恶化, 拖累 HK 科技股; 9/16 FOMC 加息 59.4% 隐含概率若兑现, 全球科技股估值进一步承压.
+
+- **07226**
+
+  <span class="entry-meta">-34.54% / RSI 31.7 / 趋势OFF · z-2.3σ极端 · 已破吊灯止损 / 距 MA200 -14.40%</span>
+
+  **Fundamentals**　ETF 2x 跟踪 HSTECH, 无独立基本面; HSTECH 9/10 -2.04% 跌破 4800 关键支撑, 4200 是底线.
+
+  **Sentiment**　HSTECH 跌破 4800 支撑是技术面信号; 软情绪单独不驱动 cut, cut 是 risk_rule 纪律; 9/3 南向资金净流入 03033 1.79 亿是 1x 板块少有正资金流, 1x 替代承接窗口可能打开.
+
+  **Cross-Market**　US 9/10 SPX -0.58% / NDX -0.65% + VIX 升 13.49% 风险偏好恶化, 9/16 FOMC 加息 59.4% 隐含概率若兑现, 估值进一步承压.
+
+- **CRCL**
+
+  <span class="entry-meta">+3.82% / RSI 54.7 / 趋势OFF / 距 MA200 +5.70%</span>
+
+  **Fundamentals**　EDGAR 10-Q (Q2 2026-06-30, filed 2026-08-05): 资产 771.65 亿 / 现金 17.30 亿 / EPS 0.42 / Revenue 增长中; 9/8 $400M Tazapay all-stock 收购 (2027 close) 利好; 9/8 multimillion stock sale 计划 + 9/9 CTO 减持 pre-set trading plan 是 insider sell 软利空.
+
+  **Sentiment**　OUSD 9/9 报道是硬催化 disconfirming (-17% 单日); CEO 减持 56,200 股是软利空; ARK Invest 抄底 328 万美元是反向信号; 9/8 GENIUS Act 国会听证是 confirming 已价. 软情绪单独不驱动 trim, packet 锁 hold.
+
+  **Cross-Market**　OUSD 由 Visa/Mastercard/BlackRock/Coinbase 等 140 fintech 巨头联合推, 是跨市场结构性威胁 USDC 模型; 9/16 FOMC 加息 59.4% 隐含概率若兑现, stablecoin 估值承压.
+
+- **RKLX**
+
+  <span class="entry-meta">-71.85% / RSI 35.3 / 趋势OFF · 已破吊灯止损 / 距 MA200 -22.40%</span>
+
+  **Fundamentals**　ETF 2x 跟踪 RKLB, RKLB 9/10 收 61.96 (距 52 周高 85.55 跌 28%); SpaceX CFO 9/9 透露 $1.11B/yr AI compute 合同 12/1 启动是商业航天最强催化.
+
+  **Sentiment**　SpaceX CFO $1.11B/yr AI compute 合同 12/1 启动是硬催化 confirming 已价; RKLB / ASTS / LUNR 9 月抛售是软情绪; 软情绪单独不驱动 cut, cut 是 risk_rule 纪律.
+
+  **Cross-Market**　SPCX 5d +5.3% + SPCH 5d +9.7% 反弹持续, 9 月已'抛售 by SpaceX'信号出现, 9/10 SPCX 148 接近 5d 高 155 是短期阻力. RKLX 跟涨 RKLB 2x 受限.
+
+- **SPCH**
+
+  <span class="entry-meta">-18.16% / RSI 56.8 / 趋势OFF</span>
+
+  **Fundamentals**　ETF 2x 跟踪 SPCX (SpaceX 合成多头), SPCX 9/10 收 148.18; 9/9 SpaceX CFO $1.11B/yr AI compute 合同 12/1 启动; 9/10 SPCX 接近 5d 高 155 是短期阻力; 9 月已'抛售 by SpaceX'信号.
+
+  **Sentiment**　SpaceX CFO $1.11B/yr AI compute 合同 12/1 启动是硬催化 confirming 已价; 9 月'抛售 by SpaceX'是软情绪; 软情绪单独不驱动 cut, cut 是 risk_rule 纪律.
+
+  **Cross-Market**　SPCX 5d +5.3% + SPCH 5d +9.7% 反弹持续; 9/16 FOMC 加息 59.4% 隐含概率若兑现, 估值进一步承压; macro 风险偏好恶化, 单一标的集中暴露危险.
+
+- **SPCX**
+
+  <span class="entry-meta">+0.46% / RSI 56.8 / 趋势OFF</span>
+
+  **Fundamentals**　SpaceX 是合成多头敞口, 无独立财报; 9/9 SpaceX CFO $1.11B/yr AI compute 合同 12/1 启动是商业航天最强催化; 9/10 SPCX 148.18 距 5d 高 155 仅 4.4%, 反弹有持续性.
+
+  **Sentiment**　SpaceX CFO $1.11B/yr AI compute 合同 12/1 启动是硬催化 confirming 已价; 9 月'抛售 by SpaceX'是软情绪; 软情绪单独不驱动 add, add 是 risk_rule 纪律.
+
+  **Cross-Market**　SPCX 5d +5.3% + SPCH 5d +9.7% 反弹持续; 9/16 FOMC 加息 59.4% 隐含概率若兑现, 估值进一步承压; macro 风险偏好恶化, 单一标的集中暴露危险.
+
+</div>
+
+</div>
 
 ## 这本账现在什么样
+
+<div class="brief-card" markdown="1">
 
 ### 双币账本（HK + USD 不能直接相加）
 
@@ -107,12 +311,20 @@ Book 双 leg 危险集中 (HK 0.416 / US 0.752) 单一事件可炸; 单仓 00100
 HK 现金: 17,597 HKD | US 现金: 461.63 USD
 ```
 
+</div>
+
+<div class="brief-card" markdown="1">
+
 ### 集中度
 
 | Leg | HHI | 判定 | Top2 | 腿总值 |
 |---|---|---|---|---|
 | HK | 0.416 | 🔴 危险集中 | 85.70% | 61,527 |
 | US | 0.752 | 🔴 危险集中 | 91.60% | 3,430 |
+
+</div>
+
+<div class="brief-card" markdown="1">
 
 ### 风控硬闸
 
@@ -132,6 +344,10 @@ open **8** / overridden 0 / unacknowledged 8 / oldest 58d / decision_overdue 5
 | beta | US | high | US β vs S&P = 5.4484 (cap 3.0) — 大盘 −1% 本子约 −5.4% | risk-66b800a6afe2 |
 
 **directive**: ⛔ 5 仓位硬闸 + 3 杠杆止损触发。每条必须在 Judge 段出一个对应动作(driven_by=risk_rule,纪律性再平衡,不算听消息、不受 risk_on HOLD 默认约束)；其余主动 call 仍按 regime guard。杠杆ETF解套口径=2x→1x 同因子换仓而非清仓(见各 action)。
+
+</div>
+
+<div class="brief-card" markdown="1">
 
 ### 加仓面（收盘确认）
 
@@ -158,6 +374,10 @@ candidate **0** / wait 3 / reject 1　·　技术突破(收盘站上前 20 日�
 
 _冷启动期：单族 + 价格确认 + 非杠杆 ⇒ 半个试探仓（policy `cold_start_single_family_enabled`）；计数器填满后此例外自动失效_
 
+</div>
+
+<div class="brief-card" markdown="1">
+
 ### 回本测算
 
 | Ticker | 浮% | 2x chop drag/月 | 回本需 | 半年窗含 drag 等效标的需 |
@@ -171,6 +391,10 @@ _冷启动期：单族 + 价格确认 + 非杠杆 ⇒ 半个试探仓（policy `
 | 03033 | -17.30% | — | +20.90% | — |
 
 注：回本涨幅=成本/现价−1。2x 行加印：标的σ、横盘 decay≈σ²/12 每月、半年窗含 drag 的等效标的涨幅。解读纪律：直线涨→2x 回本更快；横盘→2x 每月白付 decay；再跌→2x 双倍挨打。换 1x 买的是后两种情景的保护，不是回本速度。
+
+</div>
+
+<div class="brief-card" markdown="1">
 
 ### 仓位明细
 
@@ -195,6 +419,10 @@ _冷启动期：单族 + 价格确认 + 非杠杆 ⇒ 半个试探仓（policy `
 | SPCH Leverage Shares 2X Long SpaceX Daily ETF | 300 | 12.06 | 9.87 | +0.82% | -18.16% | -657 |
 | **小计 US** |  |  |  | 14 | -22.69% | **-1,007** |
 
+</div>
+
+<div class="brief-card" markdown="1">
+
 ### 大盘趋势（两条腿各自的读数）
 
 | 腿 | 窗口 | 距均线/动量 | 趋势 | 读数 |
@@ -206,8 +434,12 @@ _regime3=近10日动量分 牛(>+3%)/熊(<-3%)/震荡；trend_on=200日线；US 
 
 _HK 的趋势闸只收紧 HK 杠杆腿的上限；US 杠杆腿走它自己的 per-name dial_
 
+</div>
+
 <details class="brief-appendix" markdown="1">
 <summary>背景与校准</summary>
+
+<div class="brief-card" markdown="1">
 
 ### 昨日兑现（2026-09-10 的 plan）
 
@@ -223,19 +455,73 @@ _HK 的趋势闸只收紧 HK 杠杆腿的上限；US 杠杆腿走它自己的 pe
 | 03033 | hold_and_watch | core_position | — | 50% | pending |
 | CRCL | hold_and_watch | core_position | — | 50% | pending |
 
+</div>
+
+<div class="brief-card" markdown="1">
+
 ### 同行扫描
 
-| 持仓 | 主题 | 今日 self | 最强同行 | 差距 | 判断 |
-|---|---|---|---|---|---|
-| 00100 | HK AI 大模型 | -8.98% | 00020 商汤-W -1.88% | -7.10pp | AI 大模型板块 9/10 极端分化: 范式智能 +14.66% (API +860% 领涨) / 邁富時 +13.52% / 阅文 +8.36% 全部跑赢, 智谱 -10.34% / 云知声 -10.03% / 滴普 -6.05% / 迅策 -5.5% 全部跑输. 00100 -8.98% 在 LLM 阵营承压, 相对智谱略强, 但落后 API/应用层 +14% 阵营. 归因: 板块轮动到 API/应用层而非 LLM 底座, 00100 在 LLM 阵营, alpha 在掉. |
-| 02208 | 风电 | -1.19% | 00916 龙源电力 -0.91% | -0.28pp | 5d 同行 龙源 +4.11% / 大唐 +4.21% / 新天 +1.67% 全部强于 02208 +0.2%. 落后归因: JPM 减持 1.08% (已) + Trump 关税施压风电出口 (sector_hits) 软利空未消化 + 半年报业绩已价. |
-| 03032 | HK 科技指数 1x (HSTECH 标的) | -2.08% | 03033 南方恒生科技 -1.89% | -0.19pp | 1d 与 03033 (-1.89%) / 03067 (-2.04%) 同步, 5d 与 HSTECH 同步无独立 alpha. 1x 替代与 2x 杠杆 07226 同源 HSTECH, cut 07226 后 1x 承接规模合适. |
-| 03033 | HK 科技指数 1x (HSTECH 标的) | -1.89% | 03032 恒生科技ETF -2.08% | +0.19pp | 1d 与 03032 (-2.08%) / 03067 (-2.04%) 同步, 5d 与 HSTECH 同步无独立 alpha. 1x 替代与 2x 杠杆 07226 同源 HSTECH, cut 07226 后 1x 承接是 swap_mandate 设计, 但 buy 腿 blocked 待 setup. |
-| 07226 | HK 科技指数 2x leveraged (HSTECH 标的) | -4.29% | 09999 网易 -0.05% | -4.24pp | 5d 同行 HSTECH 权重 网易 0.05% / 京东 -1.31% / 腾讯 -1.71% / 阿里 -0.56% / 美团 -3.73% 全部强于 07226 -6.3% (2x underlying 弱势). 1d 同行 网易 -0.05% / 京东 -0.75% / 腾讯 -1.94% / 阿里 -2.64% / 美团 -3.92% 全部强于 07226 -4.29%. 归因: 杠杆放大 underlying 弱势, cut 换 1x 是减仓最优解. |
-| CRCL | 稳定币 + agent 支付 | -2.87% | PYPL Paypal +2.19% | -5.06pp | 5d 同行 BKKT +6.73% / HOOD +5.93% 强于 CRCL +1.9%, COIN -1.53% / PYPL -2.49% 弱. 1d 同行 PYPL +2.19% / COIN -1.4% / HOOD -1.69% / BKKT -4.0% 弱于 CRCL -2.87%. OUSD 硬催化对 stablecoin 板块整体压力. |
-| RKLX | RKLB 2x leveraged | -3.45% | RKLB Rocket Lab -1.76% | -1.69pp | 5d 同行 RKLB -4.2% / RKLX -4.2% 同步, ASTS / BKSY / IRDM 略强. 1d 9/10 SPCX +0.43% 略强, ASTS / RKLB 略弱. 商业航天板块 9 月分化, SPCX/SPCH 反弹持续, RKLX 受 RKLB 弱势拖累. |
-| SPCH | SpaceX 2x leveraged (商业航天) | +0.82% | RKLB Rocket Lab -1.76% | +2.58pp | 5d 同行 SPCX +5.3% 强于 SPCH +9.7% (2x 放大), ASTS / BKSY / IRDM 弱. 1d 9/10 SPCX +0.43% 持平, SPCH 略弱. 商业航天板块 9 月分化, SPCX/SPCH 反弹持续但短期阻力 155. |
-| SPCX | 商业航天 (火箭发射 + Starlink 卫星互联网) | +0.43% | IRDM 铱星通讯 -0.06% | +0.49pp | 5d 同行 SPCX +5.3% 强, ASTS / BKSY / IRDM 弱. 1d 9/10 SPCX +0.43% 持平, SPCH 略弱. 商业航天板块 9 月分化, SPCX/SPCH 反弹持续但短期阻力 155. |
+<div class="brief-entries" markdown="1">
+
+- **00100** · 今日 -8.98% · 差距 -7.10pp
+
+  <span class="entry-meta">HK AI 大模型 · 最强同行 00020 商汤-W -1.88%</span>
+
+  **判断**　AI 大模型板块 9/10 极端分化: 范式智能 +14.66% (API +860% 领涨) / 邁富時 +13.52% / 阅文 +8.36% 全部跑赢, 智谱 -10.34% / 云知声 -10.03% / 滴普 -6.05% / 迅策 -5.5% 全部跑输. 00100 -8.98% 在 LLM 阵营承压, 相对智谱略强, 但落后 API/应用层 +14% 阵营. 归因: 板块轮动到 API/应用层而非 LLM 底座, 00100 在 LLM 阵营, alpha 在掉.
+
+- **02208** · 今日 -1.19% · 差距 -0.28pp
+
+  <span class="entry-meta">风电 · 最强同行 00916 龙源电力 -0.91%</span>
+
+  **判断**　5d 同行 龙源 +4.11% / 大唐 +4.21% / 新天 +1.67% 全部强于 02208 +0.2%. 落后归因: JPM 减持 1.08% (已) + Trump 关税施压风电出口 (sector_hits) 软利空未消化 + 半年报业绩已价.
+
+- **03032** · 今日 -2.08% · 差距 -0.19pp
+
+  <span class="entry-meta">HK 科技指数 1x (HSTECH 标的) · 最强同行 03033 南方恒生科技 -1.89%</span>
+
+  **判断**　1d 与 03033 (-1.89%) / 03067 (-2.04%) 同步, 5d 与 HSTECH 同步无独立 alpha. 1x 替代与 2x 杠杆 07226 同源 HSTECH, cut 07226 后 1x 承接规模合适.
+
+- **03033** · 今日 -1.89% · 差距 +0.19pp
+
+  <span class="entry-meta">HK 科技指数 1x (HSTECH 标的) · 最强同行 03032 恒生科技ETF -2.08%</span>
+
+  **判断**　1d 与 03032 (-2.08%) / 03067 (-2.04%) 同步, 5d 与 HSTECH 同步无独立 alpha. 1x 替代与 2x 杠杆 07226 同源 HSTECH, cut 07226 后 1x 承接是 swap_mandate 设计, 但 buy 腿 blocked 待 setup.
+
+- **07226** · 今日 -4.29% · 差距 -4.24pp
+
+  <span class="entry-meta">HK 科技指数 2x leveraged (HSTECH 标的) · 最强同行 09999 网易 -0.05%</span>
+
+  **判断**　5d 同行 HSTECH 权重 网易 0.05% / 京东 -1.31% / 腾讯 -1.71% / 阿里 -0.56% / 美团 -3.73% 全部强于 07226 -6.3% (2x underlying 弱势). 1d 同行 网易 -0.05% / 京东 -0.75% / 腾讯 -1.94% / 阿里 -2.64% / 美团 -3.92% 全部强于 07226 -4.29%. 归因: 杠杆放大 underlying 弱势, cut 换 1x 是减仓最优解.
+
+- **CRCL** · 今日 -2.87% · 差距 -5.06pp
+
+  <span class="entry-meta">稳定币 + agent 支付 · 最强同行 PYPL Paypal +2.19%</span>
+
+  **判断**　5d 同行 BKKT +6.73% / HOOD +5.93% 强于 CRCL +1.9%, COIN -1.53% / PYPL -2.49% 弱. 1d 同行 PYPL +2.19% / COIN -1.4% / HOOD -1.69% / BKKT -4.0% 弱于 CRCL -2.87%. OUSD 硬催化对 stablecoin 板块整体压力.
+
+- **RKLX** · 今日 -3.45% · 差距 -1.69pp
+
+  <span class="entry-meta">RKLB 2x leveraged · 最强同行 RKLB Rocket Lab -1.76%</span>
+
+  **判断**　5d 同行 RKLB -4.2% / RKLX -4.2% 同步, ASTS / BKSY / IRDM 略强. 1d 9/10 SPCX +0.43% 略强, ASTS / RKLB 略弱. 商业航天板块 9 月分化, SPCX/SPCH 反弹持续, RKLX 受 RKLB 弱势拖累.
+
+- **SPCH** · 今日 +0.82% · 差距 +2.58pp
+
+  <span class="entry-meta">SpaceX 2x leveraged (商业航天) · 最强同行 RKLB Rocket Lab -1.76%</span>
+
+  **判断**　5d 同行 SPCX +5.3% 强于 SPCH +9.7% (2x 放大), ASTS / BKSY / IRDM 弱. 1d 9/10 SPCX +0.43% 持平, SPCH 略弱. 商业航天板块 9 月分化, SPCX/SPCH 反弹持续但短期阻力 155.
+
+- **SPCX** · 今日 +0.43% · 差距 +0.49pp
+
+  <span class="entry-meta">商业航天 (火箭发射 + Starlink 卫星互联网) · 最强同行 IRDM 铱星通讯 -0.06%</span>
+
+  **判断**　5d 同行 SPCX +5.3% 强, ASTS / BKSY / IRDM 弱. 1d 9/10 SPCX +0.43% 持平, SPCH 略弱. 商业航天板块 9 月分化, SPCX/SPCH 反弹持续但短期阻力 155.
+
+</div>
+
+</div>
+
+<div class="brief-card" markdown="1">
 
 ### 板块全景
 
@@ -253,25 +539,101 @@ _HK 的趋势闸只收紧 HK 杠杆腿的上限；US 杠杆腿走它自己的 pe
 
 AI 大模型板块 9/10 极端分化: 范式智能 +14.66% (API +860% 领涨) / 邁富時 +13.52% (应用层) / 阅文 +8.36% 全部跑赢, 智谱 -10.34% (基本面 +399.7% revenue 仍暴跌说明估值重估) / 云知声 -10.03% / 滴普 -6.05% 全部跑输. 00100 9/10 -8.98% 在 LLM 阵营承压, 相对智谱 -10.34% 略强, 但落后于 API/应用层 +14% 阵营, 板块轮动从 LLM 底座到 API/应用层明确. HSTECH 9/10 -2.04% 跌破 4800 关键支撑, 9/16 FOMC 前 4200 是底线. 风电板块 龙源 1-8 月累计发电 -1.31% YoY, 金风 5d +0.2% 同行 龙源 +4.11% / 大唐 +4.21% 略强. 商业航天 SPCX 5d +5.3% + SPCH 5d +9.7% 反弹持续, 但 9 月已'抛售 by SpaceX'信号出现, 9/10 SPCX 148 接近 5d 高 155 是短期阻力. Stablecoin 板块 140 fintech 巨头推 OUSD 共享收益稳定币, 直击 CRCL 独占储备收益命门, 当日 -17%, ARK 抄底 328 万美元是反向信号, OCC 11 月前发 GENIUS Act 最终规则是中期催化.
 
+</div>
+
+<div class="brief-card" markdown="1">
+
 ### 大盘速读
 
 VIX **17.84** (+13.49%) · HSI **24,954.47** (-1.27%) · HSTECH **4,330.49** (-2.04%) · SPX **7,591.70** (-0.58%) · 纳指 **26,081.72** (-0.65%) · DXY **99.09** (+0.04%) · F&G **33.3** fear · 10Y **4.94%**（as_of 2026-09-10T23:26:58.161946+00:00, age 0.6h）
 
 VIX 17.84 (+13.49% 升) · F&G 33.3 fear → 风险偏好降温, leveraged 仓位 (SOXL/07226/SPCH/RKLX) 注意; SPX 7591.7 (-0.58%) / NDX 26081.7 (-0.65%) → 美股小幅向下, 不构成 regime 切换但 + VIX 升 = 风险偏好恶化; HSI 24954 (-1.27%) / HSTECH 4330.49 (-2.04%) → HSTECH 4800 支撑已破, 07226 2x 杠杆暴露危险; 10Y yield 4.944% (高位) · DXY 99.09 → 高利率持续压制成长股估值; Fed 最新动态: 9/16 FOMC 加息 25bp 隐含 59.4% 概率, 是本周最大宏观催化, 影响 CRCL / AI 板块 / 商业航天估值.
 
+</div>
+
+<div class="brief-card" markdown="1">
+
 ### 社交舆情
 
-| 票 | Reddit 7d | 新闻关键词 | 近 5 日 | 信号判断 |
-|---|---|---|---|---|
-| CRCL | 1 mentions | Circle Internet Group (CRCL) CEO sel、Circle Internet Group (CRCL) Agrees 、Circle Internet Group (NYSE:CRCL) CE | — | OUSD 9/9 报道是硬催化 disconfirming (-17% 单日); CEO 减持 56,200 股是软利空; ARK Invest 抄底 328 万美元是反向信号; 9/8 GENIUS Act 国会听证是 confirming 已价. 软情绪单独不驱动 trim, packet 锁 hold. |
-| RKLX | 0 mentions | Technical Reactions to RKLX Trends i、RKLX: Benefits And Risks Of Leveragi、$Defiance Daily Target 2X Long RKLB  | — | SpaceX CFO $1.11B/yr AI compute 合同 12/1 启动是硬催化 confirming 已价; RKLB / ASTS / LUNR 9 月抛售是软情绪; 软情绪单独不驱动 cut, cut 是 risk_rule 纪律. |
-| SPCX | 3 mentions | SpaceX stock rises with data center 、SpaceX Lockup Expiry: 59M Shares Set、SpaceX: Why You Should Wait For Its  | — | SpaceX CFO $1.11B/yr AI compute 合同 12/1 启动是硬催化 confirming 已价; 9 月'抛售 by SpaceX'是软情绪; 软情绪单独不驱动 add, add 是 risk_rule 纪律. |
-| SPCH | 3 mentions | $Leverage Shares 2X Long SpaceX Dail、Liquidity Mapping Around (SPCH) Pric、SPCH ETF Price and Chart — CBOE:SPCH | — | SpaceX CFO $1.11B/yr AI compute 合同 12/1 启动是硬催化 confirming 已价; 9 月'抛售 by SpaceX'是软情绪; 软情绪单独不驱动 cut, cut 是 risk_rule 纪律. |
-| 00100 | 0 mentions | HK Stock Market Watch \| MINIMAX-W (0、HK Stock Market Watch \| MINIMAX-W (0、MINIMAX GROUP INC. - W (100) - stock | — | Saudi HUMAIN 9/4 合作是硬催化 confirming 已价; 8/28 招股书版权风险未消化是软利空; 板块轮动从 LLM 底座到 API/应用层是结构性软情绪; 软情绪单独不驱动 trim, 仅 confidence ±10pp. 当前 hold 是 packet 锁定, 不是情绪驱动. |
-| 02208 | 0 mentions | Zhitong Statistics on Significant Ch、Hong Kong Stock Market Movement \| Co、Jinfeng Technology's Hong Kong-liste | — | JPM/BlackRock 加仓是 supporting 已价; 5d 落后同行是软利空; Trump 关税施压风电出口是软情绪未落地; 软情绪单独不驱动 trim, 仅 confidence ±10pp. 当前 hold 是 packet 锁定. |
-| 03032 | 0 mentions | New funds are channeling into the Ho、Zhitong HK Stock Connect Holdings Ra、Report: Volcano Engine's revenue wil | — | HSTECH 跌破 4800 支撑是技术面信号; 南向资金 9/3 净流入 03033 1.79 亿是 1x 板块少有正资金流; 当前 hold 是 packet 锁定. |
-| 07226 | 0 mentions | Hang Seng Tech Index Surges, Souther、ETF Market Movement \| CSOP FTSE Chin、7226 ETF Price and Chart — HKEX:7226 | — | HSTECH 跌破 4800 支撑是技术面信号; 软情绪单独不驱动 cut, cut 是 risk_rule 纪律; 9/3 南向资金净流入 03033 1.79 亿是 1x 板块少有正资金流, 1x 替代承接窗口可能打开. |
-| 03033 | 0 mentions | Zhitong HK Stock Connect Holdings An、Zhitong HK Stock Connect Holdings Ra、Zhito Hong Kong Stock Connect Holdin | — | 9/3 南向资金净流入 1.79 亿是 1x 板块少有正资金流, confirming 已价; 板块轮动从 LLM 到 API/应用层不利 03033 (跟踪 HSTECH 整指). |
+<div class="brief-entries" markdown="1">
+
+- **CRCL** · 近 5 日 —
+
+  <span class="entry-meta">Reddit 7d 1 mentions</span>
+
+  **新闻**　Circle Internet Group (CRCL) CEO sel、Circle Internet Group (CRCL) Agrees 、Circle Internet Group (NYSE:CRCL) CE
+
+  **信号判断**　OUSD 9/9 报道是硬催化 disconfirming (-17% 单日); CEO 减持 56,200 股是软利空; ARK Invest 抄底 328 万美元是反向信号; 9/8 GENIUS Act 国会听证是 confirming 已价. 软情绪单独不驱动 trim, packet 锁 hold.
+
+- **RKLX** · 近 5 日 —
+
+  <span class="entry-meta">Reddit 7d 0 mentions</span>
+
+  **新闻**　Technical Reactions to RKLX Trends i、RKLX: Benefits And Risks Of Leveragi、$Defiance Daily Target 2X Long RKLB 
+
+  **信号判断**　SpaceX CFO $1.11B/yr AI compute 合同 12/1 启动是硬催化 confirming 已价; RKLB / ASTS / LUNR 9 月抛售是软情绪; 软情绪单独不驱动 cut, cut 是 risk_rule 纪律.
+
+- **SPCX** · 近 5 日 —
+
+  <span class="entry-meta">Reddit 7d 3 mentions</span>
+
+  **新闻**　SpaceX stock rises with data center 、SpaceX Lockup Expiry: 59M Shares Set、SpaceX: Why You Should Wait For Its 
+
+  **信号判断**　SpaceX CFO $1.11B/yr AI compute 合同 12/1 启动是硬催化 confirming 已价; 9 月'抛售 by SpaceX'是软情绪; 软情绪单独不驱动 add, add 是 risk_rule 纪律.
+
+- **SPCH** · 近 5 日 —
+
+  <span class="entry-meta">Reddit 7d 3 mentions</span>
+
+  **新闻**　$Leverage Shares 2X Long SpaceX Dail、Liquidity Mapping Around (SPCH) Pric、SPCH ETF Price and Chart — CBOE:SPCH
+
+  **信号判断**　SpaceX CFO $1.11B/yr AI compute 合同 12/1 启动是硬催化 confirming 已价; 9 月'抛售 by SpaceX'是软情绪; 软情绪单独不驱动 cut, cut 是 risk_rule 纪律.
+
+- **00100** · 近 5 日 —
+
+  <span class="entry-meta">Reddit 7d 0 mentions</span>
+
+  **新闻**　HK Stock Market Watch \| MINIMAX-W (0、HK Stock Market Watch \| MINIMAX-W (0、MINIMAX GROUP INC. - W (100) - stock
+
+  **信号判断**　Saudi HUMAIN 9/4 合作是硬催化 confirming 已价; 8/28 招股书版权风险未消化是软利空; 板块轮动从 LLM 底座到 API/应用层是结构性软情绪; 软情绪单独不驱动 trim, 仅 confidence ±10pp. 当前 hold 是 packet 锁定, 不是情绪驱动.
+
+- **02208** · 近 5 日 —
+
+  <span class="entry-meta">Reddit 7d 0 mentions</span>
+
+  **新闻**　Zhitong Statistics on Significant Ch、Hong Kong Stock Market Movement \| Co、Jinfeng Technology's Hong Kong-liste
+
+  **信号判断**　JPM/BlackRock 加仓是 supporting 已价; 5d 落后同行是软利空; Trump 关税施压风电出口是软情绪未落地; 软情绪单独不驱动 trim, 仅 confidence ±10pp. 当前 hold 是 packet 锁定.
+
+- **03032** · 近 5 日 —
+
+  <span class="entry-meta">Reddit 7d 0 mentions</span>
+
+  **新闻**　New funds are channeling into the Ho、Zhitong HK Stock Connect Holdings Ra、Report: Volcano Engine's revenue wil
+
+  **信号判断**　HSTECH 跌破 4800 支撑是技术面信号; 南向资金 9/3 净流入 03033 1.79 亿是 1x 板块少有正资金流; 当前 hold 是 packet 锁定.
+
+- **07226** · 近 5 日 —
+
+  <span class="entry-meta">Reddit 7d 0 mentions</span>
+
+  **新闻**　Hang Seng Tech Index Surges, Souther、ETF Market Movement \| CSOP FTSE Chin、7226 ETF Price and Chart — HKEX:7226
+
+  **信号判断**　HSTECH 跌破 4800 支撑是技术面信号; 软情绪单独不驱动 cut, cut 是 risk_rule 纪律; 9/3 南向资金净流入 03033 1.79 亿是 1x 板块少有正资金流, 1x 替代承接窗口可能打开.
+
+- **03033** · 近 5 日 —
+
+  <span class="entry-meta">Reddit 7d 0 mentions</span>
+
+  **新闻**　Zhitong HK Stock Connect Holdings An、Zhitong HK Stock Connect Holdings Ra、Zhito Hong Kong Stock Connect Holdin
+
+  **信号判断**　9/3 南向资金净流入 1.79 亿是 1x 板块少有正资金流, confirming 已价; 板块轮动从 LLM 到 API/应用层不利 03033 (跟踪 HSTECH 整指).
+
+</div>
+
+</div>
+
+<div class="brief-card" markdown="1">
 
 ### 名人异动 / 政策风向（0.7h 前）
 
@@ -282,6 +644,10 @@ VIX 17.84 (+13.49% 升) · F&G 33.3 fear → 风险偏好降温, leveraged 仓�
 - [板块相关] Musk（endorse）：英国加深对 SpaceX 卫星服务依赖，签下近 4000 万美元合同，强化 SpaceX 政府/国防订单趋势，间接利好 kcn 的 SPCX/SPCH 持仓。
 - [板块相关] Trump（endorse）：Trump转发力挺能源/油价分析师Phil Flynn，间接利好能源板块，与kcn持有的金风科技(02208)板块相关。
 - [板块相关] Trump（neutral）：Trump评论德国选择党崛起、民粹回潮，对欧洲资产/全球风险偏好有间接影响，与kcn恒生科技ETF相关（情绪传导）。
+
+</div>
+
+<div class="brief-card" markdown="1">
 
 ### 决策校准
 
@@ -295,6 +661,10 @@ VIX 17.84 (+13.49% 升) · F&G 33.3 fear → 风险偏好降温, leveraged 仓�
 
 Decision v2: 46 settled episodes, Brier 0.3031 LOSES baseline_loo 0.28 (overconfident, mean_conf 0.88 vs base_rate 0.64). 8 calibrator 全部 edge_supported=false, signal_size_multiplier=0 → 今日所有 call 是纪律非择时, alpha 期望统计噪声. by_action: cut n=9 胜 6 (66.7%, CI 跨 0), hold n=35 胜 24 (68.6%, CI 跨 0) → 持胜率与 cut 类似, 主动 trim 没统计意义. by_driver: technical n=27 胜 19 (70.4%, CI 跨 0) → 最高但仍无显著 edge. execution: active 0/60 (0%, 3 stranded), passive 130/131 (99.2%) → 主动 call 执行率 0% 是真实问题. 重新报: Brier 高于 baseline = 信心值校准不合格 (过度自信), 不是没信息量 — reliability 把 resolution 吃掉了.
 
+</div>
+
+<div class="brief-card" markdown="1">
+
 ### 待补
 
 - 今日 US 1 leg 报价全部来自 Finnhub (4/4), Nasdaq API 主源 0/4 — US 价可信度依赖单源, 异常波动需 manual 核实
@@ -302,5 +672,7 @@ Decision v2: 46 settled episodes, Brier 0.3031 LOSES baseline_loo 0.28 (overconf
 - 00100 历史 165 bars 不足 200, MA200 null, 趋势 unknown — 同上, LLM 浮亏 -47% 反弹中无量化锚定
 - 9/16 FOMC 加息隐含 59.4% 概率来自 CME FedWatch 9/10 数据, 9/11-9/15 CPI/PPI 数据可能改预期, macro 数据刷新频率 24h
 - 2 bar conflicts need --repair
+
+</div>
 
 </details>

--- a/site/_layouts/default.html
+++ b/site/_layouts/default.html
@@ -26,6 +26,12 @@
     --radius: 12px;
     --radius-sm: 8px;
     --mono: ui-monospace, "SF Mono", Menlo, monospace;
+    /* Brief cards (2026-09-11): the lit top edge and the drop shadow are the
+       two halves of "a card sitting on the page", and each needs its own value
+       per theme — a white edge vanishes on a white card, a soft shadow vanishes
+       on a near-black page. Tokens, not literals, for the #1272 reason. */
+    --card-edge: rgba(255, 255, 255, 0.05);
+    --card-shadow: 0 1px 2px rgba(0, 0, 0, 0.30), 0 14px 32px -18px rgba(0, 0, 0, 0.70);
   }
   @media (prefers-color-scheme: light) {
     :root {
@@ -39,6 +45,8 @@
       --accent-2: #7c5ce8;
       --green: #16a34a;
       --red: #dc2626;
+      --card-edge: rgba(255, 255, 255, 0.9);
+      --card-shadow: 0 1px 2px rgba(15, 22, 38, 0.05), 0 14px 32px -20px rgba(15, 22, 38, 0.22);
     }
   }
   * { box-sizing: border-box; }
@@ -226,6 +234,152 @@
     article table th, article table td { padding: 6px 8px; }
   }
 
+  /* ── Brief pages: one card per subsection (2026-09-11) ────────────────────
+     kcn: "在 dashboard 里看 brief 也很丑，也没什么卡片区块感，数据排版也很杂乱".
+     Measured on the 2026-09-11 brief before this change: zero containers below
+     the part bands (every `h3` subsection was a quiet label with a hairline,
+     `background: transparent`, `border: 0`), five of sixteen tables carrying a
+     prose column with cells up to 668 characters, and — under the phone rule's
+     `nowrap` — a 4,880px table inside a 328px screen.
+
+     `brief_render` now wraps each subsection in `.brief-card` and lays the five
+     prose tables out as `.brief-entries`. Everything below is scoped to
+     `article:has(.brief-card)`, so the weekly reviews, the FAQ and every other
+     page on this layout keep the single-panel look they were designed with; a
+     brief rendered before this change has no cards and also keeps it. */
+  article:has(.brief-card) {
+    background: transparent; border: 0; padding: 0;
+  }
+  article:has(.brief-card) > h1 { margin: 6px 2px 14px; font-size: 24px; }
+  /* Parts become section headers ON the page, between groups of cards — the
+     cards carry the weight now, so the band would be a card-shaped thing that
+     is not a card. */
+  article:has(.brief-card) h2 {
+    background: none; border-left: 0; border-radius: 0;
+    padding: 0 2px; margin: 34px 0 10px;
+    font-size: 18px; font-weight: 700;
+    display: flex; align-items: center; gap: 10px;
+  }
+  article:has(.brief-card) h2::before {
+    content: ""; flex: 0 0 auto; width: 4px; height: 1.05em;
+    border-radius: 2px; background: var(--accent);
+  }
+  .brief-card {
+    background: var(--card);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 18px 20px;
+    margin: 12px 0;
+    box-shadow: inset 0 1px 0 var(--card-edge), var(--card-shadow);
+  }
+  .brief-card > :first-child { margin-top: 0; }
+  .brief-card > :last-child { margin-bottom: 0; }
+  article .brief-card > h3 {
+    font-size: 15px; font-weight: 650; color: var(--text);
+    letter-spacing: -0.005em; margin: 0 0 12px;
+  }
+  article .brief-card > h3::after { display: none; }
+  /* The opening call: the first thing the page says, set a size up. */
+  .brief-lede { font-size: 15.5px; line-height: 1.7; }
+  .brief-lede > p { margin: 8px 0; }
+
+  /* One block per row for the rows whose content is prose. */
+  .brief-entries > ul {
+    list-style: none; padding: 0; margin: 0;
+    display: grid; gap: 10px;
+  }
+  article .brief-entries li {
+    margin: 0; padding: 12px 14px;
+    background: var(--card-2);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+  }
+  .brief-entries li > p { margin: 6px 0 0; }
+  .brief-entries li > p:first-child { margin: 0; font-size: 15px; line-height: 1.5; }
+  .brief-entries .entry-meta {
+    display: block; font-family: var(--mono); font-size: 12px;
+    line-height: 1.5; color: var(--text-dim); overflow-wrap: anywhere;
+  }
+  /* The field label (理由 / 证伪条件 / Fundamentals …) reads as a label, so the
+     prose after it is what the eye lands on. */
+  .brief-entries li > p:not(:first-child) > strong:first-child {
+    color: var(--text-dim); font-size: 12.5px; font-weight: 600;
+    letter-spacing: 0.02em;
+  }
+  /* In 今日动作 the title is `**ticker** · **action**`: the second bold is the
+     call itself, so it reads as a chip. Only that section has a second bold in
+     its title line, which is the renderer's doing, not an accident. */
+  .brief-entries li > p:first-child > strong:nth-of-type(2) {
+    display: inline-block; padding: 0 9px; border-radius: 999px;
+    font-size: 13px; line-height: 1.7; vertical-align: 1px;
+    color: var(--accent);
+    background: color-mix(in srgb, var(--accent) 14%, transparent);
+  }
+
+  .brief-card table { margin: 4px 0; }
+  .brief-card > table:last-child { margin-bottom: 0; }
+
+  /* The folded reference material: the toggle becomes a card of its own and
+     the sections inside it stay cards, instead of cards nested in a panel. */
+  article:has(.brief-card) details.brief-appendix {
+    background: transparent; border: 0; padding: 0; margin-top: 34px;
+  }
+  article:has(.brief-card) details.brief-appendix > summary {
+    padding: 13px 18px; background: var(--card);
+    border: 1px solid var(--border); border-radius: var(--radius);
+    box-shadow: inset 0 1px 0 var(--card-edge), var(--card-shadow);
+  }
+  article:has(.brief-card) details.brief-appendix[open] > summary {
+    border-bottom: 1px solid var(--border); margin-bottom: 4px;
+  }
+
+  @media (max-width: 600px) {
+    article:has(.brief-card) { padding: 0; }
+    article:has(.brief-card) > h1 { font-size: 20px; }
+    .brief-card { padding: 14px; margin: 10px 0; border-radius: var(--radius-sm); }
+    article .brief-entries li { padding: 10px 12px; }
+    /* Cells wrap on brief pages. `nowrap` (below, for every page) was there so
+       a wide numeric table scrolls instead of breaking the layout — the scroll
+       still happens via `display: block; overflow-x: auto`, and with prose out
+       of the tables a wrapped cell is a number and a word, not 668 characters
+       on one line. Headers keep `nowrap` so a column name never splits. */
+    article:has(.brief-card) table { white-space: normal; }
+    article:has(.brief-card) table th { white-space: nowrap; }
+
+    /* On a phone the call has to be visible before the reasoning (the 09-09
+       rule: what matters must be seen without a second action). Nine
+       decisions with ~500 characters of reasoning each made 今日动作 4,249px
+       tall at 390px, so the prose fields clamp to two lines and a tap opens the
+       entry. Keyed on `.brief-js`, which the script at the end of this file
+       sets: with no script there is no clamp and no way to lose text. The hint
+       is drawn only on entries the script measured as actually cut. */
+    /* The enum line (`.entry-meta`) is short facts, not prose — clamping it
+       cut `risk_rule` off the end of a three-enum line. Only prose clamps. */
+    .brief-js .brief-entries li > p:not(:first-child):not(:has(> .entry-meta)) {
+      display: -webkit-box; -webkit-box-orient: vertical;
+      -webkit-line-clamp: 2; line-clamp: 2; overflow: hidden;
+    }
+    .brief-js .brief-entries li.is-open > p:not(:first-child):not(:has(> .entry-meta)) {
+      display: block; -webkit-line-clamp: unset; line-clamp: none; overflow: visible;
+    }
+    .brief-js .brief-entries li.is-clamped { cursor: pointer; }
+    /* A collapsed tile on a phone is the call plus two lines of why. The enum
+       line waits for the tap — only on tiles that ARE tappable, so it is never
+       more than one action away (a tile with nothing clamped keeps it shown).
+       Four calls per screen instead of two. */
+    .brief-js .brief-entries li.is-clamped:not(.is-open) > p:has(> .entry-meta) {
+      display: none;
+    }
+    .brief-js .brief-entries li.is-clamped::after {
+      content: "展开全文"; display: block; margin-top: 6px;
+      font-size: 12px; color: var(--accent);
+    }
+    .brief-js .brief-entries li.is-clamped.is-open::after { content: "收起"; }
+    .brief-js .brief-entries li.is-clamped:focus-visible {
+      outline: 2px solid var(--accent); outline-offset: 2px;
+    }
+  }
+
   /* Brief-list (for briefs.html index) */
   .brief-list { list-style: none; padding: 0; margin: 8px 0; }
   .brief-list li {
@@ -294,6 +448,63 @@
     Not investment advice. Real positions shown. Point-in-time data. Past performance ≠ future results.
   </p>
 </footer>
+
+<script>
+  /* Phone-width brief entries: clamp the prose, tap to open (see the
+     `.brief-js` rules above). A page with no `.brief-entries` — every page on
+     this layout except a brief rendered from 2026-09-11 on — returns at once.
+     "Is this entry cut?" is measured (`scrollHeight > clientHeight` on the
+     clamped paragraphs), never inferred from its length, so a two-line reason
+     does not get a "展开全文" that opens nothing. */
+  (function () {
+    var items = document.querySelectorAll('article .brief-entries li');
+    if (!items.length) return;
+    var root = document.documentElement;
+    var narrow = window.matchMedia('(max-width: 600px)');
+    root.classList.add('brief-js');
+
+    function measure() {
+      items.forEach(function (li) {
+        if (li.classList.contains('is-open')) return;
+        var cut = narrow.matches && Array.prototype.some.call(
+          li.querySelectorAll(':scope > p:not(:first-child):not(:has(> .entry-meta))'),
+          function (p) { return p.scrollHeight > p.clientHeight + 1; });
+        li.classList.toggle('is-clamped', cut);
+        if (cut) {
+          li.setAttribute('role', 'button');
+          li.setAttribute('tabindex', '0');
+          li.setAttribute('aria-expanded', 'false');
+        } else {
+          li.removeAttribute('role');
+          li.removeAttribute('tabindex');
+          li.removeAttribute('aria-expanded');
+        }
+      });
+    }
+    function toggle(li) {
+      if (!li.classList.contains('is-clamped')) return;
+      var open = li.classList.toggle('is-open');
+      li.setAttribute('aria-expanded', open ? 'true' : 'false');
+    }
+    items.forEach(function (li) {
+      li.addEventListener('click', function (event) {
+        if (event.target.closest('a') || window.getSelection().toString()) return;
+        toggle(li);
+      });
+      li.addEventListener('keydown', function (event) {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault();
+          toggle(li);
+        }
+      });
+    });
+    measure();
+    if (narrow.addEventListener) narrow.addEventListener('change', measure);
+    document.querySelectorAll('article details').forEach(function (d) {
+      d.addEventListener('toggle', measure);
+    });
+  })();
+</script>
 
 </body>
 </html>

--- a/src/clawock/harness/brief_postflight.py
+++ b/src/clawock/harness/brief_postflight.py
@@ -82,12 +82,55 @@ BRIEF_READABILITY_TARGET_BYTES = 28_000
 BRIEF_READABILITY_EXTREME_BYTES = 40_000
 
 
+_LAYOUT_TAG = re.compile(r'</?(?:div|span|details|summary)\b[^>]*>')
+_TABLE_RULE = re.compile(r'\|?[\s:|-]+\|?')
+
+
+def reader_bytes(text):
+    """Bytes of what a reader reads: the words, not the layout around them.
+
+    The thresholds below are a reading-burden budget, but they used to be
+    compared with the file size. On 2026-09-11 the report moved from prose
+    tables to one card per subsection and one block per prose row
+    (`brief_render.card` / `entries`): the same words, and 4–5KB more file per
+    brief of `<div markdown="1">` wrappers, indentation and blank lines. Three
+    of the five briefs from 09-07 to 09-11 would have jumped from `advisory` to
+    `extreme` — a warning every morning about markup nobody sees.
+
+    Counted here: front matter, layout tags, table rules and pipes, list and
+    heading markers, `**`, and runs of whitespace all removed. Measured on those
+    same five briefs, this count under the new layout gives the same status as
+    the raw file size gave under the old one, on every day — so the 28KB/40KB
+    lines keep the meaning they were calibrated with.
+    """
+    if text.startswith('---\n'):
+        _, _, text = text[4:].partition('\n---\n')
+    kept = []
+    for line in _LAYOUT_TAG.sub('', text).splitlines():
+        line = line.strip()
+        if not line or _TABLE_RULE.fullmatch(line):
+            continue
+        line = re.sub(r'^(?:[-*]|\d+\.)\s+', '', line)
+        line = re.sub(r'^#{1,6}\s+', '', line)
+        line = line.replace('|', ' ').replace('**', '')
+        kept.append(re.sub(r'\s+', ' ', line).strip())
+    return len('\n'.join(kept).encode('utf-8'))
+
+
 def assess_brief_readability(path):
-    """Return structured size health without changing the authored brief."""
+    """Return structured size health without changing the authored brief.
+
+    `bytes` is the reader-visible count that decides `status` (see
+    `reader_bytes`) — it is what the dashboard shows beside the status and what
+    the warning quotes. `file_bytes` is the raw size, kept for anyone tracking
+    the artifact itself.
+    """
     try:
-        nbytes = Path(path).stat().st_size
-    except OSError:
-        nbytes = None
+        text = Path(path).read_text(encoding='utf-8')
+        file_bytes = len(text.encode('utf-8'))
+        nbytes = reader_bytes(text)
+    except (OSError, UnicodeDecodeError):
+        nbytes = file_bytes = None
 
     if nbytes is None:
         status = 'unavailable'
@@ -105,6 +148,7 @@ def assess_brief_readability(path):
     return {
         'status': status,
         'bytes': nbytes,
+        'file_bytes': file_bytes,
         'target_bytes': BRIEF_READABILITY_TARGET_BYTES,
         'extreme_bytes': BRIEF_READABILITY_EXTREME_BYTES,
         'over_by_bytes': over_by,
@@ -117,19 +161,30 @@ def readability_issues(readability):
         return []
     return [
         'pre-open.md 极端超长 '
-        f'{readability.get("bytes")} bytes（≥40KB，完整保留但下次生成须按分段预算收敛）'
+        f'{readability.get("bytes")} bytes 正文（≥40KB，版式标记不计；完整保留但下次生成须按分段预算收敛）'
     ]
 
 
 def _section_markers(text):
-    """Return real section-marker lines, not incidental aliases in prose."""
-    return [
-        line.strip()
-        for line in text.splitlines()
+    """Return real section markers, not incidental aliases in prose.
+
+    A heading or `▎` line is a marker as a whole. A bold marker is only its bold
+    text: since 2026-09-11 every prose row in the report is laid out as
+    `  **理由**　<the reasoning>` (`brief_render.entries`), and counting that
+    whole line let the reasoning itself satisfy a required section — the
+    09-11 rationale for 07226 contains "Judge 段明确要求…", which is an alias
+    for 今日动作. The label is the name; the sentence after it is prose.
+    """
+    markers = []
+    for line in text.splitlines():
         if (re.match(r'^\s{0,3}#{1,6}\s+\S', line)
-            or re.match(r'^\s{0,3}\*\*\S', line)
-            or re.match(r'^\s{0,3}▎\s*\S', line))
-    ]
+                or re.match(r'^\s{0,3}▎\s*\S', line)):
+            markers.append(line.strip())
+            continue
+        bold = re.match(r'^\s{0,3}\*\*(\S.*?)\*\*', line)
+        if bold:
+            markers.append(bold.group(1).strip())
+    return markers
 
 
 def _marker_has_alias(marker, alias):

--- a/src/clawock/harness/brief_render.py
+++ b/src/clawock/harness/brief_render.py
@@ -131,6 +131,58 @@ def table(headers, rows):
     return "\n".join(out)
 
 
+def entries(items):
+    """Rows whose content is prose, laid out as one block per row.
+
+    Tables are for numbers. Five of this report's sixteen tables used to carry a
+    prose column — a decision's rationale, a falsifier, a peer read — and on
+    2026-09-11 the longest such cell was 668 characters. On the page that made
+    every row 300–400px tall with the short columns floating in whitespace, and
+    under the phone stylesheet's `nowrap` the same cell became one line: a
+    4,880px table inside a 328px screen. The same wall is what GitHub's own
+    `.md` view and a plain-text reader got, so this is a structure fix, not a
+    stylesheet one.
+
+    Each item is `{"title": str, "meta": [str], "fields": [(label, str)]}`:
+    the title is the row's identity plus its short facts, `meta` is the
+    secondary enums (one dim line), `fields` are the labelled prose. Markdown
+    only, plus the one `entry-meta` span the stylesheet needs to set the enums
+    apart — GitHub strips the class and keeps the text, same contract as
+    `verdict_badge`. Wrapped in `markdown="1"` for the reason the appendix is:
+    kramdown does not parse markdown inside a block HTML element otherwise.
+    """
+    # Every value goes through `_cell`, table or not. GFM treats a pipe in a
+    # plain paragraph line as a table row too: the first render of this
+    # function turned three news headlines ("HK Stock Market Alert | MINIMAX…")
+    # into three one-row tables in the middle of 社交舆情. A plan rationale can
+    # carry a pipe as well — it is not judgment-gated.
+    blocks = []
+    for item in items:
+        lines = [f"- {_cell(item['title'])}"]
+        meta = [_cell(m) for m in (item.get("meta") or []) if m and m != MISSING]
+        if meta:
+            lines += ["", f'  <span class="entry-meta">{" · ".join(meta)}</span>']
+        for label, value in item.get("fields") or []:
+            lines += ["", f"  **{label}**　{_cell(value)}"]
+        blocks.append("\n".join(lines))
+    if not blocks:
+        return "无。"
+    return "\n".join(['<div class="brief-entries" markdown="1">', "",
+                      "\n\n".join(blocks), "", "</div>"])
+
+
+def card(section):
+    """One subsection as one card on the page.
+
+    A `div` the stylesheet can draw, not a new heading level: the `###`
+    inside it stays the section's name, which is what postflight's
+    `REQUIRED_MARKDOWN_SECTIONS` and every other reader key on. GitHub strips
+    the class and shows the section as it always did.
+    """
+    return "\n".join(['<div class="brief-card" markdown="1">', "", section.strip(), "",
+                      "</div>"])
+
+
 def _cell(value):
     """One table cell, escaped so its content cannot become layout.
 
@@ -141,6 +193,22 @@ def _cell(value):
     failure this module exists to end.
     """
     return str(value).replace("|", "\\|").replace("\n", " ")
+
+
+def _inline(value):
+    """Untrusted feed text on its way into an entry's prose line.
+
+    News headlines are the one input here written by an outside party: they
+    come straight out of the sentiment feed. In a table they only needed their
+    pipes escaped; as running text they can also open emphasis, a link, or —
+    with a `<` — raw HTML that kramdown passes through to the page. Escape what
+    inline markdown would act on, so a headline can only ever be words. (Pipes
+    are `entries`' job: it runs every value through `_cell`.)
+    """
+    out = str(value).replace("\n", " ")
+    for char in ("\\", "`", "*", "_", "[", "]"):
+        out = out.replace(char, "\\" + char)
+    return out.replace("<", "&lt;")
 
 
 def _holdings(context, leg):
@@ -486,10 +554,14 @@ def tier1_section(context, judgment):
             if signal.get("dist_ma200_pct") is not None else None,
             f"⚠️{signal.get('status')}" if stale else None,
         ])) or MISSING
-        rows.append([ticker, market, text(row.get("fundamentals")),
-                     text(row.get("sentiment_read")), text(row.get("cross_market"))])
-    return "### 分析师四格\n\n" + table(
-        ["票", "Market（harness 计算）", "Fundamentals", "Sentiment", "Cross-Market"], rows)
+        rows.append({
+            "title": f"**{ticker}**",
+            "meta": [market],
+            "fields": [("Fundamentals", text(row.get("fundamentals"))),
+                       ("Sentiment", text(row.get("sentiment_read"))),
+                       ("Cross-Market", text(row.get("cross_market")))],
+        })
+    return "### 分析师四格\n\n" + entries(rows)
 
 
 def tier2_section(judgment):
@@ -534,16 +606,15 @@ def judge_section(plan):
     rows = []
     for decision in (plan.get("decisions") or []):
         debate = decision.get("debate") or {}
-        rows.append([
-            text(decision.get("ticker")),
-            f"**{text(decision.get('action'))}**",
-            " + ".join(debate.get("frames") or []) or MISSING,
-            text(decision.get("strategy_id")),
-            text(decision.get("driven_by")),
-            text(decision.get("rationale")),
-        ])
-    return f"### {PAGE_ACTION_HEADING}\n\n" + table(
-        ["Ticker", "Action", "Frame", "Strategy", "driven_by", "理由"], rows)
+        rows.append({
+            "title": (f"**{text(decision.get('ticker'))}** · "
+                      f"**{text(decision.get('action'))}**"),
+            "meta": [" + ".join(debate.get("frames") or []) or MISSING,
+                     text(decision.get("strategy_id")),
+                     text(decision.get("driven_by"))],
+            "fields": [("理由", text(decision.get("rationale")))],
+        })
+    return f"### {PAGE_ACTION_HEADING}\n\n" + entries(rows)
 
 
 def sector_section(sector_scan, judgment):
@@ -587,17 +658,15 @@ def peer_section(context, judgment):
         gap = None
         if best and best.get("pct_1d") is not None and row.get("self_pct_1d") is not None:
             gap = row["self_pct_1d"] - best["pct_1d"]
-        rows.append([
-            ticker,
-            text(row.get("theme")),
-            pct(row.get("self_pct_1d")),
-            f"{text(best.get('ticker'))} {text(best.get('name'))} {pct(best.get('pct_1d'))}"
-            if best else MISSING,
-            f"{gap:+.2f}pp" if gap is not None else MISSING,
-            text((judgments.get(ticker) or {}).get("peer_read")),
-        ])
-    return "### 同行扫描\n\n" + table(
-        ["持仓", "主题", "今日 self", "最强同行", "差距", "判断"], rows)
+        strongest = (f"{text(best.get('ticker'))} {text(best.get('name'))} "
+                     f"{pct(best.get('pct_1d'))}") if best else MISSING
+        rows.append({
+            "title": (f"**{ticker}** · 今日 {pct(row.get('self_pct_1d'))} · "
+                      f"差距 {f'{gap:+.2f}pp' if gap is not None else MISSING}"),
+            "meta": [text(row.get("theme")), f"最强同行 {strongest}"],
+            "fields": [("判断", text((judgments.get(ticker) or {}).get("peer_read")))],
+        })
+    return "### 同行扫描\n\n" + entries(rows)
 
 
 def macro_section(context, judgment):
@@ -634,19 +703,19 @@ def sentiment_section(context, judgment):
             str((item.get("title") or item.get("headline") or "")
                 if isinstance(item, dict) else item)[:36]
             for item in (row.get("news_top") or [])[:3])
-        rows.append([
-            ticker,
-            (f"{row['reddit_mentions_7d']} mentions"
-             if row.get("reddit_mentions_7d") is not None else MISSING),
-            keywords or MISSING,
-            pct((row.get("recent_move") or {}).get("pct_5d"))
-            if isinstance(row.get("recent_move"), dict) else MISSING,
-            text((judgments.get(ticker) or {}).get("sentiment_read")),
-        ])
+        mentions = (f"Reddit 7d {row['reddit_mentions_7d']} mentions"
+                    if row.get("reddit_mentions_7d") is not None else MISSING)
+        move = (pct((row.get("recent_move") or {}).get("pct_5d"))
+                if isinstance(row.get("recent_move"), dict) else MISSING)
+        rows.append({
+            "title": f"**{ticker}** · 近 5 日 {move}",
+            "meta": [mentions],
+            "fields": [("新闻", _inline(keywords) if keywords else MISSING),
+                       ("信号判断", text((judgments.get(ticker) or {}).get("sentiment_read")))],
+        })
     if not rows:
         return ""
-    return "### 社交舆情\n\n" + table(
-        ["票", "Reddit 7d", "新闻关键词", "近 5 日", "信号判断"], rows)
+    return "### 社交舆情\n\n" + entries(rows)
 
 
 def influencer_section(context):
@@ -686,16 +755,14 @@ def confidence_section(judgment, plan):
         ticker = str(decision.get("ticker"))
         row = judgments.get(ticker) or {}
         confidence = decision.get("confidence")
-        rows.append([
-            ticker,
-            text(decision.get("action")),
-            pct((confidence or 0) * 100, digits=0, sign=False),
-            verdict_badge(row.get("verdict")),
-            text(row.get("rationale")),
-            text(row.get("falsifier")),
-        ])
-    return "### 信心与判定\n\n" + table(
-        ["Ticker", "Action", "Confidence", "Verdict", "理由", "证伪条件"], rows)
+        rows.append({
+            "title": (f"**{ticker}** · {text(decision.get('action'))} · "
+                      f"信心 {pct((confidence or 0) * 100, digits=0, sign=False)} · "
+                      f"{verdict_badge(row.get('verdict'))}"),
+            "fields": [("理由", text(row.get("rationale"))),
+                       ("证伪条件", text(row.get("falsifier")))],
+        })
+    return "### 信心与判定\n\n" + entries(rows)
 
 
 def _interval(bounds):
@@ -832,9 +899,13 @@ def render_brief(context, judgment, plan, *, date=None, sector_scan=None):
         "",
         f"# {title}",
         "",
+        '<div class="brief-card brief-lede" markdown="1">',
+        "",
         text(judgment.get("portfolio_assessment")),
         "",
         f"**反方**：{text(judgment.get('portfolio_counterargument'))}",
+        "",
+        "</div>",
         "",
     ]
     for heading, sections in parts:
@@ -843,7 +914,7 @@ def render_brief(context, judgment, plan, *, date=None, sector_scan=None):
             continue
         blocks += [f"## {heading}", ""]
         for section in rendered:
-            blocks += [section, ""]
+            blocks += [card(section), ""]
 
     # `<details>` rather than a fifth part: this is the material a reader consults
     # when a number above surprises them, not material they read every morning.
@@ -862,7 +933,7 @@ def render_brief(context, judgment, plan, *, date=None, sector_scan=None):
             "",
         ]
         for section in kept:
-            blocks += [section, ""]
+            blocks += [card(section), ""]
         blocks += ["</details>", ""]
 
     body = "\n".join(block for block in blocks if block is not None)

--- a/tests/test_brief_readability.py
+++ b/tests/test_brief_readability.py
@@ -34,6 +34,7 @@ def test_modest_overage_is_separate_advisory_not_validation_warning(tmp_path):
     assert readability == {
         'status': 'advisory',
         'bytes': size,
+        'file_bytes': size,
         'target_bytes': postflight.BRIEF_READABILITY_TARGET_BYTES,
         'extreme_bytes': postflight.BRIEF_READABILITY_EXTREME_BYTES,
         'over_by_bytes': 1_234,

--- a/tests/test_brief_render.py
+++ b/tests/test_brief_render.py
@@ -474,3 +474,166 @@ def test_a_sweep_with_no_sectors_counts_as_missing(tmp_path):
     issues, _ = render.render_from_workspace(ws, "2026-08-31")
 
     assert render.SECTOR_SCAN_MISSING in issues
+
+
+# ── tables for numbers, entries for prose, one card per subsection ───────────
+#    (2026-09-11: "在 dashboard 里看 brief 也很丑，也没什么卡片区块感，数据排版也很杂乱")
+
+PROSE_SECTIONS = ("今日动作", "信心与判定", "分析师四格", "同行扫描", "社交舆情")
+
+
+def _section(body, heading):
+    start = body.index(f"### {heading}")
+    end = body.find("\n### ", start + 1)
+    return body[start:end if end != -1 else len(body)]
+
+
+def test_prose_is_never_laid_out_as_a_table_cell():
+    """Five sections used to put prose in a column — up to 668 characters in one
+    cell on 2026-09-11, a 4,880px table on a phone. They are entries now."""
+    long_reason = "硬止损破位且纪律债逐日加码，" * 30
+    plan = {**PLAN, "decisions": [{**PLAN["decisions"][0], "rationale": long_reason}]}
+    body = render.render_brief(CONTEXT, _judgment(), plan, date="2026-08-31")
+
+    for heading in PROSE_SECTIONS:
+        section = _section(body, heading)
+        assert '<div class="brief-entries" markdown="1">' in section, heading
+        assert not any(line.startswith("|") for line in section.splitlines()), heading
+    assert long_reason.strip() in _section(body, "今日动作")
+
+
+def test_a_pipe_inside_an_entry_is_escaped_or_it_becomes_a_table():
+    """GFM reads a pipe in a PLAIN paragraph line as a table row too. The first
+    render of the entries layout turned three news headlines into three one-row
+    tables in the middle of 社交舆情 — and the column-consistency check above
+    could not see it, because those lines do not start with a pipe."""
+    body = render.render_brief(CONTEXT, _judgment(), PLAN, date="2026-08-31")
+
+    for heading in PROSE_SECTIONS:
+        for line in _section(body, heading).splitlines():
+            unescaped = line.replace("\\|", "")
+            assert "|" not in unescaped, f"{heading}: {line}"
+    assert "Southbound buys" in body and "敞口保留" in body
+
+
+def test_a_feed_headline_cannot_open_markup_in_running_text():
+    """Headlines are the one unvalidated input: in a cell they only needed their
+    pipes escaped, as running text they could open a link or raw HTML."""
+    context = {**CONTEXT, "sentiment": {"tickers": [{"ticker": "07226", "news_top": [
+        {"title": "<b onclick=x> [x](e) *boom*"}]}]}}   # ≤36 chars: the section truncates
+    section = _section(render.render_brief(context, _judgment(), PLAN, date="2026-08-31"),
+                       "社交舆情")
+
+    assert "<b " not in section and "&lt;b " in section
+    assert "\\[x\\]" in section and "\\*boom\\*" in section
+
+
+def test_every_card_and_entries_block_says_markdown_1():
+    """Same load-bearing attribute as the appendix: without it kramdown ships the
+    whole card's contents as literal markdown."""
+    body = render.render_brief(CONTEXT, _judgment(), PLAN, date="2026-08-31")
+    lines = body.splitlines()
+
+    opened = [i for i, line in enumerate(lines)
+              if line.startswith('<div class="brief-card') or
+              line.startswith('<div class="brief-entries')]
+    assert len(opened) >= 10
+    for i in opened:
+        assert 'markdown="1"' in lines[i], lines[i]
+        assert lines[i + 1] == "", "GitHub renders markdown in an HTML block only after a blank line"
+    assert body.count("<div ") == body.count("</div>")
+
+
+def test_every_subsection_is_a_card_and_keeps_its_heading():
+    """The card is a wrapper, not a new heading level: postflight and every other
+    reader key on the `###` names, so a card must never replace one."""
+    body = render.render_brief(CONTEXT, _judgment(), PLAN, date="2026-08-31")
+    main = body.split('<details class="brief-appendix"')[0]
+
+    headings = [line for line in main.splitlines() if line.startswith("### ")]
+    cards = main.count('<div class="brief-card"')
+    assert headings and cards == len(headings), (cards, len(headings))
+    assert '<div class="brief-card brief-lede" markdown="1">' in main
+
+
+def test_postflight_still_finds_every_required_section(tmp_path):
+    from clawock.harness import brief_postflight
+
+    path = tmp_path / "2026-08-31-pre-open.md"
+    path.write_text(render.render_brief(CONTEXT, _judgment(), PLAN, date="2026-08-31"))
+
+    missing = [issue for issue in brief_postflight.validate_markdown(path, CONTEXT)
+               if "缺段标记" in issue]
+    assert missing == []
+
+
+def test_the_stylesheet_draws_the_cards_it_is_given():
+    """Classes are only worth emitting if the layout for memory/*.md defines them,
+    and the card look must stay scoped: the weekly reviews, FAQ and evidence
+    pages share this layout and were designed as a single panel."""
+    layout = (ROOT / "site" / "_layouts" / "default.html").read_text(encoding="utf-8")
+
+    for selector in (".brief-card {", ".brief-entries > ul", ".entry-meta",
+                     "article:has(.brief-card) {"):
+        assert selector in layout, selector
+    # Theme-following: the card's lit edge and shadow are tokens with a value in
+    # BOTH theme blocks, for the #1272 reason.
+    assert layout.count("--card-edge:") == 2 and layout.count("--card-shadow:") == 2
+    assert "box-shadow: inset 0 1px 0 var(--card-edge), var(--card-shadow)" in layout
+
+
+def test_the_phone_clamp_cannot_hide_text_without_a_script():
+    """The two-line clamp is keyed on `.brief-js`, which only the layout's own
+    script sets — with no script there is no clamp, so no text becomes
+    unreachable. The script measures before it offers "展开全文"."""
+    layout = (ROOT / "site" / "_layouts" / "default.html").read_text(encoding="utf-8")
+
+    clamp_rules = [line for line in layout.splitlines() if "line-clamp: 2" in line]
+    assert clamp_rules
+    block = layout[layout.index(".brief-js .brief-entries li > p"):]
+    assert block.index(".brief-js") == 0
+    assert "root.classList.add('brief-js')" in layout
+    assert "p.scrollHeight > p.clientHeight" in layout
+    assert ":not(:has(> .entry-meta))" in layout, "the enum line must never clamp"
+    # It may be tucked away — but only on a tile the script made tappable, so it
+    # is never more than one action from the reader.
+    hidden = [line for line in layout.splitlines()
+              if "p:has(> .entry-meta)" in line and "not(:has" not in line]
+    assert hidden and all("li.is-clamped:not(.is-open)" in line for line in hidden)
+
+
+def test_reasoning_that_names_a_section_cannot_stand_in_for_it(tmp_path):
+    """Entry field lines start with a bold label. The reasoning after the label
+    must not satisfy a required section: the 09-11 rationale for 07226 says
+    "Judge 段明确要求…", and 'Judge' is an alias for 今日动作."""
+    from clawock.harness import brief_postflight
+
+    plan = {**PLAN, "decisions": [{**PLAN["decisions"][0],
+                                   "rationale": "Judge 段明确要求三选一关闭。"}]}
+    body = render.render_brief(CONTEXT, _judgment(), plan, date="2026-08-31")
+    without_heading = body.replace(f"### {render.PAGE_ACTION_HEADING}", "### 别的名字")
+    path = tmp_path / "x-pre-open.md"
+    path.write_text(without_heading)
+
+    issues = brief_postflight.validate_markdown(path, CONTEXT)
+    assert 'pre-open.md 缺段标记 "今日动作"' in issues
+
+
+def test_size_health_counts_words_not_layout(tmp_path):
+    """The reading-burden budget must not move when only the markup does."""
+    from clawock.harness import brief_postflight
+
+    words = "硬止损破位且纪律债逐日加码。" * 40
+    plain = tmp_path / "plain.md"
+    plain.write_text(f"### 今日动作\n\n{words}\n")
+    carded = tmp_path / "carded.md"
+    carded.write_text(
+        '<div class="brief-card" markdown="1">\n\n### 今日动作\n\n'
+        '<div class="brief-entries" markdown="1">\n\n'
+        f'- **07226** · **cut**\n\n  <span class="entry-meta">risk_rule</span>\n\n'
+        f"  {words}\n\n</div>\n\n</div>\n")
+
+    a = brief_postflight.assess_brief_readability(plain)
+    b = brief_postflight.assess_brief_readability(carded)
+    assert b["file_bytes"] > a["file_bytes"] + 100          # the markup is real …
+    assert abs(b["bytes"] - a["bytes"]) < 60                 # … and not counted


### PR DESCRIPTION
kcn：「在 dashboard 里看 brief 也很丑，也没什么卡片区块感，数据排版也很杂乱」。

## 改前量出来的（2026-09-11 真实简报，本地按 Pages 同一套 kramdown + layout 渲染）

| | 改前 | 改后 |
|---|---|---|
| 卡片 | 0 | 22 |
| 表格 | 16（5 张带散文列） | 11（只剩数字表） |
| 最长表格单元格 | 668 字符 | 126 |
| 手机上最宽表格溢出 | **4,880px**（「理由」整列在屏幕外） | 138px |
| 手机上「今日动作」卡高 | —（横着看不到） | 1,279px（9 条决策，理由夹两行） |

## 做了什么

**结构（`brief_render`，三个阅读面都受益）**
- `entries()`：五个散文段（今日动作 / 信心与判定 / 分析师四格 / 同行扫描 / 社交舆情）一行一块：标题 = 票 + 短事实，一行灰色枚举，带标签的正文。
- `card()`：每个 `###` 包 `<div class="brief-card" markdown="1">`，与折叠附录同一机制；标题不变。
- 每个 entry 值过 `_cell` —— GFM 把普通段落里的竖线也读成表格行（第一版把三条新闻标题渲染成了三张一行表）；新闻标题再过 `_inline` 转义强调/链接/`<`。

**版式（`site/_layouts/default.html`，只作用于 `article:has(.brief-card)`）**
- 卡片落在页面底色上，节标题在卡之间，action 胶囊；新 token `--card-edge` / `--card-shadow` 两个主题各一份。
- 手机：表格单元格换行；entry 散文夹两行、点开看全文、枚举行展开时出现。夹行只在布局脚本设了 `.brief-js` 时生效（没脚本就不夹、文字不丢），「展开全文」只画在实测被截断的条目上，键盘可操作，附录展开时重测。
- 周复盘、FAQ、evidence 页、以及没有卡的旧简报：维持原样。

**这次改动自己带出来的两个问题，一并修掉**
1. `brief_postflight` 的尺寸健康检查原来量文件字节：同样的字多出 4–5KB 标记，5 份里 3 份会从 advisory 跳到 extreme，每天多一条「极端超长」。改量读者看得到的字（`reader_bytes`）；五份实测新旧状态逐日一致。
2. `_section_markers` 把「`**` 开头的整行」当段标记，新字段行 `**理由**　<正文>` 让正文能冒充必需段（09-11 的理由里就有 "Judge 段…"）。粗体标记只取粗体里的字。

**重渲染 09-07～09-11 五份简报**：先用旧渲染器从盘上输入重出，与已提交文件逐字节一致，证明输入没变 —— 新文件只有版式变化。五份都过 postflight 必需段检查。

## 验证

新增 10 条测试，两条关键的验过会红（去掉 entry 竖线转义 / 去掉卡片 `markdown="1"`）。本地全量 3650 passed。

https://claude.ai/code/session_0193DYZhJVWyRDinTLzPnAME