### PR TITLE
brief：今日动作与信心与判定合成一票一块；兜底彩排失败按到期日降为告警

### DIFF
--- a/.github/workflows/cron-health.yml
+++ b/.github/workflows/cron-health.yml
@@ -95,7 +95,14 @@ jobs:
         if: always()
         env:
           GH_TOKEN: ${{ github.token }}
-        run: python3 ops/ci/backstop_rehearsal.py --strict
+        # kcn 2026-09-11: 「不好做就放弃了…兜底不容易触发」— the backstop stays
+        # broken on purpose (OpenCode wallet empty, MiniMax the only leg). It
+        # still prints and annotates; it stops reddening the whole check until
+        # the date below, when it has to be decided again.
+        run: >-
+          python3 ops/ci/backstop_rehearsal.py --strict
+          --accepted-until 2026-10-11
+          --accepted-reason "kcn 2026-09-11 决定不修兜底（OpenCode 余额空，只剩 MiniMax 一条腿）"
 
       # `assets/data/schedule-drift.json` has measured GitHub's delivery
       # lateness twice a week since #781 and nothing read it, while five

--- a/ops/ci/backstop_rehearsal.py
+++ b/ops/ci/backstop_rehearsal.py
@@ -199,7 +199,14 @@ def main(argv=None) -> int:
     ap.add_argument("--strict", action="store_true",
                     help="exit 1 on a determined failure (never on 'unknown')")
     ap.add_argument("--json", action="store_true")
+    ap.add_argument("--accepted-until", metavar="YYYY-MM-DD",
+                    help="a known, decided-on failure: through this date --strict "
+                         "reports it as a warning instead of exiting 1")
+    ap.add_argument("--accepted-reason", default="",
+                    help="who decided and why; required with --accepted-until")
     args = ap.parse_args(argv)
+    if args.accepted_until and not args.accepted_reason.strip():
+        ap.error("--accepted-until needs --accepted-reason")
 
     verdict = assess()
     if args.json:
@@ -211,8 +218,30 @@ def main(argv=None) -> int:
             print(f"      last rehearsal: {verdict['run_url']} "
                   f"({verdict.get('at')})")
     if args.strict and verdict["status"] in ("fail", "overdue"):
+        if _accepted(args.accepted_until):
+            # kcn 2026-09-11 decided not to repair the backstop. A step that is red
+            # every day for a decided reason hides every NEW red in the same
+            # workflow (the 09-11 publisher false-stale was only found by diffing
+            # run logs by hand), so a decided failure is reported as a warning —
+            # still printed, still annotated — and only until a date, after which
+            # it is red again and has to be decided again. Never open-ended.
+            print(f"::warning title=off-host brief backstop::{verdict['reason']} "
+                  f"(accepted until {args.accepted_until}: {args.accepted_reason})")
+            print(f"      accepted until {args.accepted_until} — {args.accepted_reason}")
+            return 0
         return 1
     return 0
+
+
+def _accepted(until, today=None):
+    """True while `until` (inclusive, UTC date) has not passed."""
+    if not until:
+        return False
+    try:
+        limit = datetime.strptime(until, "%Y-%m-%d").date()
+    except ValueError:
+        return False  # an unreadable date accepts nothing: fail closed, stay red
+    return (today or datetime.now(timezone.utc).date()) <= limit
 
 
 if __name__ == "__main__":

