### PR TITLE
cron/dashboard 巡检：发布器假警告、持仓卡 undefined、简报超长被写成「可能有误」

### DIFF
--- a/ops/host/cron_health_check.py
+++ b/ops/host/cron_health_check.py
@@ -461,6 +461,38 @@ def heartbeat_coverage(job_name, slots, tz_name, now, ledger, day=None):
 # it is "nothing has moved in the book for three hours during a session", which
 # on a trading day means the 0,20,40 crontab entry stopped running.
 PUBLISHER_STALE_HOURS = 3
+# Resolution of the session-time count below. Five minutes against a three-hour
+# threshold is noise; it keeps a three-day lookback to under a thousand probes.
+_SESSION_PROBE = timedelta(minutes=5)
+_SESSION_LOOKBACK = timedelta(days=4)
+
+
+def _session_hours_between(start, end):
+    """Hours between `start` and `end` during which HK or US was trading.
+
+    "During a session" was the threshold's meaning all along, but the check
+    measured wall-clock age: from the last HK-close publish (~16:40 HKT) to the
+    US open (21:30 HKT) nothing moves, the publisher correctly pushes nothing,
+    and by 21:3x the generation is ~4.9h old. The workflow is scheduled for
+    17:17 HKT, when that gap is well under the threshold, but GitHub delivers it
+    ~4h late — so on 2026-09-11 it landed at 21:32, two minutes before the US
+    open publish, and called a healthy publisher dead.
+
+    Returns None when the calendar is unavailable, so the caller keeps judging
+    wall-clock age — the same fail-open rule as the trading-day check.
+    """
+    try:
+        from clawock import sessions as _tc
+    except Exception:
+        return None
+    start = max(start, end - _SESSION_LOOKBACK)
+    probes = 0
+    t = start + _SESSION_PROBE / 2
+    while t < end:
+        if _tc.in_session('hk', t) or _tc.in_session('us', t):
+            probes += 1
+        t += _SESSION_PROBE
+    return round(probes * _SESSION_PROBE.total_seconds() / 3600, 1)
 
 
 def check_scheduled_publisher(now=None, path=None):
@@ -495,28 +527,25 @@ def check_scheduled_publisher(now=None, path=None):
         return {'state': 'failed', 'detail': f'generation stamp unreadable: {e}',
                 'age_hours': None}
     age_hours = round((now - published).total_seconds() / 3600, 1)
-    local = now.astimezone(HKT)
-    # A weekend or a double holiday has no session to publish into, so silence
-    # is correct there and must not be reported as a stalled publisher.
-    # Same local, fail-open import as _market_closed_today: an unavailable
-    # calendar must not turn this into a red, so it falls through to judging.
-    try:
-        from clawock import sessions as _tc
-        trading = any(_tc.is_trading_day(m, local.date()) for m in ('hk', 'us'))
-    except Exception:
-        trading = True
-    if not trading:
-        return {'state': 'ok',
-                'detail': f'last generation {age_hours}h old · 非交易日不判',
-                'age_hours': age_hours}
-    if age_hours > PUBLISHER_STALE_HOURS:
+    # Only session time counts: a weekend, a holiday, lunch and the gap between
+    # the HK close and the US open have nothing to publish, so silence there is
+    # correct. This replaced a "非交易日不判" short-circuit keyed on today's HK
+    # date, which also hid a publisher that died on Friday — Saturday 00:00-04:00
+    # HKT is still Friday's US session.
+    session_hours = _session_hours_between(published, now)
+    judged = age_hours if session_hours is None else session_hours
+    if judged > PUBLISHER_STALE_HOURS:
+        within = '' if session_hours is None else f'，其中盘中 {session_hours}h'
         return {'state': 'stale',
-                'detail': (f'已发布的那一代已 {age_hours}h 未更新 '
+                'detail': (f'已发布的那一代已 {age_hours}h 未更新{within} '
                            f'(> {PUBLISHER_STALE_HOURS}h) — 0,20,40 的 '
                            f'publish_dashboard.sh 大概率没在跑'),
-                'age_hours': age_hours}
-    return {'state': 'ok', 'detail': f'last generation {age_hours}h old',
-            'age_hours': age_hours}
+                'age_hours': age_hours, 'session_hours': session_hours}
+    detail = f'last generation {age_hours}h old'
+    if session_hours is not None and session_hours < age_hours:
+        detail += f' · 盘中 {session_hours}h（休市/收盘后没有要发的东西）'
+    return {'state': 'ok', 'detail': detail,
+            'age_hours': age_hours, 'session_hours': session_hours}
 
 
 def check_dashboard_build():

