### PR TITLE
risk: 长期不执行的建议——证据和护栏归 harness，今天提不提归模型

### DIFF
--- a/skills/daily-deep-brief/SKILL.md
+++ b/skills/daily-deep-brief/SKILL.md
@@ -345,7 +345,7 @@ preflight 已算好,直接读 `context.risk_guardrail`:
 - `context.risk_discipline.records[]` — 同一 breach 的持久状态：`breach_id`、严重度、`age_days`、首次/最后变化、required reduction、acknowledgement、限时 override、execution evidence。每日重新生成的 plan 不是状态账本。
 
 硬性规则:
-- **每一条 breach 和 hard_stop 必须在 Judge 段落出一个对应的具体动作**(trim 到 ≤cap / cut),不准忽略、不准"观望"。直接采用 `action` 文案或给等价方案。
+- **每一条 breach 和 hard_stop 必须在 Judge 段落出一个对应的具体动作**(trim 到 ≤cap / cut),不准忽略、不准"观望"。直接采用 `action` 文案或给等价方案。**唯一例外**是下面「长期不执行的建议」里 `adaptive.may_stand=true` 的那几条。
 - 每条 open 记录必须引用 `breach_id + age_days + acknowledgement/execution 状态`；未确认的老 breach 要明确升级，不得每天当新提醒重写。
 - 当天 plan 内的 `override.status=active` **不能**豁免硬闸。只有 durable ledger 里带非空 reason 且未过 TTL 的 `status=overridden` 才有效；创建例外必须由用户明确决定，可用 `/root/.local/bin/clawock risk override BREACH_ID --reason '...' --ttl-hours N`。确认已看见用 `risk ack ... --note '...'`，成交证据用 `risk confirm ... --evidence '...'`；这些命令只记账，绝不下单。
 - 任何 critical/high breach 未关闭且未 durable override 时，禁止新增同一标的、杠杆或因子暴露。卖出不受阻；同一份 plan 中可证明净降 factor exposure 的 2x→1x 配对换仓不受阻。
@@ -368,6 +368,21 @@ preflight 已算好,直接读 `context.risk_guardrail`:
   要么用 `risk override --reason` 记下**为什么决定不做**。实测 2026-08-26:三条 hard_stop 站了
   42 天、同一条砍单发了 136 次、执行 0 次,而 `override` 字段一次没用过——账本读起来像"没人看",
   真相是有人每天看、每天决定不做。
+- **长期不执行的建议 —— 今天提不提，由你判断(2026-09-12 kcn)**:每条风险行带 `adaptive`。
+  harness 已经从账本和成交记录算好了证据,你不用、也不许自己推断 kcn 想不想做:
+  - `eligible=true` = 挂 ≥10 天 + kcn 明确没照做:`stance.stance=declined`(同期在别的票有成交,
+    这几只一股没减)或 `contrary`(被要求减的时候反向买入,`buys_on_target` 次)。`silent`(最近
+    没交易,可能不在)**不算**表态,照常出动作。
+  - `may_stand=true` → 今天由你选:**重提**(照常出 cut/trim)或**维持**(出 `hold_and_watch`,
+    `strategy_id=risk_rebalance`、`driven_by=risk_rule`)。默认维持;**只有今天和上次重提时比
+    有实质不同**才重提——跌穿关键位、新的一手催化、制度切换、临近事件(FOMC/财报)——
+    并在 rationale 第一句写出「今天和 `last_reissued_on` 那天比,变了什么」。写不出来就维持。
+  - 选**维持**时,rationale 不要再写第 N 遍「应该砍」。kcn 的做法已经摆在 `stance` 里
+    (例:SPCH 是「无限子弹流继续摊本」):在他选的打法里给有用的话——这个仓位最该盯的位、
+    什么情况下这套打法本身不成立。**加仓仍然冻结**,维持不等于可以加。
+  - `must_reissue=true` → 护栏到了,你关不掉:照常出 cut/trim,rationale 引 `must_reason`
+    (再深 10pp / 需减额 1.5 倍 / 严重度升级,或距上次重提满 28 天)。
+  - 选择由 postflight 记进账本(`adaptive.stances`),你不写账本、不编 id。
 - 若 `breach_count=0` → 本段写"✅ 仓位硬闸无触发",照常决策。
 - **解套/回本数字只准引用 `context.breakeven_math`**(preflight 已算好:每只浮亏持仓回本所需涨幅、2x 的横盘 decay ≈σ²/12 每月、半年窗含 drag 等效标的涨幅),禁止自己心算或编造。解读纪律见其 `note`:直线涨→2x 回本更快;横盘→2x 每月白付 decay;再跌→2x 双倍挨打——换 1x 买的是后两种情景的保护,不是回本速度,别说反。
 - **技术面判断只准引用 `context.quant_signals` 中 `status=fresh` 的行**(每只持仓的趋势/动量/RSI/zscore20/吊灯止损线/vol_target_weight,杠杆 ETF 按标的算)；`stale/missing/retired` 行只用于披露数据缺口，禁止据此形成判断，也禁止自创"看图"结论。**因子话语权由 `context.quant_signal_review` 决定**(信号每日留痕 vs T+1/T+5 前瞻收益自动对账):必须公示 `n_events/n_dates/n_tickers`;`usable=false` 或聚类 CI 跨 50% 的因子只能当背景展示不入决策；`decision_direction=reverse` 仅在反向 CI 整体低于 50% 时成立，禁止因 raw hit_rate<50% 自动反向。T+0 牌面同样只在 `sample_sufficient=true AND edge_supported=true` 时可入决策；样本够多但 Wilson CI 不支持原方向仍是 `usable=false`，不得自动反向交易。`driven_by=technical` 的整体战绩一律读取 `context.decision_metrics.by_driver.technical` 的实时计算值，禁止引用固定百分比。这是自迭代环——哪个因子可信,数据说了算,每天自动更新。

--- a/src/clawock/decision/packet.py
+++ b/src/clawock/decision/packet.py
@@ -713,6 +713,26 @@ def _event_view(event: dict) -> dict:
     return view
 
 