--- a/skills/daily-deep-brief/SKILL.md
+++ b/skills/daily-deep-brief/SKILL.md
@@ -816,7 +816,7 @@ portfolio_counterargument/narrative/ticker_judgments`。
   "disposition": "candidate|wait|reject",
   "assessment": "你的评价",
   "counterargument": "最强反方",
-  "rationale": "为何在冲突信号中这样判断",
+  "rationale": "为何在冲突信号中这样判断（只写 plan rationale 里没有的：历史战绩、反方为何不成立；≤2 句）",
   "falsifier": "什么事实会推翻当前候选/等待判断",
   "next_evidence": "下一步要找的一手披露或价格确认",
   "fundamentals": "Tier 1 · 基本面格：EDGAR/财报/ETF 标的口径",
@@ -825,6 +825,12 @@ portfolio_counterargument/narrative/ticker_judgments`。
   "peer_read": "同行扫描那一行的判断：领先/落后说明什么"
 }
 ```
+
+**`rationale` 不许复述 plan。** 报告里「今日动作 · 信心与判定」是一票一块：plan 的 `rationale`
+印在「理由」，这里的 `rationale` 印在「判定」，和前者逐句相同的会被 harness 删掉（`brief_render._unsaid`）。
+换个说法把同样的事实再写一遍删不掉，只会让简报变长：2026-09-11 两处加起来 12.5KB，简报 44KB 越过
+40KB 极端线。这里写 plan 没说的——`bucket_history` 战绩、为什么反方不成立、信心为什么是这个数——
+没有就一句话。
 
 `narrative`（整篇报告的辩论层，全部必填）：
 

--- a/src/clawock/harness/brief_render.py
+++ b/src/clawock/harness/brief_render.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 from datetime import date as _date
 from pathlib import Path
 
@@ -596,25 +597,74 @@ def risk_voices_section(judgment):
     return "\n".join(out).rstrip()
 
 
-def judge_section(plan):
+def judge_section(plan, judgment=None):
     """The calls themselves — what the harness validated and the ledger records.
 
     Split out of the old `Tier 3 — 3 Risk Voices + Judge` because those are two
     different questions: the voices are the argument, this is the answer. Under
     the four-part layout the answer opens the report and the argument follows it.
+
+    One entry per call, confidence and verdict included. 信心与判定 used to be a
+    second section with its own entry per ticker, and the two rationales it
+    printed side by side were largely the same text: on 2026-09-11 the 07226
+    entry of both ended in the same forty characters (「cut 释放 17,707 HKD 留现
+    金；03033 1x 替代 buy 腿 blocked…」), and the two sections together were
+    12.5KB of a 44KB brief that had crossed the 40KB extreme line. The judgment's
+    rationale now prints only the clauses the call's own rationale did not
+    already say (`_unsaid`), under 判定; the falsifier stays whole.
     """
+    judgments = _judgments(judgment or {})
     rows = []
     for decision in (plan.get("decisions") or []):
+        ticker = str(decision.get("ticker"))
         debate = decision.get("debate") or {}
+        row = judgments.get(ticker) or {}
+        confidence = decision.get("confidence")
+        rationale = text(decision.get("rationale"))
+        fields = [("理由", rationale)]
+        extra = _unsaid(row.get("rationale"), decision.get("rationale"))
+        if extra:
+            fields.append(("判定", text(extra)))
+        if row.get("falsifier"):
+            fields.append(("证伪条件", text(row.get("falsifier"))))
+        title = f"**{text(ticker)}** · **{text(decision.get('action'))}**"
+        if confidence is not None:
+            title += f" · 信心 {pct(confidence * 100, digits=0, sign=False)}"
+        if row.get("verdict"):
+            title += f" · {verdict_badge(row.get('verdict'))}"
         rows.append({
-            "title": (f"**{text(decision.get('ticker'))}** · "
-                      f"**{text(decision.get('action'))}**"),
+            "title": title,
             "meta": [" + ".join(debate.get("frames") or []) or MISSING,
                      text(decision.get("strategy_id")),
                      text(decision.get("driven_by"))],
-            "fields": [("理由", text(decision.get("rationale")))],
+            "fields": fields,
         })
-    return f"### {PAGE_ACTION_HEADING}\n\n" + entries(rows)
+    return f"### {PAGE_ACTION_HEADING} · {PAGE_CONFIDENCE_HEADING}\n\n" + entries(rows)
+
+
+# A clause ends at CJK/ASCII sentence punctuation — but a period only when a
+# space or the end follows it, or "-71.8%" would be cut in two.
+_CLAUSE_END = re.compile(r"[;；。!！?？\n]+|\.(?=\s|$)")
+_CLAUSE_NOISE = re.compile(r"[\s,，、:：()（）'\"“”‘’`·]+")
+
+
+def _unsaid(extra, said):
+    """The clauses of `extra` that `said` does not already contain, in order.
+
+    Compared with spacing and punctuation folded away, so "cut 释放 17,707 HKD"
+    and "cut 释放 17,707 HKD," are one clause. Containment, not equality: the
+    call's rationale often carries a clause verbatim inside a longer sentence.
+    """
+    if not extra:
+        return ""
+    folded = _CLAUSE_NOISE.sub("", str(said or "")).lower()
+    kept = []
+    for clause in _CLAUSE_END.split(str(extra)):
+        clause = clause.strip()
+        key = _CLAUSE_NOISE.sub("", clause).lower()
+        if key and key not in folded and clause not in kept:
+            kept.append(clause)
+    return "；".join(kept)
 
 
 def sector_section(sector_scan, judgment):
@@ -748,23 +798,6 @@ def verdict_badge(value):
             f'{spec["glyph"]} {spec["label"]}</span>')
 
 