--- a/site/assets/js/dashboard.render.js
+++ b/site/assets/js/dashboard.render.js
@@ -2413,7 +2413,12 @@
     if (e.stop) risk.push(`<div class="bd-note neg">止损盯防 · ${escapeHtml(stripEmoji(e.stop.detail || e.stop.action || ""))}</div>`);
     if (e.be) {
       risk.push(kv("回本需", "+" + e.be.breakeven_need_pct + "%", "neg"));
-      if (e.be.leveraged) risk.push(kv("横盘 decay", "≈" + e.be.chop_drag_pct_per_month + "%/月"));
+      // A 2x whose underlying has no volatility yet (SPCH → SPCX, listed too
+      // recently) carries no drag figure — the Risk tab's copy of this row
+      // already skips it; printing it here read "≈undefined%/月".
+      if (e.be.leveraged && e.be.chop_drag_pct_per_month != null) {
+        risk.push(kv("横盘 decay", "≈" + e.be.chop_drag_pct_per_month + "%/月"));
+      }
     }
     if (e.conv) risk.push(kv("仓位 × 信心",
       `${e.conv.weight_pct}% · conf ${Math.round((e.conv.avg_confidence || 0) * 100)}%`,

--- a/src/clawock/publish/cron_schedule.py
+++ b/src/clawock/publish/cron_schedule.py
@@ -103,6 +103,22 @@ def _narrate_degraded(record):
     # `escalating_count` is the exact field `_advisory_only` reads — a nonzero
     # count is the same signal that made the ledger call this slot degraded,
     # not a re-judgment of it.
+    # An extreme-length brief is promoted to one of those escalating issues on
+    # purpose (`brief_postflight.readability_issues`), but it is a length
+    # problem, not a correctness one. On 2026-09-11 it was the only one, and the
+    # card still said「报告已投递但可能有误」— a claim about the content that
+    # nothing had made. Name it, and keep the generic line for whatever is left.
+    readability = postflight.get('readability') or {}
+    if escalating and readability.get('status') == 'extreme':
+        length = (f'简报正文 {readability.get("bytes", 0) / 1000:.1f}KB，超过 '
+                  f'{readability.get("extreme_bytes", 0) / 1000:.0f}KB 极端线'
+                  '（全文已送达，下次生成须按分段预算收敛）')
+        others = escalating - 1
+        if others <= 0:
+            return _note(NEEDS_ACTION, length + '；内容校验没有别的实质问题')
+        return _note(NEEDS_ACTION,
+                    f'{length}；另有 {others} 条不是仅供参考的内容问题'
+                    '——报告已投递但可能有误，查 workflow-outcomes.json 这一槽的 stages')
     if escalating:
         return _note(NEEDS_ACTION,
                     f'内容校验有 {issues} 条问题，其中 {escalating} 条不是仅供参考的'

--- a/tests/dashboard_tab_runtime.spec.js
+++ b/tests/dashboard_tab_runtime.spec.js
@@ -1209,6 +1209,45 @@ async function testAddSideCardExplainsWhyThereIsNoAdd(browser, base) {
   await page.close();
 }
 
+async function testALeveragedRowWithoutVolatilityPrintsNoUndefined(browser, base) {
+  // 2026-09-11 live, Holdings tab: SPCH is a 2x whose underlying (SPCX) has no
+  // volatility yet, so `compute_breakeven_math` leaves its drag figures out —
+  // and the book card printed「横盘 decay ≈undefined%/月」. The Risk tab's copy
+  // of the same row already skipped it. Every holding gets such a row here so
+  // the case does not depend on which tickers the CI build happens to carry.
+  const context = await browser.newContext({ viewport: { width: 1280, height: 900 } });
+  const page = await context.newPage();
+  await stubLiveOrigin(page, {
+    patch: (name, json) => {
+      if (name !== "dashboard.json") return null;
+      const holdings = [...((json.holdings || {}).us || []), ...((json.holdings || {}).hk || [])];
+      json.breakeven_math = {
+        rows: holdings.map(h => ({ ticker: h.ticker, pnl_pct: -18.8,
+                                    breakeven_need_pct: 23.2, leveraged: true })),
+        note: "",
+      };
+      return json;
+    },
+  });
+  const state = observe(page);
+  await page.goto(base, { waitUntil: "networkidle" });
+  await waitForData(page);
+  for (const tab of ["drill", "risk"]) {
+    await page.click(`.tab-btn[data-tab="${tab}"]`);
+    await waitForTab(page, tab);
+  }
+  const book = await page.locator("#book-card").textContent();
+  assert.match(book, /回本需\s*\+23\.2%/, "the breakeven row itself must still render");
+  const pageText = await page.evaluate(() =>
+    [...document.querySelectorAll(".panel")].map(panel => panel.textContent).join("\n"));
+  assert.doesNotMatch(pageText, /(?:undefined|NaN)\s*%/,
+    "a missing number was formatted as text instead of being left out");
+
+  assert.deepEqual(state.failures, []);
+  assert.deepEqual(state.errors, []);
+  await page.close();
+}
+
 async function testAPanelSaysWhenItsDataDidNotLoad(browser, base) {
   // A detail tab needs dashboard.json (191 KB, normally from the data branch)
   // before it can paint. When that request failed the only trace was
@@ -2041,6 +2080,7 @@ async function main() {
     await testTheDebateTrailIsAListOfCasesNotAWallOfText(browser, base);
     await testThePlanTimelineClampsItsRationales(browser, base);
     await testAddSideCardExplainsWhyThereIsNoAdd(browser, base);
+    await testALeveragedRowWithoutVolatilityPrintsNoUndefined(browser, base);
     await testAPanelSaysWhenItsDataDidNotLoad(browser, base);
     await testCronRailAccountsForEverySlotWithoutASecondVerdict(browser, base);
     await testCronNeedsActionMergesIntoTheOneTodoListButWatchDoesNot(browser, base);

--- a/tests/test_cron_health_check.py
+++ b/tests/test_cron_health_check.py
@@ -68,14 +68,45 @@ def _generation(tmp_path, published_at):
 
 
 def test_a_frozen_generation_on_a_trading_day_is_reported():
-    # 2026-08-05 is a Wednesday and a session in both markets.
-    now = datetime(2026, 8, 5, 16, 0, tzinfo=timezone.utc)
+    # 2026-08-05 is a Wednesday and a session in both markets. 15:30 HKT, last
+    # publish 10:30 HKT: 1.5h of morning + 2.5h of afternoon session went by
+    # with nothing published — the lunch break is not counted.
+    now = datetime(2026, 8, 5, 7, 30, tzinfo=timezone.utc)
     import tempfile
     with tempfile.TemporaryDirectory() as d:
-        stale = _generation(Path(d), now - timedelta(hours=4))
+        stale = _generation(Path(d), now - timedelta(hours=5))
         result = cron_health_check.check_scheduled_publisher(now=now, path=stale)
     assert result["state"] == "stale"
-    assert result["age_hours"] == 4.0
+    assert result["age_hours"] == 5.0
+    assert result["session_hours"] == 4.0
+
+
+def test_the_gap_between_hk_close_and_us_open_is_not_a_dead_publisher():
+    # 2026-09-11 (Fri), the run that went red: the last publish was the HK
+    # close at 16:40 HKT, the US open publish lands at 21:34, and GitHub
+    # delivered this workflow (scheduled 17:17 HKT) at 21:32. Nothing traded in
+    # between, so there was nothing to publish — 4.9h old, 0.0h of it in session.
+    now = datetime(2026, 9, 11, 13, 32, 58, tzinfo=timezone.utc)
+    import tempfile
+    with tempfile.TemporaryDirectory() as d:
+        quiet = _generation(Path(d), datetime(2026, 9, 11, 8, 40, tzinfo=timezone.utc))
+        result = cron_health_check.check_scheduled_publisher(now=now, path=quiet)
+    assert result["state"] == "ok", result
+    assert result["age_hours"] == 4.9
+    assert result["session_hours"] < 0.5  # the US open was three minutes old
+
+
+def test_a_publisher_dead_since_the_close_is_caught_once_the_next_session_runs():
+    # Same 16:40 publish, but nothing after it: by 01:00 HKT the US session has
+    # been open 3.5h with the site still frozen. That is already Saturday in
+    # Hong Kong, which the old "非交易日不判" short-circuit waved through.
+    now = datetime(2026, 9, 11, 17, 0, tzinfo=timezone.utc)
+    import tempfile
+    with tempfile.TemporaryDirectory() as d:
+        stale = _generation(Path(d), datetime(2026, 9, 11, 8, 40, tzinfo=timezone.utc))
+        result = cron_health_check.check_scheduled_publisher(now=now, path=stale)
+    assert result["state"] == "stale"
+    assert result["session_hours"] == 3.5
 
 
 def test_a_quiet_tick_is_not_a_dead_publisher():
@@ -222,7 +253,8 @@ def test_a_closed_weekend_is_silence_by_design():
         stale = _generation(Path(d), now - timedelta(hours=30))
         result = cron_health_check.check_scheduled_publisher(now=now, path=stale)
     assert result["state"] == "ok"
-    assert "非交易日" in result["detail"]
+    assert result["session_hours"] == 0.0
+    assert "盘中 0.0h" in result["detail"]
 
 
 def test_commit_evidence_is_fetched_once_not_once_per_job(monkeypatch):

--- a/tests/test_cron_schedule_panel.py
+++ b/tests/test_cron_schedule_panel.py
@@ -164,6 +164,29 @@ def test_degraded_with_a_real_content_issue_reads_as_needs_action():
     assert '3 条问题' in note['text'] and '1 条不是仅供参考' in note['text']
 
 
+def test_an_overlong_brief_is_named_as_length_not_as_possibly_wrong():
+    """2026-09-11 08:03: the one escalating issue was the extreme-length flag,
+    and the card said the delivered brief「可能有误」. Length is not content."""
+    readability = {'status': 'extreme', 'bytes': 45799, 'extreme_bytes': 40000}
+    alone = _record_with('degraded', postflight={
+        'issue_count': 1, 'escalating_count': 1, 'readability': readability,
+    }, primary_delivery={'wechat_ok': True, 'telegram_ok': True})
+    note = timetable(_contract('3 10 * * 1-5'), [alone],
+                     now=datetime(2026, 9, 3, 12, 0, tzinfo=HKT))['jobs'][0]['slots'][0]['note']
+    assert note['disposition'] == 'needs_action'
+    assert '45.8KB' in note['text'] and '40KB' in note['text']
+    assert '可能有误' not in note['text']
+
+    # A real content issue beside it still gets the generic warning, counted
+    # without the length flag.
+    both = _record_with('degraded', postflight={
+        'issue_count': 3, 'escalating_count': 2, 'readability': readability,
+    }, primary_delivery={'wechat_ok': True, 'telegram_ok': True})
+    note = timetable(_contract('3 10 * * 1-5'), [both],
+                     now=datetime(2026, 9, 3, 12, 0, tzinfo=HKT))['jobs'][0]['slots'][0]['note']
+    assert '另有 1 条' in note['text'] and '可能有误' in note['text']
+
+
 def test_degraded_from_a_publish_lag_alone_reads_as_watch_not_needs_action():
     """The pattern behind every degraded slot on 2026-09-03: both channels
     delivered, content check clean, only the dashboard commit hadn't published


### PR DESCRIPTION
09-11 晚巡检 cron / 定时任务 / dashboard 显示，实测到三处问题。

## 1. Holdings 持仓卡「横盘 decay ≈undefined%/月」
线上 1280/390 都能看到（SPCH 那一行）。SPCH 是 2x，标的 SPCX 还没有波动率 ⇒ `compute_breakeven_math` 不产 `chop_drag_pct_per_month`。Risk 页 `renderBreakevenMath` 有 `underlying_vol_pct != null` 判空，持仓卡 `dashboard.render.js` 这份没有。
- 修：判空后不印这一行。
- 闸：`testALeveragedRowWithoutVolatilityPrintsNoUndefined`：每只持仓都挂一行无 σ 的 2x，Holdings/Risk 两个 tab 的面板文本不许出现 `undefined%`/`NaN%`。**用旧 render.js 跑是红的**，修后是绿的。

## 2. Cron Health Check：scheduled publisher 假「4.9h 未更新」
run 34604921720（09-11 13:32 UTC）的 ⚠ 行。发布时间实测（Deploy Pages 触发时刻）：每天 08:40 UTC（16:40 HKT）后停，13:34 UTC（21:34 HKT）美股开盘恢复——中间没东西可发，这是正常的。workflow 排在 `17 9 * * 1-5`（17:17 HKT），但 GitHub 晚 ~4h 投递：09-09 13:41、09-10 13:34 都刚好落在美股开盘发布**之后**（0.0h），09-11 13:32 落在它**之前**两分钟 ⇒ 4.9h > 3h 判 warn。
- 阈值注释写的是「盘中三小时没动」，代码量的是墙钟。改成 `_session_hours_between`：按 `sessions.in_session` 只数 HK/US 盘中时间，5 分钟粒度，最多回看 4 天。
- 去掉按港股日期的「非交易日不判」短路：它会放过周五晚美股盘（港股时间已是周六）就死掉的发布器。新测试钉住这一条。
- 日历不可用时仍退回墙钟（与原来一样 fail-open）。

注：这条 workflow 另有一个每天都红的原因——off-host 兜底彩排失败，kcn 09-11 已拍板接受，不在本 PR 范围。

## 3. 数据健康卡：简报超长被写成「报告已投递但可能有误」
09-11 08:03 简报唯一一条升级问题是 `readability.status=extreme`（`brief_postflight.readability_issues` 故意把极端超长升级）。卡上的说法却是在断言内容可能有误。现在点名「简报正文 45.8KB，超过 40KB 极端线」；有其它升级问题时另起「另有 N 条…可能有误」。处置档（需处理）不变。

## 验证
- `pytest tests/test_cron_health_check.py tests/test_cron_token_audit.py tests/test_cron_schedule_panel.py`，外加 `-k "cron or schedule or health or publish or dashboard"` 子集 640 passed
- 浏览器测试单独跑：修复版绿、旧 render.js 红

https://claude.ai/code/session_0124MF14ku86GPxxM7jXszyW
