### PR TITLE
wechat: 数腾讯「每条入站约 10 条」的推送额度，最后三条能送达的消息提醒续上

### DIFF
--- a/src/clawock/harness/_watchdog_common.py
+++ b/src/clawock/harness/_watchdog_common.py
@@ -391,8 +391,19 @@ def send_wechat(channel, to, account, message, dry_run):
     migrating the watchdogs' mirror-on-suspicion logic onto it is a separate
     change with live delivery consequences.
     """
+    from clawock.providers import wechat_allowance
+    # Every WeChat push goes through here (brief / report / intraday postflight),
+    # which makes this the one place that can count Tencent's per-inbound
+    # allowance and, on the last few that can still land, ask kcn to renew it.
+    try:
+        message, _remaining = wechat_allowance.annotate(to, message)
+    except Exception:  # noqa: BLE001 — a counting failure must never cost the send
+        pass
     result = _delivery(account).send(channel, str(to), message, dry_run=dry_run)
-    return result.status != 'failed', result.detail
+    ok = result.status != 'failed'
+    if not dry_run:
+        wechat_allowance.record(to, message, ok)
+    return ok, result.detail
 
 
 def send_telegram(target, message, dry_run):

--- a/src/clawock/harness/_watchdog_common.py
+++ b/src/clawock/harness/_watchdog_common.py
@@ -395,15 +395,21 @@ def send_wechat(channel, to, account, message, dry_run):
     # Every WeChat push goes through here (brief / report / intraday postflight),
     # which makes this the one place that can count Tencent's per-inbound
     # allowance and, on the last few that can still land, ask kcn to renew it.
+    ledger = wechat_sends_ledger()
     try:
-        message, _remaining = wechat_allowance.annotate(to, message)
+        message, _remaining = wechat_allowance.annotate(to, message, ledger=ledger)
     except Exception:  # noqa: BLE001 — a counting failure must never cost the send
         pass
     result = _delivery(account).send(channel, str(to), message, dry_run=dry_run)
     ok = result.status != 'failed'
     if not dry_run:
-        wechat_allowance.record(to, message, ok)
+        wechat_allowance.record(to, message, ok, ledger=ledger)
     return ok, result.detail
+
+
+def wechat_sends_ledger():
+    """Where this desk counts its WeChat pushes (runtime state, gitignored)."""
+    return workspace_root() / 'memory' / '.tmp' / 'wechat-sends.json'
 
 
 def send_telegram(target, message, dry_run):

--- a/src/clawock/providers/openclaw.py
+++ b/src/clawock/providers/openclaw.py
@@ -76,6 +76,10 @@ class OpenClawPaths:
         return self.home / "gateway-supervisor-restart-handoff.json"
 
     @property
+    def weixin_accounts_dir(self) -> Path:
+        return self.home / "openclaw-weixin" / "accounts"
+
+    @property
     def workspace_memory_tmp(self) -> Path:
         return self.workspace / "memory" / ".tmp"
 

--- a/src/clawock/providers/wechat_allowance.py
+++ b/src/clawock/providers/wechat_allowance.py
@@ -1,0 +1,123 @@
+"""WeChat's per-inbound send allowance, and the line that asks kcn to renew it.
+
+Tencent's iLink bot API lets a bot send about ten messages after each message the
+user sends it, within a 24-hour session; past that, `sendmessage` answers
+`ret=-2 prepare failed` until the user writes again (Tencent/openclaw-weixin#81,
+acknowledged by the maintainers in #202, unchanged as of 2026-09-11). Measured on
+this desk 2026-09-07…11: eight inbound-to-inbound runs, each ~9 pushes landing
+and every later push failing — the bot's own chat reply spends the tenth. With
+~26 slots a day and 2–3 messages from kcn, part of every day was going to drop,
+and 08:03 dropped most: the overnight monitor and the US close spend the
+allowance first.
+
+Nothing on this side can raise the allowance; a keep-alive was declined, and
+sending without a context token (what `openclaw message send` does anyway — the
+CLI loads the plugin fresh and never restores its token map) is refused the same
+way. What this module does is count, so the last messages that can still land say
+so: kcn 2026-09-12:「提醒我刷新」.
+
+The count is local: pushes that this desk sent successfully since the user's last
+inbound, whose time is the mtime of the plugin's context-token file (the gateway
+rewrites it on every inbound). When that file is missing or does not name the
+recipient, nothing is annotated — an unknown count is not guessed.
+"""
+from __future__ import annotations
+
+import json
+import math
+import time
+from pathlib import Path
+
+from clawock.workspace import workspace_root
+
+#: Server-side, per user inbound (Tencent/openclaw-weixin#81).
+ALLOWANCE = 10
+#: The bot's chat reply to that inbound spends one.
+RESERVED_FOR_REPLY = 1
+#: Annotate while this many pushes, or fewer, remain after the one being sent.
+NOTE_AT_REMAINING = 2
+#: The plugin splits text at this many characters, and every chunk is a message.
+CHUNK_CHARS = 4000
+_KEEP = 200
+
+
+def _ledger_path(workspace=None) -> Path:
+    return Path(workspace or workspace_root()) / "memory" / ".tmp" / "wechat-sends.json"
+
+
+def _accounts_dir() -> Path:
+    from clawock.providers.openclaw import runtime_paths
+    return runtime_paths().weixin_accounts_dir
+
+
+def last_inbound(target, accounts_dir=None) -> float | None:
+    """Epoch seconds of the user's last message to the bot, or None if unknown."""
+    folder = Path(accounts_dir) if accounts_dir else _accounts_dir()
+    newest = None
+    for path in folder.glob("*.context-tokens.json"):
+        try:
+            if str(target) in json.loads(path.read_text(encoding="utf-8")):
+                mtime = path.stat().st_mtime
+                newest = mtime if newest is None else max(newest, mtime)
+        except (OSError, ValueError):
+            continue
+    return newest
+
+
+def chunks(message) -> int:
+    return max(1, math.ceil(len(str(message or "")) / CHUNK_CHARS))
+
+
+def _sends(workspace=None) -> list[dict]:
+    try:
+        rows = json.loads(_ledger_path(workspace).read_text(encoding="utf-8"))
+        return rows if isinstance(rows, list) else []
+    except (OSError, ValueError):
+        return []
+
+
+def used_since(target, since, workspace=None) -> int:
+    return sum(int(row.get("chunks") or 1) for row in _sends(workspace)
+               if row.get("target") == str(target) and row.get("ok")
+               and float(row.get("ts") or 0) >= since)
+
+
+def remaining_after(target, message, *, workspace=None, accounts_dir=None):
+    """Pushes left after this one lands, or None when the count is unknown."""
+    since = last_inbound(target, accounts_dir)
+    if since is None:
+        return None
+    budget = ALLOWANCE - RESERVED_FOR_REPLY
+    return budget - used_since(target, since, workspace) - chunks(message)
+
+
+def note(remaining) -> str:
+    if remaining is None or remaining > NOTE_AT_REMAINING:
+        return ""
+    head = ("📮 这是本轮最后一条微信推送" if remaining <= 0
+            else f"📮 微信本轮还能再推 {remaining} 条")
+    return (f"{head}（腾讯规定你每发一条消息，bot 最多推约 10 条）。"
+            "回我任意一个字就续满；不回的话，之后的推送只在 Telegram。")
+
+
+def annotate(target, message, *, workspace=None, accounts_dir=None):
+    """(message with the renewal line appended when due, remaining-or-None)."""
+    remaining = remaining_after(target, message, workspace=workspace,
+                                accounts_dir=accounts_dir)
+    line = note(remaining)
+    return (f"{message.rstrip()}\n\n{line}" if line else message), remaining
+
+
+def record(target, message, ok, *, workspace=None, now=None) -> None:
+    """File one send. Best effort: losing a row only makes the note late."""
+    rows = _sends(workspace)
+    rows.append({"ts": now if now is not None else time.time(), "target": str(target),
+                 "ok": bool(ok), "chunks": chunks(message)})
+    path = _ledger_path(workspace)
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = path.with_suffix(".tmp")
+        tmp.write_text(json.dumps(rows[-_KEEP:], ensure_ascii=False), encoding="utf-8")
+        tmp.replace(path)
+    except OSError:
+        pass