-def confidence_section(judgment, plan):
-    judgments = _judgments(judgment)
-    rows = []
-    for decision in (plan.get("decisions") or []):
-        ticker = str(decision.get("ticker"))
-        row = judgments.get(ticker) or {}
-        confidence = decision.get("confidence")
-        rows.append({
-            "title": (f"**{ticker}** · {text(decision.get('action'))} · "
-                      f"信心 {pct((confidence or 0) * 100, digits=0, sign=False)} · "
-                      f"{verdict_badge(row.get('verdict'))}"),
-            "fields": [("理由", text(row.get("rationale"))),
-                       ("证伪条件", text(row.get("falsifier")))],
-        })
-    return "### 信心与判定\n\n" + entries(rows)
-
-
 def _interval(bounds):
     """A confidence interval in the same units as the benefit beside it.
 
@@ -825,6 +858,7 @@ def data_holes_section(context, judgment):
 #: other: renaming a heading in only one of them is how they drift into looking
 #: like different reports. `test_the_card_and_the_page_agree` pins the pair.
 PAGE_ACTION_HEADING = "今日动作"
+PAGE_CONFIDENCE_HEADING = "信心与判定"
 PAGE_BOOK_PART = "这本账现在什么样"
 CARD_BOOK_HEADING = "这本账"
 
@@ -859,8 +893,7 @@ def render_brief(context, judgment, plan, *, date=None, sector_scan=None):
     # one model paragraph, and the reader never wonders where to start.
     parts = [
         ("今天做什么", [
-            judge_section(plan),
-            confidence_section(judgment, plan),
+            judge_section(plan, judgment),
             next_session_section(judgment),
         ]),
         ("我的看法", [

--- a/tests/test_backstop_rehearsal.py
+++ b/tests/test_backstop_rehearsal.py
@@ -182,3 +182,35 @@ def test_cron_health_runs_this_check_and_does_not_skip_it_on_a_red_verdict():
     assert "if: always()" in block, (
         "the cron health check exits non-zero on a miss; without always() this "
         "step is skipped on exactly the days somebody is reading the run")
+
+
+# --- a decided failure is a warning until a date, never forever ------------
+
+def test_an_accepted_failure_warns_until_its_date_then_reddens_again(monkeypatch, capsys):
+    monkeypatch.setattr(br, "assess", lambda: {"status": "fail", "reason": "dead"})
+    args = ["--strict", "--accepted-until", "2026-10-11", "--accepted-reason", "kcn 定的"]
+
+    real = br._accepted
+    monkeypatch.setattr(br, "_accepted", lambda until: real(
+        until, today=datetime(2026, 10, 11).date()))
+    assert br.main(args) == 0
+    out = capsys.readouterr().out
+    assert "::warning" in out and "dead" in out and "kcn 定的" in out
+
+    monkeypatch.setattr(br, "_accepted", lambda until: real(
+        until, today=datetime(2026, 10, 12).date()))
+    assert br.main(args) == 1
+
+
+def test_acceptance_needs_a_reason_and_a_readable_date(monkeypatch):
+    monkeypatch.setattr(br, "assess", lambda: {"status": "fail", "reason": "dead"})
+    with pytest.raises(SystemExit):
+        br.main(["--strict", "--accepted-until", "2026-10-11"])
+    assert br._accepted("not-a-date") is False
+    assert br._accepted(None) is False
+
+
+def test_cron_health_acceptance_is_dated():
+    cron_health = (ROOT / ".github" / "workflows" / "cron-health.yml").read_text()
+    block = cron_health.split("- name: Off-host brief backstop", 1)[1].split("- name:", 1)[0]
+    assert "--accepted-until 20" in block and "--accepted-reason" in block

--- a/tests/test_brief_render.py
+++ b/tests/test_brief_render.py
@@ -115,7 +115,7 @@ def test_the_report_is_rendered_in_one_fixed_order():
     # used to be: the report's shape is a decision, not an accident of which
     # section function happened to be appended last.
     order = ["# 盘前深度简报",
-             "## 今天做什么", "### 今日动作", "### 信心与判定", "### 下一节点",
+             "## 今天做什么", "### 今日动作 · 信心与判定", "### 下一节点",
              "## 我的看法", "### 多空对辩", "### 风险官三票", "### 分析师四格",
              "## 这本账现在什么样", "### 双币账本", "### 集中度", "### 风控硬闸",
              "### 回本测算", "### 仓位明细", "### 大盘趋势",
@@ -183,7 +183,7 @@ def test_the_judge_table_comes_from_the_plan_not_the_prose():
     """The plan is the validated boundary; the report must not restate it in the
     model's own words, or the two can disagree about what was decided."""
     body = render.render_brief(CONTEXT, _judgment(), PLAN, date="2026-08-31")
-    judge = body[body.index("### 今日动作"):body.index("### 信心与判定")]
+    judge = body[body.index("### 今日动作"):body.index("### 下一节点")]
 
     assert "**cut**" in judge and "risk_rebalance" in judge
     assert "technical_breakdown + relative_strength" in judge