+def _adaptive_view(adaptive: dict | None) -> dict:
+    """What the plan writer needs from the breach's adaptive state — and no more.
+
+    The ledger keeps the full history (`stances`, anchors); the model gets the verdict,
+    the evidence behind it, and the rails, so it can judge without re-deriving them.
+    """
+    adaptive = adaptive or {}
+    if not adaptive.get("eligible"):
+        return {"eligible": False,
+                "not_eligible_because": adaptive.get("not_eligible_because") or []}
+    return {
+        key: adaptive.get(key)
+        for key in ("eligible", "may_stand", "must_reissue", "must_reason", "stance",
+                    "last_reissued_on", "days_since_reissue", "forced_on", "rearm_at")
+    } | {"recent_choices": [
+        {"date": row.get("date"), "choice": row.get("choice")}
+        for row in (adaptive.get("stances") or [])[-5:]
+    ]}
+
+
 def _risk_map(context: dict, active: set[str]) -> dict[str, list[dict]]:
     guardrail = context.get("risk_guardrail") or {}
     out = {ticker: [] for ticker in active}
@@ -737,6 +757,7 @@ def _risk_map(context: dict, active: set[str]) -> dict[str, list[dict]]:
                 # writer is the one who can turn it into an execute, an
                 # acknowledge or an override (#1075).
                 "standing": row.get("standing") or {},