--- a/src/clawock/providers/wechat_allowance.py
+++ b/src/clawock/providers/wechat_allowance.py
@@ -28,8 +28,6 @@ import math
 import time
 from pathlib import Path
 
-from clawock.workspace import workspace_root
-
 #: Server-side, per user inbound (Tencent/openclaw-weixin#81).
 ALLOWANCE = 10
 #: The bot's chat reply to that inbound spends one.
@@ -39,10 +37,6 @@ NOTE_AT_REMAINING = 2
 #: The plugin splits text at this many characters, and every chunk is a message.
 CHUNK_CHARS = 4000
 _KEEP = 200
-
-
-def _ledger_path(workspace=None) -> Path:
-    return Path(workspace or workspace_root()) / "memory" / ".tmp" / "wechat-sends.json"
 
 
 def _accounts_dir() -> Path:
@@ -68,27 +62,27 @@ def chunks(message) -> int:
     return max(1, math.ceil(len(str(message or "")) / CHUNK_CHARS))
 
 
-def _sends(workspace=None) -> list[dict]:
+def _sends(ledger: Path) -> list[dict]:
     try:
-        rows = json.loads(_ledger_path(workspace).read_text(encoding="utf-8"))
+        rows = json.loads(Path(ledger).read_text(encoding="utf-8"))
         return rows if isinstance(rows, list) else []
     except (OSError, ValueError):
         return []
 
 