@@ -308,10 +308,39 @@ def test_an_unknown_verdict_still_prints_itself():
 
 def test_the_confidence_table_carries_the_badge():
     body = render.render_brief(CONTEXT, _judgment(), PLAN, date="2026-08-31")
-    table = body[body.index("### 信心与判定"):body.index("### 下一节点")]
+    table = body[body.index("### 今日动作 · 信心与判定"):body.index("### 下一节点")]
 
     assert '<span class="verdict verdict-bearish">🔴 看空</span>' in table
     assert "| 看空 |" not in table, "the plain-text cell is what #1272 replaced"
+
+
+def test_the_judgment_prints_only_what_the_call_did_not_already_say():
+    """2026-09-11: 今日动作 and 信心与判定 were two entries per ticker whose two
+    rationales ended in the same forty characters. One entry now; the judgment
+    keeps only its own clauses, and a judgment that adds nothing prints nothing."""
+    shared = "cut 释放 17,707 HKD 留现金；03033 1x 替代 buy 腿 blocked (无 technical setup)"
+    decision = {**PLAN["decisions"][0], "rationale": "硬止损 -34.5% ≤ -18% 线。" + shared + "。"}
+    judgment = _judgment()
+    target = render._judgments(judgment)[str(decision["ticker"])]
+    target["rationale"] = ("reflections 持×5 胜 2 (40%) 不如 cut 历史胜率. "
+                           "cut 释放 17,707 HKD 留现金; 03033 1x 替代 buy 腿 blocked (无 technical setup).")
+    plan = {**PLAN, "decisions": [decision] + PLAN["decisions"][1:]}
+    body = render.render_brief(CONTEXT, judgment, plan, date="2026-08-31")
+    section = body[body.index("### 今日动作"):body.index("### 下一节点")]
+
+    assert section.count("17,707") == 1, "the shared clause printed twice"
+    assert "reflections 持×5 胜 2 (40%) 不如 cut 历史胜率" in section
+    assert "**判定**" in section and "**证伪条件**" in section
+    assert "### 信心与判定" not in body, "a second per-ticker section came back"
+
+    target["rationale"] = shared
+    body = render.render_brief(CONTEXT, judgment, plan, date="2026-08-31")
+    first = body[body.index("### 今日动作"):].split("\n- ", 2)[1]
+    assert "**判定**" not in first, "a judgment with nothing new still got a field"
+
+
+def test_unsaid_keeps_decimals_whole():
+    assert render._unsaid("浮亏 -71.8% 仍在扩大. 另一句", "另一句") == "浮亏 -71.8% 仍在扩大"
 
 
 def test_the_stylesheet_tints_every_badge_class():
@@ -479,7 +508,7 @@ def test_a_sweep_with_no_sectors_counts_as_missing(tmp_path):
 # ── tables for numbers, entries for prose, one card per subsection ───────────
 #    (2026-09-11: "在 dashboard 里看 brief 也很丑，也没什么卡片区块感，数据排版也很杂乱")
 
-PROSE_SECTIONS = ("今日动作", "信心与判定", "分析师四格", "同行扫描", "社交舆情")
+PROSE_SECTIONS = ("今日动作", "分析师四格", "同行扫描", "社交舆情")
 
 
 def _section(body, heading):


### PR DESCRIPTION
## 简报：两节合一
- 「今日动作」「信心与判定」每票各一块、两段理由大量重复（09-11 两节合计 12.5KB，简报 44KB 越过 40KB 极端线）。
- 现在一票一块：标题 `**票** · **动作** · 信心 N% · 判定徽章`；「理由」= plan rationale；「判定」= judgment rationale 中 plan 没说过的句子（`_unsaid`）；「证伪条件」照旧。
- 标题 `### 今日动作 · 信心与判定`，postflight 两个必需段标记都满足。
- 实测：09-09/10/11 真实输入重渲染，逐字重复删掉只省 ~1.5KB；剩下是换说法的复述 ⇒ SKILL 同步要求 judgment rationale 只写 plan 没有的内容（≤2 句）。真正的大头（三只票天天重发 cut）由下一个 PR 的自适应机制处理。

## Cron Health Check：已决定的红按到期日降为告警
- 兜底彩排失败 kcn 09-11 决定不修；它每天染红整个检查，新红因只能手工比日志发现（09-11 发布器误报就是这么找到的）。
- `backstop_rehearsal.py --accepted-until 2026-10-11 --accepted-reason …`：期内打印 + `::warning` 注解、退 0；过期自动回红。无理由不许接受；日期读不懂按未接受。

## 验证
- `-k "brief or skill or payload or cron or backstop or render"` 684 passed
- 新测试：共享句只印一次、无新内容不出「判定」、小数不被断句；接受期内退 0 / 过期退 1 / 无理由报错

https://claude.ai/code/session_01Dkn6aA3Ru8AQUW8qoz7ryV