+                "adaptive": _adaptive_view(row.get("adaptive")),
                 "required_reduction": {
                     key: reduction.get(key)
                     for key in (
@@ -764,6 +785,7 @@ def _risk_map(context: dict, active: set[str]) -> dict[str, list[dict]]:
             "detail": row.get("detail"),
             "action_text": row.get("action"),
             "standing": row.get("standing") or {},
+            "adaptive": _adaptive_view(row.get("adaptive")),
             "required_reduction": {
                 key: reduction.get(key)
                 for key in (
@@ -876,14 +898,23 @@ def _status(technical: dict, risks: list[dict]) -> dict:
 def _constraints(shares: int, risks: list[dict], actionable_ids: list[str],
                  technical: dict, execution: dict,
                  swap_mandates: list[dict] | None = None) -> dict:
-    hard_stop = any(row.get("kind") == "hard_stop" for row in risks)
+    # A breach the book has kept declining may stand (risk.py `_adaptive`): the plan
+    # writer chooses between raising it again and holding, and only the breaches that
+    # are NOT allowed to stand still force an action.
+    loud = [row for row in risks if not (row.get("adaptive") or {}).get("may_stand")]
+    hard_stop = any(row.get("kind") == "hard_stop" for row in loud)
     direct_risk = bool(risks)
     if hard_stop:
         allowed = ["cut"]
         forced = ["cut"]
-    elif direct_risk:
+    elif loud:
         allowed = ["trim_on_rebound", "cut"]
         forced = ["trim_on_rebound", "cut"]
+    elif direct_risk:
+        # Every breach on this name may stand. Adds stay shut — `can_add` below still
+        # reads `risks` — so standing never turns into buying more of a breach.
+        allowed = ["hold_and_watch", "watch", "trim_on_rebound", "cut"]
+        forced = []
     else:
         allowed = ["hold_and_watch", "watch"]
         forced = []

--- a/src/clawock/decision/plans.py
+++ b/src/clawock/decision/plans.py
@@ -114,6 +114,31 @@ def _overridden_risk_tickers(ledger_path=None):
     return overridden
 
 
+def _standing_risk_tickers(ledger_path=None):
+    """Tickers whose breach today's brief chose to let stand (risk.py `_adaptive`).
+
+    Same carry-over problem as an override (#552): once the morning plan holds a
+    breach the book keeps declining, every intraday slot re-reading last week's open
+    "SPCH cut" as an unfilled swap is the nagging the choice was made to stop. Unlike an
+    override these rows are NOT settled — nobody declined them explicitly, so they keep
+    their own evaluation — they are only not re-announced. Reads the choice the brief
+    postflight filed, so a day the model re-raised the breach carries it as before.
+    """
+    try:
+        ledger = risk_ledger.load_ledger(
+            Path(ledger_path) if ledger_path else risk_ledger.LEDGER)
+    except Exception:  # noqa: BLE001 — a broken breach ledger must not red a report cron
+        return set()
+    tickers = set()
+    for row in ledger.get("records") or []:
+        adaptive = row.get("adaptive") or {}
+        choices = adaptive.get("stances") or []
+        if (row.get("status") == "open" and adaptive.get("may_stand")
+                and choices and choices[-1].get("choice") == "stand"):
+            tickers |= risk_ledger._targets(row)
+    return tickers
+
+
 def _entry(row):
     size = row.get("size") or {}
     condition = row.get("condition") or {}
@@ -322,6 +347,18 @@ def open_decisions_context(*, leg=None, today=None, ledger=None, memory_dir=None
         # discipline. Other decisions on the same ticker stay untouched.
         overridden_tickers = _overridden_risk_tickers(
             ledger_path=memory / "risk_breaches.json")
+        standing_tickers = _standing_risk_tickers(
+            ledger_path=memory / "risk_breaches.json") - overridden_tickers
+        standing_hidden = sorted({
+            str(row.get("ticker")) for row in rows
+            if str(row.get("ticker") or "") in standing_tickers
+            and row.get("driven_by") == "risk_rule"
+            and row.get("action") in ("cut", "trim_on_rebound")})
+        if standing_tickers:
+            rows = [row for row in rows
+                    if not (str(row.get("ticker") or "") in standing_tickers
+                            and row.get("driven_by") == "risk_rule"
+                            and row.get("action") in ("cut", "trim_on_rebound"))]
         dropped = []
         if overridden_tickers:
             def _is_overridden_cut(row):
@@ -338,9 +375,14 @@ def open_decisions_context(*, leg=None, today=None, ledger=None, memory_dir=None
         if not rows:
             if open_add_gate_error:
                 return {"open_add_tickers": [], "open_add_gate_error": open_add_gate_error}
+            quiet = {}
             if dropped:
-                return {"open_add_tickers": [], "overridden_by_user": sorted(set(dropped))}
-            return {}
+                quiet["overridden_by_user"] = sorted(set(dropped))
+            if standing_hidden:
+                # Said, not dropped: a slot must be able to write "SPCH 的 cut 今天维持
+                # 不重提" rather than read as if there were nothing on the book.
+                quiet["standing_by_choice"] = standing_hidden
+            return {"open_add_tickers": [], **quiet} if quiet else {}
 
         # Today's plan first, then the oldest carried-over orders: a swap hanging
         # since Friday is more urgent than one written this morning, but the
@@ -364,6 +406,8 @@ def open_decisions_context(*, leg=None, today=None, ledger=None, memory_dir=None
         }
         if dropped:
             context["overridden_by_user"] = sorted(set(dropped))
+        if standing_hidden:
+            context["standing_by_choice"] = standing_hidden
         if open_add_gate_error:
             context["open_add_gate_error"] = open_add_gate_error
         if len(rows) > MAX_DECISIONS:

--- a/src/clawock/decision/risk.py
+++ b/src/clawock/decision/risk.py
@@ -279,6 +279,7 @@ def reconcile_guardrail(
                 },
                 "fingerprint": fingerprint,
                 "resolution": None,
+                "pressure": _pressure(row),
             }
         else:
             record = previous
@@ -304,6 +305,7 @@ def reconcile_guardrail(
                 record["last_changed_at"] = stamp
             record.update({
                 "status": "open",
+                "pressure": _pressure(row),
                 "severity": row.get("severity") or record.get("severity"),
                 "last_seen_at": stamp,
                 "detail": row.get("detail") or "",
@@ -338,6 +340,7 @@ def reconcile_guardrail(
         record["age_days"] = _age_days(
             record.get("current_opened_at"), current_time)
         record["standing"] = _standing(record)
+        record["adaptive"] = _adaptive(record, portfolio, current_time)
         by_id[breach_id] = record
 
     for breach_id, record in by_id.items():
@@ -388,6 +391,9 @@ def reconcile_guardrail(
             [r.get("age_days") or 0 for r in active] or [0]),
         "decision_overdue_count": sum(
             bool((r.get("standing") or {}).get("decision_overdue")) for r in active),
+        "may_stand_count": sum(may_stand(r) for r in active),
+        "must_reissue_count": sum(
+            bool((r.get("adaptive") or {}).get("must_reissue")) for r in active),
         "records": active,
     }
 
@@ -416,6 +422,225 @@ def _standing(record: dict) -> dict:
         # Named so the reader does not have to infer what would clear it.
         "closes_with": ["execute", "acknowledge", "override"],
     }
+
+
+#: Advice the book keeps declining (kcn 2026-09-12:「我们长期不听的模型建议可以考虑有一个
+#: 自适应机制」). Measured the same day: 58 of the 61 active calls not followed in 30 days
+#: were the same three risk_rule cuts (07226 / RKLX / SPCH), re-issued every morning for
+#: 29 / 58 / 57 days, while the book showed what kcn had decided — shares unchanged, trades
+#: in other names, and ten buys INTO SPCH (「无限子弹流继续摊本」) while it was told to cut.
+#:
+#: Split by who is good at what. The harness owns the evidence and the ledger: whether a
+#: breach is ELIGIBLE to stand (`_revealed_stance`), the two rails that force it back
+#: (`_worsened`, `REISSUE_CEILING_DAYS`), and the record of each day's choice
+#: (`record_stances`). The brief model owns the judgment inside that envelope: whether
+#: today is different enough to raise it again, and what to say instead. A model left to
+#: itself shouts louder when ignored (09-11: 「今日第 5 次重发…三选一关闭」), and a model
+#: that writes ledger state corrupts it (#1433) — so it gets the choice, not the pen.
+REISSUE_CEILING_DAYS = 28
+REARM_LOSS_PP = 10.0
+REARM_REDUCTION_RATIO = 1.5
+#: A trade elsewhere older than this says nothing about today: someone who has not
+#: traded for a month may simply be away, and silence is not a decision.
+RECENT_ACTIVITY_DAYS = 30
+_SEVERITY_RANK = {"critical": 0, "high": 1, "medium": 2}
+
+
+def _pressure(row: dict) -> dict | None:
+    """The one number that says how bad this breach is, in its own units."""
+    if row.get("type") in ("hard_stop", "leveraged_hard_stop") and isinstance(
+            row.get("pnl_pct"), (int, float)):
+        return {"kind": "pnl_pct", "value": float(row["pnl_pct"])}
+    reduction = row.get("required_reduction") or {}
+    value = reduction.get("minimum_value")
+    if isinstance(value, (int, float)):
+        return {"kind": "minimum_value", "value": float(value),
+                "currency": reduction.get("currency")}
+    return None
+
+
+def _targets(record: dict) -> set[str]:
+    targets = {str(t) for t in (record.get("required_reduction") or {}).get(
+        "target_tickers") or []}
+    if record.get("ticker"):
+        targets.add(str(record["ticker"]))
+    return targets
+
+
+def _trades(portfolio: dict) -> list[dict]:
+    out = []
+    for ticker, holding in _holding_map(portfolio).items():
+        for trade in holding.get("trades") or []:
+            if isinstance(trade, dict) and isinstance(trade.get("date"), str):
+                out.append({"ticker": ticker, "date": trade["date"][:10],
+                            "action": str(trade.get("action") or "").lower()})
+    return out
+
+
+def _revealed_stance(record: dict, portfolio: dict, now: datetime) -> dict:
+    """What the book shows the user did about this breach while it stood.
+
+    `acting`   — sold one of the names it targets since it opened;
+    `contrary` — bought one of them instead;
+    `declined` — traded other names recently, never these;
+    `silent`   — no recent trading at all: maybe away. Not a decision, never inferred as one.
+
+    Read from trades on the CURRENT target tickers, not from `execution.status`: that
+    field keeps whatever evidence it ever collected, and the US leverage breach carries
+    `evidence_present` from July sells of MSFU/PLTU while its targets today are RKLX/SPCH.
+    """
+    opened = (_parse_stamp(record.get("current_opened_at"))
+              or _parse_stamp(record.get("first_seen_at")))
+    since = opened.date().isoformat() if opened else ""
+    recent = (now.date() - timedelta(days=RECENT_ACTIVITY_DAYS)).isoformat()
+    targets = _targets(record)
+    today = now.date().isoformat()
+    window = [t for t in _trades(portfolio) if since <= t["date"] <= today]
+    on_target = [t for t in window if t["ticker"] in targets]
+    sells = [t for t in on_target if t["action"] == "sell"]
+    buys = [t for t in on_target if t["action"] == "buy"]
+    elsewhere = [t for t in window if t["ticker"] not in targets and t["date"] >= recent]
+    if sells:
+        stance = "acting"
+    elif buys:
+        stance = "contrary"
+    elif elsewhere:
+        stance = "declined"
+    else:
+        stance = "silent"
+    return {
+        "stance": stance,
+        "since": since,
+        "target_tickers": sorted(targets),
+        "sells_on_target": len(sells),
+        "buys_on_target": len(buys),
+        "last_buy_on_target": max((t["date"] for t in buys), default=None),
+        "trades_elsewhere_recent": len(elsewhere),
+        "last_trade_elsewhere": max((t["date"] for t in elsewhere), default=None),
+    }
+
+
+def _worsened(anchor, current, anchor_severity, severity) -> str:
+    """Why this breach is materially worse than when it was last raised, or ''."""
+    if _SEVERITY_RANK.get(severity, 3) < _SEVERITY_RANK.get(anchor_severity, 3):
+        return f"严重度 {anchor_severity} → {severity}"
+    if not anchor or not current or anchor.get("kind") != current.get("kind"):
+        return ""
+    before, now_value = float(anchor["value"]), float(current["value"])
+    if anchor["kind"] == "pnl_pct" and now_value <= before - REARM_LOSS_PP:
+        return (f"浮亏 {before:.1f}% → {now_value:.1f}%"
+                f"（比上次重提时再深 ≥{REARM_LOSS_PP:g}pp）")
+    if (anchor["kind"] == "minimum_value" and before > 0
+            and now_value >= before * REARM_REDUCTION_RATIO):
+        return (f"需减额 {before:,.0f} → {now_value:,.0f} {current.get('currency') or ''}"
+                f"（≥{REARM_REDUCTION_RATIO:g}×）").replace(" （", "（")
+    return ""
+
+
+def _rearm_at(anchor) -> str:
+    # A breach with no number of its own (the US β row carries its value only in
+    # prose) has only the severity rail and the ceiling; say so rather than print "—".
+    if not anchor:
+        return "严重度升级"
+    if anchor.get("kind") == "pnl_pct":
+        return f"浮亏 ≤ {float(anchor['value']) - REARM_LOSS_PP:.1f}%"
+    return (f"需减额 ≥ {float(anchor['value']) * REARM_REDUCTION_RATIO:,.0f} "
+            f"{anchor.get('currency') or ''}").rstrip()
+
+
+def _adaptive(record: dict, portfolio: dict, now: datetime) -> dict:
+    """May today's brief let this breach stand, or must it raise it again?"""
+    prev = record.get("adaptive") or {}
+    today = now.date()
+    stance = _revealed_stance(record, portfolio, now)
+    blockers = []
+    if record.get("status") != "open":
+        blockers.append(f"status={record.get('status')}")
+    if (record.get("execution") or {}).get("status") == "confirmed":
+        blockers.append("execution confirmed")
+    if int(record.get("age_days") or 0) < STANDING_DECISION_DAYS:
+        blockers.append(f"open {record.get('age_days') or 0}d < {STANDING_DECISION_DAYS}d")
+    if stance["stance"] not in ("declined", "contrary"):
+        blockers.append(f"stance={stance['stance']}")
+    stances = list(prev.get("stances") or [])[-10:]
+    if blockers:
+        return {"eligible": False, "may_stand": False, "must_reissue": False,
+                "not_eligible_because": blockers, "stance": stance,
+                "stances": stances}
+
+    entering = not prev.get("eligible")
+    anchor = record.get("pressure") if entering else prev.get("anchor")
+    anchor_severity = record.get("severity") if entering else prev.get("anchor_severity")
+    last = prev.get("last_reissued_on") if not entering else None
+    # Entering: until today the plan re-issued it every morning, so today is the
+    # last reissue the ceiling counts from.
+    last = last or today.isoformat()
+    try:
+        since_last = (today - datetime.fromisoformat(last).date()).days
+    except ValueError:
+        since_last, last = 0, today.isoformat()
+    worse = _worsened(anchor, record.get("pressure"), anchor_severity,
+                      record.get("severity"))
+    ceiling = since_last >= REISSUE_CEILING_DAYS
+    must = bool(worse or ceiling)
+    reason = worse or (f"距上次重提 {since_last} 天（上限 {REISSUE_CEILING_DAYS} 天）"
+                       if ceiling else "")
+    return {
+        "eligible": True,
+        "may_stand": not must,
+        "must_reissue": must,
+        "must_reason": reason,
+        "stance": stance,
+        "anchor": anchor,
+        "anchor_severity": anchor_severity,
+        "last_reissued_on": last,
+        "days_since_reissue": since_last,
+        "forced_on": (datetime.fromisoformat(last).date()
+                      + timedelta(days=REISSUE_CEILING_DAYS)).isoformat(),
+        "rearm_at": _rearm_at(anchor),
+        "stances": stances,
+    }
+
+
+def may_stand(row: dict) -> bool:
+    """True when today's plan may hold this breach instead of re-issuing its cut."""
+    return bool((row.get("adaptive") or {}).get("may_stand"))
+
+
+def record_stances(path: Path, plan_date: str, decisions: list[dict]) -> list[dict]:
+    """File what today's plan did with each eligible breach. Harness-written.
+
+    `reissue` when the plan carries a cut/trim on one of the breach's targets, which
+    also re-anchors both rails; otherwise `stand`, with the call's own rationale as the
+    reason. Keyed on `plan_date`, so a postflight re-run replaces its own entry.
+    """
+    ledger = load_ledger(path)
+    by_ticker: dict[str, list[dict]] = {}
+    for decision in decisions or []:
+        by_ticker.setdefault(str(decision.get("ticker") or ""), []).append(decision)
+    filed = []
+    for record in ledger["records"]:
+        adaptive = record.get("adaptive") or {}
+        if record.get("status") != "open" or not adaptive.get("eligible"):
+            continue
+        mine = [d for t in sorted(_targets(record)) for d in by_ticker.get(t, [])]
+        cuts = [d for d in mine if d.get("action") in ("cut", "trim_on_rebound")]
+        choice = "reissue" if cuts else "stand"
+        why = ((cuts or mine or [{}])[0].get("rationale") or "")[:240]
+        entry = {"date": plan_date, "choice": choice, "why": why}
+        stances = [row for row in adaptive.get("stances") or []
+                   if row.get("date") != plan_date]
+        adaptive["stances"] = (stances + [entry])[-10:]
+        if choice == "reissue":
+            adaptive["last_reissued_on"] = plan_date
+            adaptive["anchor"] = record.get("pressure")
+            adaptive["anchor_severity"] = record.get("severity")
+        record["adaptive"] = adaptive
+        filed.append({"breach_id": record.get("breach_id"), **entry})
+    if filed:
+        ledger["updated_at"] = _stamp()
+        _atomic_write(path, ledger)
+    return filed
 
 
 #: The three lists a guardrail context carries, in the order the brief reads them.
@@ -495,6 +720,26 @@ def attach_breach_ids(guardrail: dict) -> dict:
             ref = evidence_ref(row)
             if ref:
                 row["evidence_id"] = ref
+    return out
+
+
+def attach_discipline(guardrail: dict, discipline: dict) -> dict:
+    """Copy each breach's durable `standing` and `adaptive` onto today's detector rows.
+
+    The packet reads `risk[].standing` off these rows (#1075) — and nothing had ever
+    put it there: `reconcile_guardrail` computed it into the ledger and the context's
+    `risk_discipline`, never into `risk_guardrail`, so every packet risk row carried
+    `standing: {}` and the "stood N days undecided" verdict reached the model only if
+    it went looking in a different part of the context. Joined by `breach_id`.
+    """
+    by_id = {row.get("breach_id"): row for row in (discipline or {}).get("records") or []}
+    out = copy.deepcopy(guardrail)
+    for key in ("breaches", "hard_stop_watch"):
+        for row in out.get(key) or []:
+            record = by_id.get(row.get("breach_id"))
+            if record:
+                row["standing"] = record.get("standing") or {}
+                row["adaptive"] = record.get("adaptive") or {}
     return out
 
 

--- a/src/clawock/harness/brief_postflight.py
+++ b/src/clawock/harness/brief_postflight.py
@@ -557,7 +557,9 @@ def validate_plan_json(path, context=None, decision_packet=None, *,
         }
         for b in gr.get('breaches', []):
             tk, leg = b.get('ticker'), b.get('leg')
-            if b.get('breach_id') in durable_overrides:
+            # A breach the book keeps declining may stand today — holding it is the
+            # plan writer's call, not an omission (risk.py `_adaptive`).
+            if b.get('breach_id') in durable_overrides or risk_discipline.may_stand(b):
                 continue
             if tk and tk not in trim_tickers:
                 issues.append(f'仓位硬闸未处理: {b["type"]} {tk} ({b["detail"]}) — '
@@ -569,7 +571,7 @@ def validate_plan_json(path, context=None, decision_packet=None, *,
                 issues.append(f'仓位硬闸未处理: {b["type"]}/{leg} ({b["detail"]}) — '
                               f'plan 里没有任何目标 ticker 的 trim/cut 动作')
         for s in gr.get('hard_stop_watch', []):
-            if s.get('breach_id') in durable_overrides:
+            if s.get('breach_id') in durable_overrides or risk_discipline.may_stand(s):
                 continue
             cut_tickers = {
                 d.get('ticker') for d in trims if d.get('action') == 'cut'
@@ -745,6 +747,24 @@ def write_publish_gate(status, today, *, reason=None):
     return gate
 
 
+def record_risk_stances(today, workspace=None):
+    """File what today's plan did with each breach allowed to stand (reissue/stand).
+
+    The harness writes it, from the validated plan — the model never touches the
+    breach ledger (#1433 is what a model-written ledger field looks like). A failure
+    here must not cost the day's commit: the rails then count from the last filed
+    reissue, which errs toward raising the breach again sooner, not later.
+    """
+    ws = Path(workspace) if workspace else WS
+    try:
+        plan = json.loads((ws / 'memory' / f'{today}-plan.json').read_text(encoding='utf-8'))
+        return risk_discipline.record_stances(
+            ws / 'memory' / 'risk_breaches.json', today, plan.get('decisions') or [])
+    except Exception as exc:  # noqa: BLE001 — see docstring
+        print(f'warn: risk stance filing failed: {type(exc).__name__}: {exc}', file=sys.stderr)
+        return []
+
+
 def maybe_commit(status, today, dry_run=False):
     if status == 'fail':
         return False, 'skipped (status=fail)'
@@ -757,6 +777,7 @@ def maybe_commit(status, today, dry_run=False):
         return False, 'skipped (dry-run)'
 
     log_decisions(today)   # upsert today's v2 plan (idempotent)
+    record_risk_stances(today)
     rebuild_dashboard()
 
     msg_suffix = ' (validation warnings)' if status == 'warn' else ''

--- a/src/clawock/harness/brief_preflight.py
+++ b/src/clawock/harness/brief_preflight.py
@@ -1910,13 +1910,19 @@ def main(argv=None):
     except Exception as e:
         discipline = {'error': f'{type(e).__name__}: {e}', 'records': []}
         issues.append(f'risk discipline reconcile failed: {type(e).__name__}')
+    else:
+        # The packet reads each row's durable state (`standing`, `adaptive`) off
+        # these rows; without this join every one of them arrived empty.
+        guardrail = risk_discipline.attach_discipline(guardrail, discipline)
     print(f'   guardrail: {guardrail["breach_count"]} breaches/stops — {guardrail["directive"][:64]}')
     if discipline.get('error'):
         print(f'   🔴 durable risk ledger failed: {discipline["error"]}')
     else:
         print(f'   durable risk ledger: {discipline.get("open_count", 0)} open / '
               f'{discipline.get("overridden_count", 0)} overridden / '
-              f'oldest {discipline.get("oldest_open_days", 0)}d')
+              f'oldest {discipline.get("oldest_open_days", 0)}d / '
+              f'may stand {discipline.get("may_stand_count", 0)} / '
+              f'must reissue {discipline.get("must_reissue_count", 0)}')
     for b in guardrail['breaches']:
         print(f'   ⛔ {b["type"]:20s} ({b["severity"]:6s}) {b["detail"][:78]}')
     for s in guardrail['hard_stop_watch']:

--- a/src/clawock/harness/brief_render.py
+++ b/src/clawock/harness/brief_render.py
@@ -406,7 +406,7 @@ def market_trend_section(context):
     return "\n".join(lines)
 
 
-def risk_section(context):
+def risk_section(context, plan=None):
     guard = context.get("risk_guardrail") or {}
     discipline = context.get("risk_discipline") or {}
     rows = []
@@ -440,7 +440,52 @@ def risk_section(context):
     directive = guard.get("directive")
     if directive:
         lines += ["", f"**directive**: {text(directive)}"]
+    standing = _standing_entries(guard, plan)
+    if standing:
+        lines += ["", "**长期未执行 · 自适应**（证据由账本算，今天提不提由模型判断，护栏到了必须提）",
+                  "", entries(standing)]
     return "\n".join(lines)
+
+
+_STANCE_WORDS = {
+    "declined": "同期在别的票有成交（最近 {last_trade_elsewhere}），这几只一股没减",
+    "contrary": "被要求减仓期间反向买入 {buys_on_target} 次（最近 {last_buy_on_target}）",
+}
+
+
+def _standing_entries(guard, plan):
+    """One block per breach the book keeps declining: evidence, today's call, rails."""
+    decisions = (plan or {}).get("decisions") or []
+    rows = []
+    for item in (guard.get("hard_stop_watch") or []) + (guard.get("breaches") or []):
+        adaptive = item.get("adaptive") or {}
+        if not adaptive.get("eligible"):
+            continue
+        stance = adaptive.get("stance") or {}
+        targets = set(stance.get("target_tickers") or [])
+        cuts = [d for d in decisions if str(d.get("ticker")) in targets
+                and d.get("action") in ("cut", "trim_on_rebound")]
+        if adaptive.get("must_reissue"):
+            today = f"必须重提：{text(adaptive.get('must_reason'))}"
+        elif cuts:
+            today = "模型判断今天重提"
+        else:
+            today = "模型判断今天维持，不重提"
+        words = _STANCE_WORDS.get(stance.get("stance"), "{stance}")
+        rows.append({
+            "title": (f"**{text(item.get('ticker') or item.get('leg'))}** · "
+                      f"{text(item.get('type'))} · 挂 {(item.get('standing') or {}).get('days_open', '?')} 天"),
+            "meta": [text(item.get("breach_id"))],
+            "fields": [
+                ("你的做法", words.format(**{
+                    k: text(v) if isinstance(v, str) or v is None else str(v)
+                    for k, v in stance.items()})),
+                ("今天", today),
+                ("护栏", f"{text(adaptive.get('rearm_at'))} 或到 {text(adaptive.get('forced_on'))}"
+                         " 必须重提"),
+            ],
+        })
+    return rows
 
 
 def breakeven_section(context):
@@ -904,7 +949,7 @@ def render_brief(context, judgment, plan, *, date=None, sector_scan=None):
         (PAGE_BOOK_PART, [
             header_section(context, judgment),
             concentration_section(context),
-            risk_section(context),
+            risk_section(context, plan),
             opportunity_section(context),
             breakeven_section(context),
             holdings_section(context),

--- a/tests/test_risk_adaptive_standing.py
+++ b/tests/test_risk_adaptive_standing.py
@@ -1,0 +1,232 @@
+"""Advice the book keeps declining may stand; the harness owns evidence and rails.
+
+kcn 2026-09-12:「我们长期不听的模型建议可以考虑有一个自适应机制」— and, asked how
+the system would know he does not want to deleverage:「你怎么判断我不想执行」. The
+answer these tests pin: from the book (shares unchanged on the targets, trades in
+other names, buys INTO the target), never from the model.
+"""
+import json
+
+from clawock.decision import packet
+from clawock.decision import plans
+from clawock.decision import risk
+from clawock.harness import brief_postflight
+from clawock.harness import brief_render
+
+
+OPENED = "2026-08-01"
+
+
+def _stop(pnl=-34.5, ticker="07226", leg="HK"):
+    return {"breaches": [], "breach_count": 1, "hard_stop_watch": [{
+        "type": "leveraged_hard_stop", "ticker": ticker, "leg": leg,
+        "pnl_pct": pnl, "severity": "critical",
+        "detail": f"{ticker} 浮亏 {pnl}% ≤ 硬止损线 -18%", "action": "cut",
+        "required_reduction": {"kind": "full_leveraged_position",
+                               "target_tickers": [ticker], "swap_to": "03033"},
+    }]}
+
+
+def _book(target_trades=(), other_trades=({"date": "2026-08-20", "action": "buy"},)):
+    return {"portfolios": {
+        "hk_stocks": {"holdings": [
+            {"ticker": "07226", "shares": 6200, "trades": list(target_trades)},
+        ]},
+        "us_stocks": {"holdings": [
+            {"ticker": "SKHY", "shares": 1, "trades": list(other_trades)},
+        ]},
+    }}
+
+
+def _history(tmp_path):
+    path = tmp_path / "history.jsonl"
+    path.write_text(json.dumps({"date": OPENED, "breaches": [], "hard_stop_watch": [
+        {"type": "leveraged_hard_stop", "ticker": "07226", "leg": "HK"}]}) + "\n")
+    return path
+
+
+def _run(tmp_path, now, guardrail=None, book=None):
+    return risk.reconcile_guardrail(
+        guardrail or _stop(), book or _book(), path=tmp_path / "risk.json",
+        history_path=_history(tmp_path), now=now)
+
+
+def _adaptive(result):
+    return result["records"][0]["adaptive"]
+
+
+# ── evidence: what the book shows, not what the model guesses ───────────────
+
+def test_trading_other_names_while_the_target_sits_untouched_is_a_decision(tmp_path):
+    adaptive = _adaptive(_run(tmp_path, "2026-09-11T00:00:00+00:00"))
+    assert adaptive["eligible"] and adaptive["may_stand"]
+    assert adaptive["stance"]["stance"] == "declined"
+    assert adaptive["stance"]["last_trade_elsewhere"] == "2026-08-20"
+
+
+def test_buying_into_a_name_told_to_cut_is_the_strongest_vote(tmp_path):
+    book = _book(target_trades=[{"date": "2026-08-12", "action": "buy"},
+                                {"date": "2026-08-19", "action": "buy"}])
+    stance = _adaptive(_run(tmp_path, "2026-09-11T00:00:00+00:00", book=book))["stance"]
+    assert stance["stance"] == "contrary"
+    assert stance["buys_on_target"] == 2 and stance["last_buy_on_target"] == "2026-08-19"
+
+
+def test_no_recent_trading_at_all_is_not_a_decision(tmp_path):
+    """Away is not declining: an old trade elsewhere says nothing about today."""
+    book = _book(other_trades=[{"date": "2026-07-01", "action": "buy"}])
+    adaptive = _adaptive(_run(tmp_path, "2026-09-11T00:00:00+00:00", book=book))
+    assert not adaptive["eligible"]
+    assert "stance=silent" in adaptive["not_eligible_because"]
+
+
+def test_selling_the_target_means_acting_and_the_rule_stays_loud(tmp_path):
+    book = _book(target_trades=[{"date": "2026-09-01", "action": "sell", "shares": 100}])
+    adaptive = _adaptive(_run(tmp_path, "2026-09-11T00:00:00+00:00", book=book))
+    assert not adaptive["eligible"] and "stance=acting" in adaptive["not_eligible_because"]
+
+
+def test_a_month_without_any_trade_turns_it_loud_again(tmp_path):
+    """Declining is judged on recent behaviour; a book gone quiet for 30 days is
+    treated as someone away, and the rule goes back to being raised every day."""
+    assert _adaptive(_run(tmp_path, "2026-09-11T00:00:00+00:00"))["may_stand"]
+    later = _adaptive(_run(tmp_path, "2026-09-25T00:00:00+00:00"))
+    assert not later["eligible"] and "stance=silent" in later["not_eligible_because"]
+
+
+def test_ten_days_first(tmp_path):
+    adaptive = _adaptive(_run(tmp_path, "2026-08-08T00:00:00+00:00"))
+    assert not adaptive["eligible"]
+
+
+def test_old_evidence_on_other_tickers_does_not_block_the_current_targets(tmp_path):
+    """The US leverage breach carries July MSFU/PLTU sells as `evidence_present`
+    while its targets today are RKLX/SPCH. Stance reads the CURRENT targets."""
+    result = _run(tmp_path, "2026-09-11T00:00:00+00:00")
+    ledger = json.loads((tmp_path / "risk.json").read_text())
+    ledger["records"][0]["execution"] = {"status": "evidence_present", "evidence": [
+        {"ticker": "MSFU", "date": "2026-07-30", "action": "sell"}]}
+    (tmp_path / "risk.json").write_text(json.dumps(ledger))
+    assert _adaptive(_run(tmp_path, "2026-09-12T00:00:00+00:00"))["eligible"]
+    assert result  # first run only seeded the ledger
+
+
+# ── rails the model cannot switch off ───────────────────────────────────────
+
+def test_ten_more_points_of_loss_forces_it_back(tmp_path):
+    _run(tmp_path, "2026-09-11T00:00:00+00:00", guardrail=_stop(pnl=-34.5))
+    near = _adaptive(_run(tmp_path, "2026-09-12T00:00:00+00:00", guardrail=_stop(pnl=-44.0)))
+    assert near["may_stand"] and near["rearm_at"] == "浮亏 ≤ -44.5%"
+    deep = _adaptive(_run(tmp_path, "2026-09-13T00:00:00+00:00", guardrail=_stop(pnl=-44.6)))
+    assert deep["must_reissue"] and not deep["may_stand"]
+    assert "-34.5% → -44.6%" in deep["must_reason"]
+
+
+def test_the_ceiling_forces_it_back_after_28_days_without_a_reissue(tmp_path):
+    active = _book(other_trades=[{"date": "2026-08-20", "action": "buy"},
+                                 {"date": "2026-10-01", "action": "buy"}])
+    _run(tmp_path, "2026-09-11T00:00:00+00:00", book=active)
+    assert _adaptive(_run(tmp_path, "2026-10-08T00:00:00+00:00", book=active))["may_stand"]
+    late = _adaptive(_run(tmp_path, "2026-10-09T00:00:00+00:00", book=active))
+    assert late["must_reissue"] and "28" in late["must_reason"]
+
+
+# ── the choice is filed by the harness, from the validated plan ─────────────
+
+def test_a_reissue_re_anchors_both_rails_and_a_stand_does_not(tmp_path):
+    path = tmp_path / "risk.json"
+    _run(tmp_path, "2026-09-11T00:00:00+00:00", guardrail=_stop(pnl=-34.5))
+    hold = [{"ticker": "07226", "action": "hold_and_watch", "rationale": "维持"}]
+    filed = risk.record_stances(path, "2026-09-11", hold)
+    assert [row["choice"] for row in filed] == ["stand"]
+
+    active = _book(other_trades=[{"date": "2026-09-15", "action": "buy"}])
+    _run(tmp_path, "2026-09-20T00:00:00+00:00", guardrail=_stop(pnl=-40.0), book=active)
+    cut = [{"ticker": "07226", "action": "cut", "rationale": "跌穿 4800，今天不同"}]
+    risk.record_stances(path, "2026-09-20", cut)
+    risk.record_stances(path, "2026-09-20", cut)  # a postflight re-run replaces, not appends
+
+    record = json.loads(path.read_text())["records"][0]
+    assert record["adaptive"]["last_reissued_on"] == "2026-09-20"
+    assert record["adaptive"]["anchor"]["value"] == -40.0
+    assert [row["date"] for row in record["adaptive"]["stances"]] == ["2026-09-11", "2026-09-20"]
+    after = _adaptive(_run(tmp_path, "2026-09-21T00:00:00+00:00",
+                           guardrail=_stop(pnl=-45.0), book=active))
+    assert after["may_stand"], "re-anchored at -40: -45 is 5pp deeper, not 10"
+
+
+# ── consumers ───────────────────────────────────────────────────────────────
+
+def test_attach_discipline_puts_the_ledger_state_on_the_rows_the_packet_reads(tmp_path):
+    guardrail = risk.attach_breach_ids(_stop())
+    discipline = _run(tmp_path, "2026-09-11T00:00:00+00:00", guardrail=guardrail)
+    rows = risk.attach_discipline(guardrail, discipline)["hard_stop_watch"]
+    assert rows[0]["standing"]["days_open"] >= 10, "standing used to arrive empty (#1075)"
+    assert rows[0]["adaptive"]["may_stand"]
+
+
+def _risk_row(may_stand, kind="hard_stop"):
+    return {"kind": kind, "adaptive": {"may_stand": may_stand}}
+
+
+def test_a_name_whose_breaches_may_all_stand_can_hold_but_still_cannot_add():
+    constraints = packet._constraints(
+        6200, [_risk_row(True), _risk_row(True, kind="breach")], [], {}, {})
+    assert "hold_and_watch" in constraints["allowed_actions"]
+    assert "cut" in constraints["allowed_actions"]
+    assert constraints["forced_action_one_of"] == []
+    assert not {"add_only_on_trigger", "add_on_breakout"} & set(constraints["allowed_actions"])
+
+
+def test_one_breach_that_may_not_stand_keeps_the_action_forced():
+    constraints = packet._constraints(
+        6200, [_risk_row(True, kind="breach"), _risk_row(False)], [], {}, {})
+    assert constraints["forced_action_one_of"] == ["cut"]
+
+
+def test_postflight_does_not_call_a_stood_hard_stop_unhandled(tmp_path):
+    def unhandled(may_stand):
+        context = {"risk_guardrail": {"breach_count": 1, "breaches": [], "hard_stop_watch": [{
+            "ticker": "07226", "detail": "x", "breach_id": "risk-x",
+            "adaptive": {"may_stand": may_stand}}]}}
+        plan = tmp_path / "plan.json"
+        plan.write_text(json.dumps({"decisions": [{
+            "ticker": "07226", "action": "hold_and_watch",
+            "strategy_id": "risk_rebalance", "driven_by": "risk_rule"}]}))
+        issues = brief_postflight.validate_plan_json(plan, context=context, normalized=False)
+        return [i for i in issues if "硬止损未处理" in i and "07226" in i]
+
+    assert unhandled(False), "the gate itself must still fire"
+    assert not unhandled(True)
+
+
+def test_intraday_slots_say_a_stood_cut_instead_of_re_reading_it(tmp_path):
+    memory = tmp_path / "memory"
+    memory.mkdir()
+    (memory / "risk_breaches.json").write_text(json.dumps({"schema_version": 1, "records": [{
+        "status": "open", "ticker": "07226", "required_reduction": {},
+        "adaptive": {"may_stand": True, "stances": [{"date": "2026-09-14", "choice": "stand"}]},
+    }]}))
+    ledger = tmp_path / "decisions.jsonl"
+    ledger.write_text(json.dumps({
+        "decision_id": "d1", "plan_date": "2026-09-11", "ticker": "07226", "leg": "HK",
+        "action": "cut", "driven_by": "risk_rule", "strategy_id": "risk_rebalance",
+        "execution": {"status": plans.OPEN_EXECUTION}, "evaluation": {"status": "pending"},
+    }) + "\n")
+    context = plans.open_decisions_context(
+        today="2026-09-14", ledger=ledger, memory_dir=memory)
+    assert context.get("standing_by_choice") == ["07226"]
+    assert not context.get("open")
+
+
+def test_the_brief_shows_evidence_choice_and_rails(tmp_path):
+    guardrail = risk.attach_breach_ids(_stop())
+    discipline = _run(tmp_path, "2026-09-11T00:00:00+00:00", guardrail=guardrail)
+    context = {"risk_guardrail": risk.attach_discipline(guardrail, discipline),
+               "risk_discipline": discipline}
+    plan = {"decisions": [{"ticker": "07226", "action": "hold_and_watch"}]}
+    section = brief_render.risk_section(context, plan)
+    assert "长期未执行 · 自适应" in section
+    assert "同期在别的票有成交（最近 2026-08-20）" in section
+    assert "模型判断今天维持" in section
+    assert "浮亏 ≤ -44.5%" in section and "2026-10-09" in section


### PR DESCRIPTION
kcn 09-12：「我们长期不听的模型建议可以考虑有一个自适应机制」「有没有一种更 llm 判断的方法」「你怎么判断我不想执行」。

实测：30 天 61 条主动建议没照做，58 条是同样三只票的 risk_rule cut（07226 / RKLX / SPCH），每天重发 29 / 58 / 57 天。

## 分工
| 谁 | 管什么 |
|---|---|
| harness | **证据**（`_revealed_stance`，只看账本和成交）：目标票卖过=acting；反向买入=contrary（SPCH 被要求减期间买了 13 次）；30 天内别的票有成交、目标票没减=declined；30 天没交易=silent（可能不在，不算表态）。挂 ≥10 天且 declined/contrary ⇒ eligible |
| harness | **护栏**（模型关不掉）：比上次重提再恶化（浮亏再深 10pp / 需减额 1.5× / 严重度升级），或距上次重提满 28 天 ⇒ `must_reissue` |
| 模型 | **判断**：`may_stand` 时选重提（第一句写今天和上次比变了什么）或维持（hold_and_watch，在 kcn 已选的打法里给有用的话）。加仓冻结不变 |
| harness | **记账**：postflight 从校验过的 plan 记下选择（`record_stances`，按日期幂等）；重提重新锚定护栏。模型不写账本 |

## 接线
- **潜伏 bug**：preflight 从没把账本 `standing` 并回 guardrail 行 ⇒ packet 里每条风险 `standing: {}`（#1075 的判词从没经 packet 到过模型）。`attach_discipline` 按 breach_id 并上 standing + adaptive。
- packet `_constraints`：违规全部 may_stand ⇒ 允许 hold 不强制；有一条不能维持 ⇒ 照旧强制。
- postflight 的「仓位硬闸/杠杆硬止损未处理」跳过 may_stand。
- `open_decisions_context`：维持的票不再在盘中把旧 cut 当未成交换仓重复念，改 `standing_by_choice` 一行说出来（不结算）。
- 简报风控硬闸一节加「长期未执行 · 自适应」：你的做法 / 今天 / 护栏。
- SKILL 写明判断规则。

## 线上账本干跑（now=09-14）
6 条可维持、0 条必须重提。SPCH 硬止损因浮亏在 -18% 上下反复、每次重开从头计天（4 天），仍强制 cut——保守一侧，保留。

## 验证
- 新测试 16 条（证据四类、10 天门槛、30 天无交易回到强制、旧证据不挡当前目标、10pp 与 28 天护栏、重提重锚、幂等、packet/postflight/plans/brief 各消费方）
- 本地全量 3677 passed

https://claude.ai/code/session_01Dkn6aA3Ru8AQUW8qoz7ryV