-def used_since(target, since, workspace=None) -> int:
-    return sum(int(row.get("chunks") or 1) for row in _sends(workspace)
+def used_since(target, since, ledger: Path) -> int:
+    return sum(int(row.get("chunks") or 1) for row in _sends(ledger)
                if row.get("target") == str(target) and row.get("ok")
                and float(row.get("ts") or 0) >= since)
 
 
-def remaining_after(target, message, *, workspace=None, accounts_dir=None):
+def remaining_after(target, message, *, ledger: Path, accounts_dir=None):
     """Pushes left after this one lands, or None when the count is unknown."""
     since = last_inbound(target, accounts_dir)
     if since is None:
         return None
     budget = ALLOWANCE - RESERVED_FOR_REPLY
-    return budget - used_since(target, since, workspace) - chunks(message)
+    return budget - used_since(target, since, ledger) - chunks(message)
 
 
 def note(remaining) -> str:
@@ -100,20 +94,25 @@ def note(remaining) -> str:
             "回我任意一个字就续满；不回的话，之后的推送只在 Telegram。")
 
 
-def annotate(target, message, *, workspace=None, accounts_dir=None):
+def annotate(target, message, *, ledger: Path, accounts_dir=None):
     """(message with the renewal line appended when due, remaining-or-None)."""
-    remaining = remaining_after(target, message, workspace=workspace,
+    remaining = remaining_after(target, message, ledger=ledger,
                                 accounts_dir=accounts_dir)
     line = note(remaining)
     return (f"{message.rstrip()}\n\n{line}" if line else message), remaining
 
 
-def record(target, message, ok, *, workspace=None, now=None) -> None:
-    """File one send. Best effort: losing a row only makes the note late."""
-    rows = _sends(workspace)
+def record(target, message, ok, *, ledger: Path, now=None) -> None:
+    """File one send. Best effort: losing a row only makes the note late.
+
+    The ledger path is the caller's: where a desk keeps its runtime state is the
+    harness's business, not the delivery provider's (providers import no
+    workspace layout).
+    """
+    rows = _sends(ledger)
     rows.append({"ts": now if now is not None else time.time(), "target": str(target),
                  "ok": bool(ok), "chunks": chunks(message)})
-    path = _ledger_path(workspace)
+    path = Path(ledger)
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
         tmp = path.with_suffix(".tmp")

--- a/tests/test_wechat_allowance.py
+++ b/tests/test_wechat_allowance.py
@@ -49,7 +49,7 @@ def test_a_new_inbound_resets_the_count(tmp_path):
 
 
 def test_failed_sends_spend_nothing_and_long_messages_spend_per_chunk(tmp_path):
-    accounts = _inbound(tmp_path)
+    _inbound(tmp_path)
     allowance.record(KCN, "x", False, ledger=tmp_path / "sends.json", now=INBOUND + 10)
     allowance.record(KCN, "长" * 8001, True, ledger=tmp_path / "sends.json", now=INBOUND + 20)
     assert allowance.used_since(KCN, INBOUND, ledger=tmp_path / "sends.json") == 3

--- a/tests/test_wechat_allowance.py
+++ b/tests/test_wechat_allowance.py
@@ -1,0 +1,116 @@
+"""Tencent's ~10-per-inbound WeChat allowance: count it, and ask to renew it in time.
+
+kcn 2026-09-12:「提醒我刷新」. Replayed on the 2026-09-11 11:14 inbound: nine pushes
+landed and the tenth failed, so the note has to ride on pushes 7, 8 and 9 — the
+last ones that can still reach him.
+"""
+import json
+import os
+
+from clawock.harness import _watchdog_common as common
+from clawock.providers import wechat_allowance as allowance
+
+KCN = "o9cq80-hGTruM-OSs8kNmDOtLVZI@im.wechat"
+INBOUND = 1_789_100_000.0
+
+
+def _inbound(tmp_path, at=INBOUND, target=KCN):
+    accounts = tmp_path / "accounts"
+    accounts.mkdir(exist_ok=True)
+    path = accounts / "bot.context-tokens.json"
+    path.write_text(json.dumps({target: "token-value-not-read"}))
+    os.utime(path, (at, at))
+    return accounts
+
+
+def _push(tmp_path, accounts, n, message="盘中盯盘"):
+    out = []
+    for i in range(n):
+        text, remaining = allowance.annotate(KCN, message, workspace=tmp_path,
+                                             accounts_dir=accounts)
+        allowance.record(KCN, text, True, workspace=tmp_path, now=INBOUND + 60 * (i + 1))
+        out.append((remaining, "📮" in text))
+    return out
+
+
+def test_the_last_three_pushes_that_can_land_carry_the_note(tmp_path):
+    accounts = _inbound(tmp_path)
+    pushes = _push(tmp_path, accounts, 9)
+    assert [r for r, _ in pushes] == [8, 7, 6, 5, 4, 3, 2, 1, 0]
+    assert [noted for _, noted in pushes] == [False] * 6 + [True] * 3
+
+
+def test_a_new_inbound_resets_the_count(tmp_path):
+    accounts = _inbound(tmp_path)
+    _push(tmp_path, accounts, 9)
+    accounts = _inbound(tmp_path, at=INBOUND + 3600)
+    text, remaining = allowance.annotate(KCN, "x", workspace=tmp_path, accounts_dir=accounts)
+    assert remaining == 8 and "📮" not in text
+
+
+def test_failed_sends_spend_nothing_and_long_messages_spend_per_chunk(tmp_path):
+    accounts = _inbound(tmp_path)
+    allowance.record(KCN, "x", False, workspace=tmp_path, now=INBOUND + 10)
+    allowance.record(KCN, "长" * 8001, True, workspace=tmp_path, now=INBOUND + 20)
+    assert allowance.used_since(KCN, INBOUND, workspace=tmp_path) == 3
+
+
+def test_an_unknown_count_is_not_guessed(tmp_path):
+    empty = tmp_path / "accounts"
+    empty.mkdir()
+    text, remaining = allowance.annotate(KCN, "简报", workspace=tmp_path, accounts_dir=empty)
+    assert remaining is None and text == "简报"
+    other = _inbound(tmp_path, target="someone-else@im.wechat")
+    assert allowance.annotate(KCN, "简报", workspace=tmp_path, accounts_dir=other)[1] is None
+
+
+def test_the_last_one_says_it_is_the_last_and_how_to_renew():
+    assert "最后一条" in allowance.note(0) and "回我任意一个字" in allowance.note(0)
+    assert "还能再推 2 条" in allowance.note(2)
+    assert allowance.note(3) == "" and allowance.note(None) == ""
+
+
+def test_send_wechat_annotates_and_records_but_a_dry_run_records_nothing(tmp_path, monkeypatch):
+    sent = []
+
+    class Result:
+        status, detail = "unknown", "ok"
+
+    class Provider:
+        def send(self, channel, to, message, dry_run=False):
+            sent.append(message)
+            return Result()
+
+    accounts = _inbound(tmp_path)
+    monkeypatch.setattr(common, "_delivery", lambda account=None: Provider())
+    monkeypatch.setattr(allowance, "_accounts_dir", lambda: accounts)
+    monkeypatch.setattr(allowance, "_ledger_path",
+                        lambda workspace=None: tmp_path / "sends.json")
+    for _ in range(7):
+        common.send_wechat("openclaw-weixin", KCN, None, "报告", dry_run=False)
+    assert "📮" in sent[-1] and "📮" not in sent[-2]
+
+    before = (tmp_path / "sends.json").read_text()
+    common.send_wechat("openclaw-weixin", KCN, None, "报告", dry_run=True)
+    assert (tmp_path / "sends.json").read_text() == before
+
+
+def test_a_counting_failure_never_costs_the_send(monkeypatch):
+    sent = []
+
+    class Result:
+        status, detail = "unknown", "ok"
+
+    class Provider:
+        def send(self, channel, to, message, dry_run=False):
+            sent.append(message)
+            return Result()
+
+    def broken(*a, **k):
+        raise RuntimeError("disk gone")
+
+    monkeypatch.setattr(common, "_delivery", lambda account=None: Provider())
+    monkeypatch.setattr(allowance, "annotate", broken)
+    monkeypatch.setattr(allowance, "record", lambda *a, **k: None)
+    assert common.send_wechat("openclaw-weixin", KCN, None, "简报", dry_run=False)[0]
+    assert sent == ["简报"]

--- a/tests/test_wechat_allowance.py
+++ b/tests/test_wechat_allowance.py
@@ -26,9 +26,9 @@ def _inbound(tmp_path, at=INBOUND, target=KCN):
 def _push(tmp_path, accounts, n, message="盘中盯盘"):
     out = []
     for i in range(n):
-        text, remaining = allowance.annotate(KCN, message, workspace=tmp_path,
+        text, remaining = allowance.annotate(KCN, message, ledger=tmp_path / "sends.json",
                                              accounts_dir=accounts)
-        allowance.record(KCN, text, True, workspace=tmp_path, now=INBOUND + 60 * (i + 1))
+        allowance.record(KCN, text, True, ledger=tmp_path / "sends.json", now=INBOUND + 60 * (i + 1))
         out.append((remaining, "📮" in text))
     return out
 
@@ -44,24 +44,24 @@ def test_a_new_inbound_resets_the_count(tmp_path):
     accounts = _inbound(tmp_path)
     _push(tmp_path, accounts, 9)
     accounts = _inbound(tmp_path, at=INBOUND + 3600)
-    text, remaining = allowance.annotate(KCN, "x", workspace=tmp_path, accounts_dir=accounts)
+    text, remaining = allowance.annotate(KCN, "x", ledger=tmp_path / "sends.json", accounts_dir=accounts)
     assert remaining == 8 and "📮" not in text
 
 
 def test_failed_sends_spend_nothing_and_long_messages_spend_per_chunk(tmp_path):
     accounts = _inbound(tmp_path)
-    allowance.record(KCN, "x", False, workspace=tmp_path, now=INBOUND + 10)
-    allowance.record(KCN, "长" * 8001, True, workspace=tmp_path, now=INBOUND + 20)
-    assert allowance.used_since(KCN, INBOUND, workspace=tmp_path) == 3
+    allowance.record(KCN, "x", False, ledger=tmp_path / "sends.json", now=INBOUND + 10)
+    allowance.record(KCN, "长" * 8001, True, ledger=tmp_path / "sends.json", now=INBOUND + 20)
+    assert allowance.used_since(KCN, INBOUND, ledger=tmp_path / "sends.json") == 3
 
 
 def test_an_unknown_count_is_not_guessed(tmp_path):
     empty = tmp_path / "accounts"
     empty.mkdir()
-    text, remaining = allowance.annotate(KCN, "简报", workspace=tmp_path, accounts_dir=empty)
+    text, remaining = allowance.annotate(KCN, "简报", ledger=tmp_path / "sends.json", accounts_dir=empty)
     assert remaining is None and text == "简报"
     other = _inbound(tmp_path, target="someone-else@im.wechat")
-    assert allowance.annotate(KCN, "简报", workspace=tmp_path, accounts_dir=other)[1] is None
+    assert allowance.annotate(KCN, "简报", ledger=tmp_path / "sends.json", accounts_dir=other)[1] is None
 
 
 def test_the_last_one_says_it_is_the_last_and_how_to_renew():
@@ -84,8 +84,7 @@ def test_send_wechat_annotates_and_records_but_a_dry_run_records_nothing(tmp_pat
     accounts = _inbound(tmp_path)
     monkeypatch.setattr(common, "_delivery", lambda account=None: Provider())
     monkeypatch.setattr(allowance, "_accounts_dir", lambda: accounts)
-    monkeypatch.setattr(allowance, "_ledger_path",
-                        lambda workspace=None: tmp_path / "sends.json")
+    monkeypatch.setattr(common, "wechat_sends_ledger", lambda: tmp_path / "sends.json")
     for _ in range(7):
         common.send_wechat("openclaw-weixin", KCN, None, "报告", dry_run=False)
     assert "📮" in sent[-1] and "📮" not in sent[-2]
@@ -93,6 +92,19 @@ def test_send_wechat_annotates_and_records_but_a_dry_run_records_nothing(tmp_pat
     before = (tmp_path / "sends.json").read_text()
     common.send_wechat("openclaw-weixin", KCN, None, "报告", dry_run=True)
     assert (tmp_path / "sends.json").read_text() == before
+
+
+def test_the_provider_does_not_know_the_workspace_layout():
+    """Decoupled on purpose (kcn 2026-09-12:「注意我们是好不容易解耦的」): the
+    delivery provider is handed its ledger; it imports no workspace module."""
+    import ast
+    import inspect
+    tree = ast.parse(inspect.getsource(allowance))
+    imported = {node.module for node in ast.walk(tree)
+                if isinstance(node, ast.ImportFrom) and node.module}
+    imported |= {alias.name for node in ast.walk(tree) if isinstance(node, ast.Import)
+                 for alias in node.names}
+    assert not {m for m in imported if m.startswith("clawock.workspace")}
 
 
 def test_a_counting_failure_never_costs_the_send(monkeypatch):


### PR DESCRIPTION
## 背景
微信掉投真因（09-12 查清）：iLink 每条用户消息后 bot 只能推约 10 条，超出后 `ret=-2 prepare failed` 直到用户再发消息（[Tencent/openclaw-weixin#81](https://github.com/Tencent/openclaw-weixin/issues/81)；维护者在 [#202](https://github.com/Tencent/openclaw-weixin/issues/202) 确认，至今未改）。本台 09-07～11 八段数据都是约 9 条送达 + 聊天回复 1 条后开始失败。

kcn：「提醒我刷新」。

## 做法（`providers/wechat_allowance.py`，挂在 `send_wechat`）
- 上次入站 = 插件 context-token 文件 mtime（gateway 每次入站重写）
- 本地账本记成功推送（按 4000 字分段计条数；失败不计）
- 剩余 = 10 − 1（聊天回复）− 已用 − 本条；≤2 时末尾加一行「还能推 N 条 / 最后一条，回任意字续满，否则之后只在 Telegram」
- 数不出来就不加（不猜）；计数出错不影响发送；dry-run 不记账

## 验证
- 按 09-11 11:14 那段回放：第 7/8/9 条带提醒，第 10 条本来就会失败
- `-k "wechat or delivery or postflight or watchdog or provider or send"` 283 passed

https://claude.ai/code/session_01Dkn6aA3Ru8AQUW8qoz7ryV
