### PR TITLE
lint: 加 Python 正确性闸（ruff F + E9），清掉累积的 174 处

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,6 +154,16 @@ jobs:
         if: steps.scope.outputs.workflows == 'true'
         run: /tmp/actionlint -color
 
+      # Correctness-only Python lint (pyflakes + syntax: undefined names,
+      # redefinitions, unused imports/variables). Style is deliberately not
+      # checked. Until 2026-09-12 no Python linter ran anywhere and 174 of these
+      # had accumulated; the rule set lives in pyproject `[tool.ruff.lint]` so a
+      # local `ruff check .` is this exact gate. Every event, like actionlint's
+      # required context: it takes seconds and a path filter on a required
+      # check waits forever.
+      - name: Lint Python (ruff, correctness rules)
+        run: pipx run --spec 'ruff==0.16.7' ruff check --output-format github .
+
   validate:
     outputs:
       # Job-level mirror of the detector, so sibling jobs can gate without a

--- a/ops/host/cron_health_check.py
+++ b/ops/host/cron_health_check.py
@@ -22,7 +22,6 @@ Usage:
 """
 import argparse
 import json
-import os
 import re
 import subprocess
 import sys

--- a/ops/host/cron_timeline.py
+++ b/ops/host/cron_timeline.py
@@ -296,7 +296,7 @@ def main():
         return 0
 
     print('📆 合并调度时间线（全部归一到 HKT，按当日触发时刻排序）')
-    print(f'   来源: openclaw cron(CLI/SQLite) · GH Actions(UTC→HKT) · 系统 crontab(HKT)\n')
+    print('   来源: openclaw cron(CLI/SQLite) · GH Actions(UTC→HKT) · 系统 crontab(HKT)\n')
     print(f'{"HKT 触发":<22}  {"来源":<12}  {"任务":<22}  {"星期":<12}  原始 cron')
     print('─' * 108)
 

--- a/ops/system_check.py
+++ b/ops/system_check.py
@@ -281,7 +281,7 @@ def check_plan_json_schema(r):
     for p in plans:
         try:
             d = json.loads(open(p).read())
-        except Exception as e:
+        except Exception:
             bad.append(f'{Path(p).name}: parse fail'); continue
         errors = decision_v2.validate_plan(d, p)
         bad.extend(f'{Path(p).name}: {e}' for e in errors)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,3 +152,10 @@ clawock = [
     "workflows/packs/*/assets/*.json",
     "workflows/packs/*/agents/*.yaml",
 ]
+
+[tool.ruff]
+target-version = "py311"
+
+[tool.ruff.lint]
+# Correctness only — see the "Lint Python" step in .github/workflows/ci.yml.
+select = ["F", "E9"]

--- a/src/clawock/automation/cron_heartbeat.py
+++ b/src/clawock/automation/cron_heartbeat.py
@@ -11,7 +11,6 @@ import argparse
 import fcntl
 import json
 import os
-import sys
 from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
 from pathlib import Path

--- a/src/clawock/automation/llm.py
+++ b/src/clawock/automation/llm.py
@@ -50,7 +50,6 @@ Usage:
     from clawock.automation.llm import chat
     reply = chat(system="...", user="...", max_tokens=32000)
 """
-import json
 import os
 import re
 import sys
@@ -198,7 +197,7 @@ class _RateLimited(Exception):
     """A provider answered 429: sleep the linear wait, retry same leg."""
 
     def __init__(self, wait):
-        super().__init__(f'429 rate limit')
+        super().__init__('429 rate limit')
         self.wait = wait
 
 

--- a/src/clawock/automation/news_digest.py
+++ b/src/clawock/automation/news_digest.py
@@ -15,9 +15,7 @@ Env: MINIMAX_API_KEY required; OPENCODE_API_KEY and FINNHUB_API_KEY optional.
 """
 import json
 import os
-import sys
 from datetime import date, datetime, timedelta
-from pathlib import Path
 
 import requests
 

--- a/src/clawock/automation/weekly_review.py
+++ b/src/clawock/automation/weekly_review.py
@@ -12,7 +12,6 @@ import glob
 import json
 import math
 import os
-import sys
 from datetime import date, timedelta
 from pathlib import Path
 

--- a/src/clawock/decision/earnings.py
+++ b/src/clawock/decision/earnings.py
@@ -24,7 +24,7 @@ import argparse
 import json
 import sys
 from datetime import date, datetime, timezone
-from decimal import Decimal, InvalidOperation
+from decimal import Decimal
 from pathlib import Path
 
 from clawock import provenance as research_provenance

--- a/src/clawock/decision/settlement.py
+++ b/src/clawock/decision/settlement.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 
 import argparse
 import copy
-import json
 import sys
 from collections import Counter, defaultdict
 

--- a/src/clawock/decision/setup_review.py
+++ b/src/clawock/decision/setup_review.py
@@ -238,7 +238,7 @@ def main(argv=None):
     for h in HORIZONS:
         _, h_grades, h_usable = _settle(days, h)
         h_summary = ('、'.join(h_usable) if h_usable
-                     else f'没有牌面同时通过样本与正向 edge 闸——结论未解锁')
+                     else '没有牌面同时通过样本与正向 edge 闸——结论未解锁')
         multi[f'H{h}'] = {'horizon': h, 'grades': h_grades, 'summary': h_summary}
 
     out = {

--- a/src/clawock/decision/setups.py
+++ b/src/clawock/decision/setups.py
@@ -79,7 +79,7 @@ def fetch_vwap_orb(code):
             parts = row.split()
             if len(parts) < 3:
                 continue
-            hhmm, price, cumvol = parts[0], _num(parts[1]), _num(parts[2])
+            _hhmm, price, cumvol = parts[0], _num(parts[1]), _num(parts[2])
             if price is None:
                 continue
             # cumvol 是累计量；用增量近似 VWAP 分子
@@ -126,7 +126,6 @@ def grade(m):
     ru = m.get('range_used_atr')
     rsi = m.get('rsi14')
     z = m.get('zscore20')
-    chg = m.get('today_change_pct')
 
     # 追高检测（ATR 缺失也能判——区间位本身就是牌面）：
     #   ① 极端高位（≥85%）：买在当日最高一截，无条件 🔴

--- a/src/clawock/decision/signal_review.py
+++ b/src/clawock/decision/signal_review.py
@@ -35,7 +35,6 @@ CI 整体成立时才允许反向解读。T+5/T+20 窗口逐日重叠 → 披露
 时段行而不是原始行。市场归属单一出处 instruments registry；日历未覆盖的年份
 fail-open 不剔数据。
 """
-import json
 import random
 from datetime import date as real_date
 from datetime import date

--- a/src/clawock/decision/signals.py
+++ b/src/clawock/decision/signals.py
@@ -26,8 +26,7 @@ LLM 引用纪律：技术面判断只准引用本表数字，不得自创（SKIL
 import json
 import math
 import sys
-from datetime import date, datetime, timedelta, timezone
-from zoneinfo import ZoneInfo
+from datetime import date, datetime, timezone
 
 import requests
 
@@ -221,7 +220,6 @@ def compute_signals(bars):
             'tranche_pct_of_position': 0.10,
             'detail': '趋势 ON 且收盘突破此前 20 日高，回落跌回 MA20/吊灯线则失效',
         })
-    rsi = sig.get('rsi14')
     # Mean-reversion add is a two-step pattern: the previous close was weak, and
     # today's bar reclaims the previous day's high. A loss or one green close by
     # itself is deliberately insufficient.
@@ -632,7 +630,7 @@ def provisional_setups(universe=None, *, region=None, fetch=None):
             # `.get` here would escape the loop and take every row already
             # collected with it.
             errors.append({'label': label,
-                           'error': f'no_bars' if not bars else f'insufficient_bars({len(bars)})'})
+                           'error': 'no_bars' if not bars else f'insufficient_bars({len(bars)})'})
             continue
         for setup in sig.get('technical_setups') or []:
             rows.append({

--- a/src/clawock/evaluation/us_leverage.py
+++ b/src/clawock/evaluation/us_leverage.py
@@ -15,7 +15,6 @@ Run: clawock evaluate-us-leverage
 """
 from clawock.evaluation.series import mdd, rvol, sma
 import argparse
-import math
 from datetime import date
 from pathlib import Path
 
@@ -150,7 +149,6 @@ def main(argv=None):
         s = simulate(closes); s['dates'] = dates; s['last_close'] = closes[-1]; sims[etf] = s
         for key in ('bh1', 'bh2', 'reg', 'rgv', 'r1x'):
             nav = s[key]
-            pos = s['pos'] if key in ('reg', 'rgv', 'r1x') else None
             tot, cg, m = nav[-1] - 1, cagr(nav, dates), mdd(nav)
             inmkt = (sum(s['pos']) / len(s['pos']) * 100) if key in ('reg', 'rgv', 'r1x') else 100
             sw = sum(1 for a, b in zip(s['pos'], s['pos'][1:]) if a != b) if key in ('reg', 'rgv', 'r1x') else 0

--- a/src/clawock/evidence/news_evidence_graph.py
+++ b/src/clawock/evidence/news_evidence_graph.py
@@ -59,7 +59,7 @@ NEGATIVE_WORDS = {
     '亏损', '处罚', '违约', '调出', '剔除',
 }
 
-from clawock.safe_io import safe_write_json, safe_write_text
+from clawock.safe_io import safe_write_json
 
 
 def _load(path, default=None):

--- a/src/clawock/harness/brief_postflight.py
+++ b/src/clawock/harness/brief_postflight.py
@@ -26,8 +26,7 @@ Side effects:
 import json
 import re
 import sys
-import subprocess
-from datetime import datetime, timedelta
+from datetime import datetime
 from pathlib import Path
 
 from clawock.workspace import workspace_root

--- a/src/clawock/harness/brief_preflight.py
+++ b/src/clawock/harness/brief_preflight.py
@@ -40,7 +40,6 @@ from clawock.portfolio.guardrail import (  # noqa: F401  (re-export)
 import argparse
 import concurrent.futures
 import json
-import math
 import os
 import re
 import subprocess
@@ -73,9 +72,7 @@ SNAPSHOT_DIR = WS / 'memory' / 'snapshots'
 from clawock.automation import workflow_outcomes  # noqa: E402
 from clawock.market_data.macro import classify_regime as _classify_regime  # noqa: E402
 from clawock.instruments import get as get_instrument  # noqa: E402
-from clawock.instruments import is_leveraged_holding  # noqa: E402
 from clawock.instruments import compute_lookthrough_exposure  # noqa: E402
-from clawock.instruments import one_x_swap_map  # noqa: E402
 
 
 def _fetch_hk_results_notices(ticker):
@@ -618,7 +615,6 @@ def compute_reflections(portfolio):
 
     held = {h['ticker'] for leg in ('hk_stocks', 'us_stocks')
             for h in portfolio['portfolios'][leg]['holdings'] if h.get('shares', 0) > 0}
-    SELL = {'cut', 'trim_on_rebound'}
     out = {}
     for tk in sorted(held):
         settled = [r for r in rows if r['ticker'] == tk and (r.get('evaluation') or {}).get('outcome') in ('win', 'loss')]
@@ -951,7 +947,7 @@ def load_macro_and_sentiment(today, issues):
     macro_trim = {}
     try:
         if not macro_path.exists():
-            print(f'   ⚠ macro.json missing — sentiment-scan never ran')
+            print('   ⚠ macro.json missing — sentiment-scan never ran')
             issues.append('macro snapshot missing')
         else:
             m = json.loads(macro_path.read_text())
@@ -995,7 +991,7 @@ def load_macro_and_sentiment(today, issues):
     sentiment_trim = {}
     try:
         if not sent_path.exists():
-            print(f'   ⚠ sentiment.json missing — sentiment-scan never ran')
+            print('   ⚠ sentiment.json missing — sentiment-scan never ran')
             issues.append('sentiment snapshot missing')
         else:
             s = json.loads(sent_path.read_text())

--- a/src/clawock/harness/brief_watchdog.py
+++ b/src/clawock/harness/brief_watchdog.py
@@ -52,7 +52,6 @@ import json
 import os
 import sys
 from datetime import datetime
-from pathlib import Path
 
 from clawock import sessions as trading_calendar
 
@@ -380,8 +379,8 @@ def alert_brief_missing(today, dry_run, issues=None):
         f'09:05 检查结果：\n{issue_text}\n\n'
         + retry_budget_note()
         + recovery_note
-        + f'\n查因：openclaw cron runs --id $(openclaw cron list | grep 盘前深度简报) '
-          f'/ sar -q 看 08:00 起的 blocked'
+        + '\n查因：openclaw cron runs --id $(openclaw cron list | grep 盘前深度简报) '
+          '/ sar -q 看 08:00 起的 blocked'
     )
 
     tg_ok, tg_out = False, ''

--- a/src/clawock/harness/config.py
+++ b/src/clawock/harness/config.py
@@ -13,7 +13,6 @@ from clawock.workflows.request import load_request  # noqa: F401
 import json
 from pathlib import Path
 
-from clawock.harness.model import AgentRunRequest
 from clawock.publish.store import write_generation
 
 

--- a/src/clawock/harness/intraday_delta.py
+++ b/src/clawock/harness/intraday_delta.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
-import sys
 from datetime import datetime, timezone
 from pathlib import Path
 from zoneinfo import ZoneInfo

--- a/src/clawock/harness/intraday_watchdog.py
+++ b/src/clawock/harness/intraday_watchdog.py
@@ -72,7 +72,6 @@ import argparse
 import json
 import sys
 from datetime import datetime, timedelta
-from pathlib import Path
 
 from ._watchdog_common import (
     WS, HKT, log, find_job_id, today_runs, KCN_TELEGRAM,

--- a/src/clawock/harness/report.py
+++ b/src/clawock/harness/report.py
@@ -11,13 +11,10 @@ twenty-odd regression tests keep exercising exactly this code.
 """
 from __future__ import annotations
 
-import re
 
 from clawock.harness.validation import (
-    ADVISORY_MARK,
     REPORT_CHAR_LIMITS as CHAR_LIMITS,
     categorize_issues,
-    check_md_table_column_consistency,
     check_numeric_claims,
     validate_forbidden_phrases,
 )

--- a/src/clawock/harness/report_postflight.py
+++ b/src/clawock/harness/report_postflight.py
@@ -37,8 +37,6 @@ Outputs JSON to stdout:
 import argparse
 import json
 import os
-import re
-import subprocess
 import sys
 from datetime import datetime
 from pathlib import Path
@@ -85,14 +83,11 @@ def load_context(market, phase, date):
 
 
 from clawock.harness.validation import (
-    REPORT_CHAR_LIMITS as CHAR_LIMITS,
+    REPORT_CHAR_LIMITS as CHAR_LIMITS,  # noqa: F401 — re-exported, tests read rp.CHAR_LIMITS
     advisory_prefix,
-    categorize_issues,
-    check_numeric_claims,
     postflight_exit_code,
     product_status,
     split_advisory,
-    validate_forbidden_phrases,
 )
 from ._harness_common import (  # noqa: E402
     dashboard_publication_state,

--- a/src/clawock/harness/report_preflight.py
+++ b/src/clawock/harness/report_preflight.py
@@ -47,7 +47,6 @@ from clawock.harness._harness_common import run_analyze
 import argparse
 import json
 import re
-import subprocess
 import sys
 from datetime import datetime
 
@@ -56,7 +55,6 @@ from clawock import sessions as trading_calendar
 from clawock.decision import plans as plan_surface
 from clawock.evidence import research_surface
 from clawock.market_data import mover_evidence as mover_news
-from clawock.utilities import PACKAGED_UTILITIES
 from clawock.market_data import peer_scan
 
 WS = workspace_root()

--- a/src/clawock/harness/report_watchdog.py
+++ b/src/clawock/harness/report_watchdog.py
@@ -46,7 +46,6 @@ import json
 import sys
 import time
 from datetime import datetime
-from pathlib import Path
 
 from ._watchdog_common import (
     WS, HKT, log, find_job_id, today_runs,

--- a/src/clawock/market_data/calendar.py
+++ b/src/clawock/market_data/calendar.py
@@ -426,7 +426,7 @@ def print_summary(out):
         print(f'  {m["date"]}  {m["type"]:5s} {m["detail"][:100]}')
     print(f'Highest impact within 7d: {out["summary"]["highest_impact_within_7d"] or "(none)"}')
     if 'error' in out:
-        print(f'\nErrors:')
+        print('\nErrors:')
         for section, errs in out['error'].items():
             for k, v in errs.items():
                 print(f'  {section}/{k}: {v}')

--- a/src/clawock/market_data/eastmoney_http.py
+++ b/src/clawock/market_data/eastmoney_http.py
@@ -88,7 +88,6 @@ def em_get(url, params=None, headers=None, timeout=TIMEOUT,
 
 if __name__ == "__main__":
     # 冒烟：连打 3 次，确认间隔 >= MIN_INTERVAL + 抖动
-    import json as _json
     t0 = time.time()
     for i in range(3):
         r = em_get("https://push2his.eastmoney.com/api/qt/stock/fflow/daykline/get",

--- a/src/clawock/market_data/factors.py
+++ b/src/clawock/market_data/factors.py
@@ -27,7 +27,7 @@ import requests
 from clawock import seeds
 from clawock import history_store
 from clawock.market_data import bar_signals
-from clawock.safe_io import safe_write_json, safe_write_text
+from clawock.safe_io import safe_write_json
 from clawock.workspace import workspace_root
 
 WS = workspace_root()

--- a/src/clawock/market_data/gold/fetch.py
+++ b/src/clawock/market_data/gold/fetch.py
@@ -35,7 +35,6 @@ from datetime import date, datetime, timezone
 
 GRAMS_PER_OZ = 31.1035  # 1 金衡盎司(troy oz) = 31.1035 克
 
-from clawock.safe_io import safe_write_json
 from clawock.market_data.eastmoney_http import em_get
 from clawock.workspace import workspace_root
 

--- a/src/clawock/market_data/hk_analysis.py
+++ b/src/clawock/market_data/hk_analysis.py
@@ -337,10 +337,8 @@ def news_sentiment(articles: List[Dict]) -> str:
 def signal(holding: Dict) -> str:
     dp    = holding.get('today_change_pct', 0)
     pnl_p = holding.get('pnl_percent', 0)
-    code  = holding.get('ticker', '')
     # Only 07226 (XL二南方恒科, 2x) is leveraged; 03032/03033 are plain 1x HSTECH
     # ETFs and must NOT be flagged 2x. Use the canonical LEVERAGED set.
-    is_lev = code in LEVERAGED
 
     if dp <= -8:
         return '⚠️ ALERT'
@@ -388,7 +386,6 @@ def update_hk_portfolio(dry_run: bool = False) -> Dict:
     quotes = fetch_hk_quotes(codes)
     print(f"  Fetched {len(quotes)}/{len(codes)} prices from Tencent gtimg")
 
-    today_date = now_hkt.strftime('%Y-%m-%d')
     # A prior close belongs to the PRIOR HK session, never today. Stamping
     # today_date here (the old behaviour) produced holdings whose
     # prev_close_date equalled the session date — an impossible state that also
@@ -501,7 +498,7 @@ def update_hk_portfolio(dry_run: bool = False) -> Dict:
               f"P&L: {pnl_s}HK${h['pnl_abs']:.0f} ({pnl_s}{h['pnl_percent']:.1f}%)")
 
     if range_warns:
-        print(f"\n  ⚠️  当日区间越界告警（疑似坏 tick，请核对 / 用同标的 2x 验向）：", file=sys.stderr)
+        print("\n  ⚠️  当日区间越界告警（疑似坏 tick，请核对 / 用同标的 2x 验向）：", file=sys.stderr)
         for w in range_warns:
             print(f"     - {w}", file=sys.stderr)
 
@@ -661,7 +658,7 @@ def print_report(data: Dict, news_map: Optional[Dict[str, List]] = None):
     loss_count = sum(1 for h in active if h.get('pnl_percent', 0) < 0)
 
     print(f"  {'─'*58}")
-    print(f"  风险摘要")
+    print("  风险摘要")
     print(f"  2x杠杆ETF敞口:  {lev_pct:.1f}%  (HK${lev_value:,.0f})")
     print(f"  亏损持仓:       {loss_count}/{len(active)} 只")
     print(f"{'═'*62}\n")
@@ -818,7 +815,7 @@ def main(argv=None) -> int:
                         if h.get('shares', 0) > 0]
         if finnhub_key:
             if not wechat:
-                print(f"  [新闻] Finnhub 7天新闻...")
+                print("  [新闻] Finnhub 7天新闻...")
             for code in active_codes:
                 articles = get_finnhub_news(code, finnhub_key)
                 news_map[code] = articles

--- a/src/clawock/market_data/peer_residuals.py
+++ b/src/clawock/market_data/peer_residuals.py
@@ -13,7 +13,6 @@ Writes:
 import argparse
 import copy
 import json
-import math
 import statistics
 from datetime import date, datetime, timezone
 from pathlib import Path
@@ -26,7 +25,7 @@ from clawock.market_data.factors import (
     clustered_mean_ci,
     fetch_universe,
 )
-from clawock.safe_io import safe_write_json, safe_write_text
+from clawock.safe_io import safe_write_json
 from clawock.workspace import workspace_root
 
 WS = workspace_root()

--- a/src/clawock/market_data/us_analysis.py
+++ b/src/clawock/market_data/us_analysis.py
@@ -16,7 +16,6 @@ Usage:
 import json, sys
 from datetime import datetime, timezone, timedelta
 from typing import Dict, List, Optional, Tuple
-import requests
 
 from clawock.market_data.us_quotes import (
     update_us_portfolio, load_api_keys,
@@ -271,7 +270,7 @@ def print_report(data: Dict, analyses: List[Dict]):
 
     w = 64
     print(f"\n{'═'*w}")
-    print(f"  US Portfolio Analysis")
+    print("  US Portfolio Analysis")
     print(f"  ET:  {now.strftime('%Y-%m-%d %H:%M %Z')}  |  HKT: {now_h.strftime('%H:%M HKT')}")
     print(f"{'═'*w}")
 
@@ -317,7 +316,7 @@ def print_report(data: Dict, analyses: List[Dict]):
     print(f"{'─'*w}")
 
     # Detailed signals
-    print(f"\n  详细信号")
+    print("\n  详细信号")
     print(f"{'─'*w}")
     for sig, ticker, reasons, h, tech, news_items in signal_rows:
         arr = SIGNAL_COLOR.get(sig, '?')
@@ -336,7 +335,7 @@ def print_report(data: Dict, analyses: List[Dict]):
 
     # Risk summary
     print(f"\n{'─'*w}")
-    print(f"  风险摘要")
+    print("  风险摘要")
     active = [h for h in us['holdings'] if h.get('shares', 0) > 0]
     lev_val   = sum(h.get('current_value', 0) for h in active
                     if _is_leveraged_holding(h))
@@ -367,7 +366,6 @@ def print_wechat_report(data: Dict, analyses: List[Dict], md_table: bool = False
     _, us = region_book(data, 'US')
     now   = datetime.now(ET_TZ)
 
-    tc   = us.get('total_cost', 0)
     tv   = us.get('total_current_value', 0)
     pnl  = us.get('total_pnl', 0)
     pnl_ = us.get('total_pnl_percent', 0)
@@ -496,7 +494,7 @@ def run_analysis(fetch: bool = True, include_news: bool = True, argv=None):
     _, us = region_book(data, 'US')
     active  = [h for h in us['holdings'] if h.get('shares', 0) > 0]
 
-    _say(f"[ 2/3 ] 拉取技术指标 (Polygon RSI-14 / MA)...")
+    _say("[ 2/3 ] 拉取技术指标 (Polygon RSI-14 / MA)...")
     tech_cache: Dict[str, Dict] = {}
     for h in active:
         ticker = h['ticker']

--- a/src/clawock/market_data/us_quotes.py
+++ b/src/clawock/market_data/us_quotes.py
@@ -966,7 +966,7 @@ def update_us_portfolio(
     hkt_str = now_hkt.strftime('%Y/%m/%d %H:%M HKT')
 
     print(f"\n{'═'*62}")
-    print(f"  US Portfolio Price Refresh")
+    print("  US Portfolio Price Refresh")
     print(f"  ET:  {et_str}  |  HKT: {hkt_str}")
     print(f"  Tickers: {', '.join(tickers)}")
     print(f"{'═'*62}")
@@ -978,7 +978,7 @@ def update_us_portfolio(
     prev_closes: Dict[str, tuple] = {}
     polygon_key = keys.get('POLYGON_API_KEY', '')
     if polygon_key:
-        print(f"  [PC] Polygon prev-close (grouped)...")
+        print("  [PC] Polygon prev-close (grouped)...")
         prev_closes, rate_limited, snapshot_valid = get_prev_closes_polygon_grouped(
             tickers, polygon_key, today_et_date)
         for t, result in prev_closes.items():
@@ -1298,7 +1298,7 @@ def update_us_portfolio(
         'source_counts':          source_counts,
         'updated_at':             et_str,
         'note': (
-            f"Multi-provider fetch. Sources: "
+            "Multi-provider fetch. Sources: "
             + ', '.join(f"{v}x {k}" for k, v in source_counts.items())
         ),
     }

--- a/src/clawock/portfolio/integrity.py
+++ b/src/clawock/portfolio/integrity.py
@@ -88,7 +88,7 @@ from clawock.portfolio.math import (
     derive_cash,
     moving_average_cost as _moving_avg_cost,
     number as _num,
-    trade_cashflow_after as _trade_cashflow_after,
+    trade_cashflow_after as _trade_cashflow_after,  # noqa: F401 — re-exported for tests
 )
 
 try:

--- a/src/clawock/publish/artifacts.py
+++ b/src/clawock/publish/artifacts.py
@@ -11,7 +11,6 @@ import json
 import math
 import os
 import re
-import struct
 import sys
 from datetime import date, datetime, timedelta, timezone
 from email.utils import parsedate_to_datetime

--- a/src/clawock/publish/dashboard.py
+++ b/src/clawock/publish/dashboard.py
@@ -1181,7 +1181,6 @@ def build_decision_traces(limit=40, workspace=None):
                         best = e
                         best_diff = diff
                 if best:
-                    subject = best.get('subject') or {}
                     mind = best.get('mind') or {}
                     emotion = best.get('emotion') or {}
                     # Two writers, one card. `mind` is the hand-recorded
@@ -2609,7 +2608,6 @@ def _series_extremes(series):
         return None
     peak = pts[0][1]
     peak_date = pts[0][0]
-    dd_peak_date = peak_date          # peak that precedes the worst trough
     worst = 0.0
     worst_trough_date = pts[0][0]
     worst_peak_date = pts[0][0]

--- a/src/clawock/publish/decision_map.py
+++ b/src/clawock/publish/decision_map.py
@@ -47,8 +47,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from clawock import history_store
-from clawock.decision.ledger import leg_sessions, load_ticker_bars
-from clawock.instruments import canonical_bar_manifest
+from clawock.decision.ledger import leg_sessions
 from clawock.safe_io import safe_write_text, to_number as _number
 from clawock.workspace import workspace_root
 
@@ -292,7 +291,6 @@ def build(ledger_rows=None, data_dir: Path | None = None,
         json.loads(line) for line in LEDGER.read_text(encoding='utf-8').splitlines()
         if line.strip()]
     snapshots = load_signal_snapshots(data_dir)
-    manifest = canonical_bar_manifest()
     sessions_by_leg = {leg: leg_sessions(leg) for leg in ('us', 'hk')}
 
     lookup, timelines = {}, defaultdict(list)

--- a/src/clawock/runtime_model.py
+++ b/src/clawock/runtime_model.py
@@ -143,7 +143,5 @@ class RunReceipt:
 # `workflows.improvements` had to import the harness to read a config file it
 # also owns — the other half of the harness<->workflows cycle (#814). A request
 # knowing how to load itself keeps both callers above the same definition.
-import json  # noqa: E402
-from pathlib import Path as _Path  # noqa: E402
 
 CONFIG_NAME = "clawock.json"

--- a/src/clawock/tools/__init__.py
+++ b/src/clawock/tools/__init__.py
@@ -31,7 +31,6 @@ from __future__ import annotations
 from clawock.tools.base import BaseTool, ToolError, ToolRegistry  # noqa: F401
 
 import json
-from typing import Any
 
 
 

--- a/src/clawock/tools/base.py
+++ b/src/clawock/tools/base.py
@@ -12,7 +12,6 @@ caller already uses.
 """
 from __future__ import annotations
 
-import json
 from typing import Any
 
 

--- a/tests/test_analyze_hk_stocks.py
+++ b/tests/test_analyze_hk_stocks.py
@@ -5,7 +5,6 @@ not call fetchers or patch a transport: the exercised surface is deterministic.
 """
 
 import json
-import sys
 from datetime import datetime, timezone, timedelta
 from pathlib import Path
 

--- a/tests/test_attribution_and_grade.py
+++ b/tests/test_attribution_and_grade.py
@@ -14,7 +14,6 @@ of the eighteen sessions is skipped, and the module has to say so rather than
 return coefficients from an underdetermined fit.
 """
 import random
-import statistics
 
 import numpy as np
 import pytest

--- a/tests/test_bar_checks.py
+++ b/tests/test_bar_checks.py
@@ -9,7 +9,6 @@ live path; the weakest one guarded the store that settles trigger verdicts.
 Run: python3 -m pytest tests/test_bar_checks.py -q
 """
 import ast
-import sys
 from pathlib import Path
 
 import pytest

--- a/tests/test_bar_conflict_classification.py
+++ b/tests/test_bar_conflict_classification.py
@@ -14,7 +14,6 @@ publish, because the bars were not written and nothing downstream is wrong.
 
 import json
 from datetime import datetime, timezone
-from pathlib import Path
 
 
 def _bars_module(tmp_path, monkeypatch):

--- a/tests/test_bar_derived_signals.py
+++ b/tests/test_bar_derived_signals.py
@@ -19,7 +19,6 @@ import math
 import random
 import statistics
 
-import pytest
 
 from clawock.market_data import bar_signals as bs
 

--- a/tests/test_bars_freshness.py
+++ b/tests/test_bars_freshness.py
@@ -9,7 +9,6 @@ refreshing around it. Nothing failed; that is what made it survive.
 
 Run: python3 -m pytest tests/test_bars_freshness.py -q
 """
-import inspect
 import json
 import sys
 from datetime import date

--- a/tests/test_block_bootstrap.py
+++ b/tests/test_block_bootstrap.py
@@ -10,7 +10,6 @@ estimator exactly when the data says it should, and it refuses the
 bias-correction on a sample too short to estimate it.
 """
 import random
-import statistics
 
 from clawock.evaluation import bootstrap
 

--- a/tests/test_brief_context_bundle.py
+++ b/tests/test_brief_context_bundle.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import json
-import sys
 from pathlib import Path
 
 import pytest

--- a/tests/test_brief_decision_packet.py
+++ b/tests/test_brief_decision_packet.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import json
-import sys
 import copy
 from pathlib import Path
 

--- a/tests/test_brief_fallback_gate.py
+++ b/tests/test_brief_fallback_gate.py
@@ -10,7 +10,6 @@ Run: python3 -m pytest tests/test_brief_fallback_gate.py -q
 """
 import json
 import re
-import sys
 import textwrap
 from pathlib import Path
 

--- a/tests/test_brief_fallback_market_closed.py
+++ b/tests/test_brief_fallback_market_closed.py
@@ -8,8 +8,6 @@ this workflow, but a manual `gh workflow run brief-fallback.yml` bypasses it,
 which is the whole reason this second layer exists.
 """
 import json
-import os
-from pathlib import Path
 
 import pytest
 

--- a/tests/test_brief_fallback_token_budget.py
+++ b/tests/test_brief_fallback_token_budget.py
@@ -5,7 +5,6 @@ behind when MiniMax M3 became primary. Thinking takes its reserve out of the sam
 allowance, so only ~16K remained for prose against a ~33KB brief. The run ended
 `stop=max_tokens` with the trailing plan.json block never emitted.
 """
-import json
 
 from clawock.automation import brief_fallback, llm
 

--- a/tests/test_brief_postflight_fail_closed.py
+++ b/tests/test_brief_postflight_fail_closed.py
@@ -6,7 +6,6 @@ skipped every context-dependent hard gate (generation pin, position/leverage
 回查, peer divergence, macro/sentiment) while the ledger recorded success.
 """
 
-import sys
 from pathlib import Path
 
 

--- a/tests/test_brief_postflight_sections.py
+++ b/tests/test_brief_postflight_sections.py
@@ -1,6 +1,5 @@
 """Semantic section-label coverage for the daily brief postflight."""
 
-import sys
 from pathlib import Path
 
 

--- a/tests/test_brief_preflight_dag.py
+++ b/tests/test_brief_preflight_dag.py
@@ -23,7 +23,6 @@ from collections import defaultdict
 from pathlib import Path
 from types import SimpleNamespace
 
-import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
 

--- a/tests/test_brief_readability.py
+++ b/tests/test_brief_readability.py
@@ -1,6 +1,5 @@
 """Brief readability is observable, but modest overage is not product failure."""
 from pathlib import Path
-import sys
 
 
 ROOT = Path(__file__).resolve().parents[1]

--- a/tests/test_brief_render.py
+++ b/tests/test_brief_render.py
@@ -9,7 +9,6 @@ them, and no string reaching a table can add a column to it.
 import json
 from pathlib import Path
 
-import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
 

--- a/tests/test_brief_watchdog_second_rerun.py
+++ b/tests/test_brief_watchdog_second_rerun.py
@@ -5,7 +5,6 @@ queued but ITS run also failed, and by 09:05 there was no brief — the only
 recovery left was the vendor fallback. A second on-host re-run at 09:05 is
 cheaper than the fallback and lands well before the 10:00 HKT cutoff.
 """
-import json
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 

--- a/tests/test_ci_trigger_paths.py
+++ b/tests/test_ci_trigger_paths.py
@@ -87,7 +87,6 @@ def test_every_push_trigger_path_reaches_a_lane():
     green in seconds. This is now behavioural: every tracked file under every
     push-trigger glob must light up at least one lane in the real classifier.
     """
-    import fnmatch as fm
 
     tracked = _tracked()
     assert tracked, "empty checkout would make this assertion vacuous"

--- a/tests/test_clawock_launcher.py
+++ b/tests/test_clawock_launcher.py
@@ -14,7 +14,6 @@ behaviour with no reinstall — which is what the live box needs.
 import json
 import os
 import subprocess
-import sys
 from pathlib import Path
 
 import pytest

--- a/tests/test_context_capability_not_vacuous.py
+++ b/tests/test_context_capability_not_vacuous.py
@@ -111,7 +111,6 @@ def test_a_missing_store_still_skips_quietly(tmp_path, monkeypatch):
 
 def test_healthy_reports_still_pass(tmp_path, monkeypatch):
     """And the gate must not start firing on the live shape it sees every day."""
-    import ops.system_check as sc
 
     monkeypatch.setattr(
         'clawock.context.assembly.verify_prompt_report',

--- a/tests/test_coverage_badge.py
+++ b/tests/test_coverage_badge.py
@@ -13,7 +13,7 @@ from pathlib import Path
 import pytest
 
 from workflow_contract_helpers import (
-    assert_validator_step, step_block, step_run, steps, strip_hash_comments)
+    step_block, step_run, steps, strip_hash_comments)
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / 'ops' / 'ci'))

--- a/tests/test_dashboard_artifact_gate_contract.py
+++ b/tests/test_dashboard_artifact_gate_contract.py
@@ -4,7 +4,6 @@ import re
 import sys
 
 from workflow_contract_helpers import (
-    assert_validator_step,
     push_paths,
     step_block,
     step_run,

--- a/tests/test_dashboard_budget_and_benchmark_freshness.py
+++ b/tests/test_dashboard_budget_and_benchmark_freshness.py
@@ -207,7 +207,7 @@ def test_a_breach_is_recorded_in_the_payload_not_only_on_stderr(monkeypatch):
     watchdog.jsonl — so "publishing over cap" was a decision that left no trace
     a reader could act on.
     """
-    dash = pytest.importorskip("clawock.publish.dashboard")
+    pytest.importorskip("clawock.publish.dashboard")
     source = (ROOT / "src" / "clawock" / "publish" / "dashboard.py").read_text(
         encoding="utf-8")
     assert "out['payload_over_cap']" in source, (

--- a/tests/test_dashboard_output_ownership.py
+++ b/tests/test_dashboard_output_ownership.py
@@ -3,7 +3,6 @@ import json
 import re
 import pytest
 import subprocess
-import sys
 from pathlib import Path
 
 

--- a/tests/test_dashboard_payload_size.py
+++ b/tests/test_dashboard_payload_size.py
@@ -6,7 +6,6 @@ document, and 27KB of calibrator posterior state shipped with no consumer at all
 """
 import json
 import re
-import sys
 from pathlib import Path
 
 import pytest
@@ -326,7 +325,6 @@ def test_the_brief_still_gets_the_calibrators_the_dashboard_no_longer_ships():
 
     Break either half and sizing silently loses its evidence base.
     """
-    import sys
 
     from clawock.decision import ledger as decision_v2
 
@@ -355,7 +353,6 @@ def test_the_brief_only_ships_calibrator_rows_that_can_move_size():
     not abstain`, so edge-supported is a strict subset. If anyone ever inverts
     that relationship, sizing loses its evidence base silently.
     """
-    import sys
 
     from clawock.decision import ledger as decision_v2
     from clawock.harness import brief_preflight

--- a/tests/test_data_plane_timeout_is_diagnosed.py
+++ b/tests/test_data_plane_timeout_is_diagnosed.py
@@ -109,10 +109,8 @@ def test_a_failed_publish_is_countable_afterwards(monkeypatch, tmp_path):
     week. Same shape as the refused bars in #1146, same answer: append it where
     it accrues a count and a first/last timestamp.
     """
-    import json
     import subprocess as sp
 
-    from clawock.automation import workflow_outcomes
 
     _run_publisher_with(
         monkeypatch, tmp_path,
@@ -130,7 +128,6 @@ def test_two_incidents_of_one_class_are_a_count_not_two_rows(monkeypatch, tmp_pa
     would write a new row each time and leave every count at 1, which is the
     number that made the log unreadable in the first place.
     """
-    import json
     import subprocess as sp
 
     _run_publisher_with(monkeypatch, tmp_path,

--- a/tests/test_decision_map.py
+++ b/tests/test_decision_map.py
@@ -99,7 +99,6 @@ def _decoded(payload, field, index):
 
 def _payload(monkeypatch, decisions, snapshots, panel=None):
     monkeypatch.setattr(dm, 'load_signal_snapshots', lambda *a, **k: snapshots)
-    monkeypatch.setattr(dm, 'canonical_bar_manifest', lambda: {})
     monkeypatch.setattr(dm, 'leg_sessions', lambda leg: [])
     return dm.build(ledger_rows=decisions, panel=panel or STUB_PANEL)
 

--- a/tests/test_decision_record.py
+++ b/tests/test_decision_record.py
@@ -1,7 +1,4 @@
 """decision-mind ledger record command: validation, append, settle round-trip."""
-import json
-import sys
-from pathlib import Path
 
 import pytest
 

--- a/tests/test_decision_traces.py
+++ b/tests/test_decision_traces.py
@@ -14,8 +14,6 @@ move and `test_t1_marks_against_canonical_bars_not_snapshots` goes red instead
 of the regression shipping quietly.
 """
 import json
-import os
-from pathlib import Path
 
 import pytest
 

--- a/tests/test_eod_archive_workflow_contract.py
+++ b/tests/test_eod_archive_workflow_contract.py
@@ -1,5 +1,4 @@
 """Publication contract for the weekly EOD CSV archive workflow."""
-import re
 from pathlib import Path
 
 from workflow_contract_helpers import assert_validator_step, step_run, steps, staged_paths

--- a/tests/test_examples_are_executed.py
+++ b/tests/test_examples_are_executed.py
@@ -10,7 +10,6 @@ Moving it into a file only helps if the file is the one CI runs. These tests pin
 that: the workflow must invoke the script, and the script must not quietly grow
 a dependency on the checkout it exists to prove is unnecessary.
 """
-import os
 import re
 import stat
 from pathlib import Path

--- a/tests/test_fx_provenance.py
+++ b/tests/test_fx_provenance.py
@@ -6,7 +6,6 @@ USD/HKD rate did not: its only durable record was the commit history of
 of any past day would stamp it with *today's* rate and produce a combined figure
 that looks entirely normal (#323).
 """
-import json
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]

--- a/tests/test_gc_sessions_rules.py
+++ b/tests/test_gc_sessions_rules.py
@@ -145,7 +145,6 @@ def test_negative_retention_env_is_rejected_at_import(monkeypatch, tmp_path):
     """GC_KEEP_*=-1 would make 'older than cutoff' true for files that do not
     exist yet; the module must die at load, not run."""
     import importlib.util
-    import os
 
     monkeypatch.setenv("GC_KEEP_TRAJECTORY_DAYS", "-1")
     spec = importlib.util.spec_from_file_location(

--- a/tests/test_gh_action_brief_fallback.py
+++ b/tests/test_gh_action_brief_fallback.py
@@ -1,6 +1,5 @@
 import json
 from pathlib import Path
-import sys
 
 
 ROOT = Path(__file__).resolve().parents[1]

--- a/tests/test_gold_dca_history_stability.py
+++ b/tests/test_gold_dca_history_stability.py
@@ -1,7 +1,6 @@
 """Regression coverage for London-gold history provenance and settlement."""
 from datetime import date, timedelta
 from pathlib import Path
-import sys
 
 
 ROOT = Path(__file__).resolve().parents[1]

--- a/tests/test_hook_entrypoints_can_import_clawock.py
+++ b/tests/test_hook_entrypoints_can_import_clawock.py
@@ -15,11 +15,9 @@ This is the shell-side companion to `test_code_imports_come_from_the_checkout`:
 that one pins where Python modules resolve their imports from, this one pins
 that the scripts *spawning* Python leave it able to resolve them at all.
 """
-import os
 import re
 import shutil
 import subprocess
-import sys
 from pathlib import Path
 
 import pytest

--- a/tests/test_instance_harness_spawns_resolve.py
+++ b/tests/test_instance_harness_spawns_resolve.py
@@ -19,7 +19,6 @@ imports and has a `main()`. It could not catch #447 because the harness did not
 go through `PACKAGED_UTILITIES` at all — it named a filesystem path. So the gap
 is not "are the commands healthy" but "does the harness use them".
 """
-import ast
 import re
 from pathlib import Path
 

--- a/tests/test_instrument_registry.py
+++ b/tests/test_instrument_registry.py
@@ -1,6 +1,5 @@
 import copy
 import json
-import sys
 from pathlib import Path
 
 

--- a/tests/test_intraday_delta_gate.py
+++ b/tests/test_intraday_delta_gate.py
@@ -1,5 +1,4 @@
 import json
-import sys
 import copy
 import io
 import subprocess

--- a/tests/test_intraday_preflight.py
+++ b/tests/test_intraday_preflight.py
@@ -5,7 +5,6 @@ a slot wakes kcn, `collect_provisional_setups` must never red a cron when the
 quote feed fails, and the unchanged receipt is the common-case push — its
 wording is the only thing most slots ever say.
 """
-import pytest
 
 from clawock.harness import intraday_preflight as P
 

--- a/tests/test_json_repair.py
+++ b/tests/test_json_repair.py
@@ -19,7 +19,6 @@ the property defended, not by function, because the refusals are what keep the
 recoveries safe.
 """
 import json
-import sys
 from pathlib import Path
 
 import pytest

--- a/tests/test_json_repair_wiring.py
+++ b/tests/test_json_repair_wiring.py
@@ -17,7 +17,6 @@ and two boundaries that must not move:
 """
 import json
 from types import SimpleNamespace
-import sys
 from pathlib import Path
 
 import pytest

--- a/tests/test_macro_scan_workflow_contract.py
+++ b/tests/test_macro_scan_workflow_contract.py
@@ -1,5 +1,4 @@
 """Publication contract for the macro sidecar workflow."""
-import re
 from pathlib import Path
 
 from workflow_contract_helpers import assert_validator_step, step_run, steps

--- a/tests/test_market_leaf_modules.py
+++ b/tests/test_market_leaf_modules.py
@@ -7,7 +7,6 @@ indirectly through monkeypatched stand-ins. These pin the pure seams.
 import sys
 from pathlib import Path
 
-import pytest
 import requests
 
 ROOT = Path(__file__).resolve().parents[1]

--- a/tests/test_mover_news.py
+++ b/tests/test_mover_news.py
@@ -5,7 +5,7 @@ the network would be untrustworthy exactly when the endpoints misbehave, which i
 the case this code exists to survive.
 """
 import json
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest

--- a/tests/test_news_digest_workflow_contract.py
+++ b/tests/test_news_digest_workflow_contract.py
@@ -1,5 +1,4 @@
 """Publication contract for the off-host LLM news digest workflow."""
-import re
 from pathlib import Path
 
 from workflow_contract_helpers import assert_validator_step, step_run, steps, staged_paths

--- a/tests/test_no_bare_clawock_invocation.py
+++ b/tests/test_no_bare_clawock_invocation.py
@@ -109,7 +109,7 @@ def test_no_shell_caller_invokes_a_bare_clawock():
 
     assert not offenders, (
         "these invoke `clawock` as a bare command; under the user crontab's "
-        f"PATH=/usr/bin:/bin it is not found:\n  " + "\n  ".join(offenders))
+        "PATH=/usr/bin:/bin it is not found:\n  " + "\n  ".join(offenders))
 
 
 def test_the_resolver_prefers_the_installed_command_but_does_not_need_it(monkeypatch):

--- a/tests/test_packet_ticker_history.py
+++ b/tests/test_packet_ticker_history.py
@@ -26,7 +26,6 @@ import copy
 import json
 from pathlib import Path
 
-import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
 

--- a/tests/test_pages_deployment_contract.py
+++ b/tests/test_pages_deployment_contract.py
@@ -298,8 +298,6 @@ def _stage_publishable_site(site):
     (site / "docs/visual-regression/issue-206").mkdir(parents=True)
     (site / "docs/visual-regression/issue-206/before-1440.jpg").write_bytes(b"\xff\xd8")
     (site / "docs/architecture.md").write_text("ok")
-    source_gif_size = (ROOT / "site/assets/dashboard.gif").stat().st_size
-    source_jsonl = sorted((ROOT / "assets/data").glob("*.jsonl"))
 
 
 

--- a/tests/test_pages_deployment_contract.py
+++ b/tests/test_pages_deployment_contract.py
@@ -39,6 +39,21 @@ INDEXNOW_KEY = "4fb2df1611ed42e5b67fd6171a237acb.txt"
 GOOGLE_VERIFICATION = "google7be5b41525cebe9d.html"
 
 
+
+def _copy_repo_data(destination, **kwargs):
+    """Copy the checkout's assets/data, minus what other xdist workers write and remove.
+
+    `money_checker.sh` writes `assets/data/integrity_report.json` into the checkout
+    and `restores_untracked_artifact` deletes it again (conftest `TOLERATED_PATHS`).
+    Under `-n` a copytree here can list the file and then find it gone:
+    `shutil.Error … No such file or directory` (CI 2026-09-12, an unrelated PR).
+    Neither file is a Pages input, so skipping them tests the same artifact.
+    """
+    def transient(_directory, names):
+        return [name for name in names
+                if name == "integrity_report.json" or name.startswith(".tmp-")]
+    shutil.copytree(ROOT / "assets/data", destination, ignore=transient, **kwargs)
+
 def _sidecar_keys() -> set[str]:
     block = UI.split("const SIDECAR_TAB = {", 1)[1].split("};", 1)[0]
     return set(re.findall(r"([a-z][a-z0-9_]+)\s*:", block))
@@ -256,7 +271,7 @@ def _stage_publishable_site(site):
     they would drift apart.
     """
     shutil.copytree(ROOT / "site/assets", site / "assets")
-    shutil.copytree(ROOT / "assets/data", site / "assets/data")
+    _copy_repo_data(site / "assets/data")
     (site / "index.html").write_text("ok")
     for path in (
         "briefs.html", "evidence.html", "faq.html", "llms.txt",
@@ -305,7 +320,7 @@ def test_builder_stages_only_public_consumers(tmp_path):
     site = tmp_path / "_site"
     output = tmp_path / "_pages"
     shutil.copytree(ROOT / "site/assets", site / "assets")
-    shutil.copytree(ROOT / "assets/data", site / "assets/data")
+    _copy_repo_data(site / "assets/data")
     (site / "index.html").write_text("ok")
     for path in (
         "briefs.html", "evidence.html", "faq.html", "llms.txt",
@@ -400,7 +415,7 @@ def test_builder_stages_only_public_consumers(tmp_path):
 def _minimal_site(site: Path) -> None:
     """The smallest `_site` the preparer accepts: everything required_pages names."""
     shutil.copytree(ROOT / "site/assets", site / "assets")
-    shutil.copytree(ROOT / "assets/data", site / "assets/data", dirs_exist_ok=True)
+    _copy_repo_data(site / "assets/data", dirs_exist_ok=True)
     for path in CONTRACT["required_pages"]:
         target = site / path
         if target.exists():

--- a/tests/test_plans_override.py
+++ b/tests/test_plans_override.py
@@ -7,7 +7,6 @@ cut while every other decision stays untouched.
 """
 import json
 from datetime import datetime, timedelta
-from pathlib import Path
 from zoneinfo import ZoneInfo
 
 from clawock.decision import plans

--- a/tests/test_push_scope.py
+++ b/tests/test_push_scope.py
@@ -66,7 +66,7 @@ SCENARIOS = [
         _lanes(code=True, analysable=False), True,
         id="automation price commit: full suite gates the money file, CodeQL skips"),
     pytest.param(
-        [f"memory/2026-08-24-pre-open.md", "memory/2026-08-24-plan.json"],
+        ["memory/2026-08-24-pre-open.md", "memory/2026-08-24-plan.json"],
         _lanes(code=True, analysable=False), True,
         id="daily brief commit (pre-open + plan): suite runs, CodeQL skips"),
     pytest.param(

--- a/tests/test_quant_row_freshness.py
+++ b/tests/test_quant_row_freshness.py
@@ -1,6 +1,5 @@
 from datetime import date
 from pathlib import Path
-import sys
 
 
 ROOT = Path(__file__).resolve().parents[1]

--- a/tests/test_reflect_audit_contract.py
+++ b/tests/test_reflect_audit_contract.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-import sys
 
 
 ROOT = Path(__file__).resolve().parents[1]

--- a/tests/test_regime_incomplete_fetch.py
+++ b/tests/test_regime_incomplete_fetch.py
@@ -27,7 +27,6 @@ def _run(monkeypatch, bars):
     monkeypatch.setattr(
         regime, "fetch_hstech",
         lambda: [(f"2026-01-{i + 1:02d}", float(bars[i])) for i in range(len(bars))])
-    buf = {}
     import io
     import contextlib
     with contextlib.redirect_stdout(io.StringIO()) as out:

--- a/tests/test_report_assembly.py
+++ b/tests/test_report_assembly.py
@@ -397,7 +397,6 @@ def test_main_refuses_to_publish_a_stale_prose_file(run_main, sent, pf, tmp_path
     """A helper-only test does not guard main(): with read_prose_text returning an
     error but main() ignoring it, everything else still passes. Drive the whole
     entry point and assert NOTHING was sent."""
-    import os
     rc, out = run_main(PROSE, context_id='abc123def456',
                        age_minutes=pf.PROSE_MAX_AGE_MIN + 5)
 
@@ -482,11 +481,7 @@ def test_watchdog_ignores_an_undelivered_marker(wd):
 
 
 # ── watchdog must not duplicate a healthy prose run ────────────────────────
-
-@pytest.fixture
-def wd():
-    return _load('report_watchdog')
-
+# (uses the `wd` fixture defined above)
 
 def test_watchdog_identifies_the_slot_by_context_id_not_first_line(wd):
     """Prose-mode bodies start with the TITLE, so the old first-line compare

--- a/tests/test_report_core_is_independent.py
+++ b/tests/test_report_core_is_independent.py
@@ -10,7 +10,6 @@ false.
 """
 import ast
 import json
-import os
 import subprocess
 import sys
 from pathlib import Path

--- a/tests/test_report_length_ceiling.py
+++ b/tests/test_report_length_ceiling.py
@@ -11,7 +11,6 @@ in exactly one place, that both report modes read that place, and that removing
 the budget did not also remove the content the reports must carry.
 """
 from pathlib import Path
-import sys
 
 ROOT = Path(__file__).resolve().parents[1]
 from clawock.harness import _harness_common as common  # noqa: F401

--- a/tests/test_report_watchdog_retry_parity.py
+++ b/tests/test_report_watchdog_retry_parity.py
@@ -12,7 +12,6 @@ a fresh-looking marker and no backstop ever fired. Both invariants are pinned
 here — a fix for either one that breaks the other fails this file.
 """
 import json
-import sys
 from datetime import datetime, timedelta
 from pathlib import Path
 

--- a/tests/test_research_surface.py
+++ b/tests/test_research_surface.py
@@ -4,7 +4,6 @@ These tests hold two lines: the surface computes the right work queue from real
 artifacts, and the three consumers (daily brief preflight, `system_check.py`,
 the `validate` workflow) actually call it.
 """
-import copy
 import json
 from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
@@ -514,7 +513,6 @@ def test_both_stock_skills_frame_it_as_attribution_not_a_trigger():
 
 
 def test_calendar_coverage_is_reported_per_market():
-    import sys
     from clawock import sessions as trading_calendar
 
     coverage = trading_calendar.coverage(date(2026, 7, 26))

--- a/tests/test_rick_broadcast.py
+++ b/tests/test_rick_broadcast.py
@@ -108,7 +108,6 @@ def _run_wrapper(tmp_path, monkeypatch):
     import os
     import shutil
     import subprocess
-    import textwrap
 
     src = ROOT / 'ops' / 'growth' / 'rick_broadcast_nostr.sh'
     script = tmp_path / 'wrapper.sh'
@@ -154,7 +153,6 @@ def _run_wrapper(tmp_path, monkeypatch):
 
 
 def test_wrapper_skips_a_byte_identical_republish_and_publishes_changes(tmp_path, monkeypatch):
-    import subprocess
     run, log, fail_flag, text_file = _run_wrapper(tmp_path, monkeypatch)
 
     first = run()
@@ -174,7 +172,6 @@ def test_wrapper_skips_a_byte_identical_republish_and_publishes_changes(tmp_path
 
 
 def test_wrapper_state_only_advances_after_a_confirmed_publish(tmp_path, monkeypatch):
-    import subprocess
     run, log, fail_flag, text_file = _run_wrapper(tmp_path, monkeypatch)
 
     assert run().returncode == 0

--- a/tests/test_risk_discipline.py
+++ b/tests/test_risk_discipline.py
@@ -1,5 +1,4 @@
 import json
-import sys
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 

--- a/tests/test_run_card.py
+++ b/tests/test_run_card.py
@@ -10,7 +10,6 @@ Run: python3 -m pytest tests/test_run_card.py -q
 """
 import ast
 import json
-import sys
 from pathlib import Path
 
 import pytest

--- a/tests/test_safe_io_strict_json.py
+++ b/tests/test_safe_io_strict_json.py
@@ -8,7 +8,6 @@ hold the write side to the same contract.
 """
 import json
 import math
-import sys
 from pathlib import Path
 
 import pytest

--- a/tests/test_scheduled_catalysts.py
+++ b/tests/test_scheduled_catalysts.py
@@ -10,7 +10,6 @@ Both failure modes below are silent by nature — a wrong date reads exactly lik
 a right one — which is what earns them a test.
 """
 import json
-import sys
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]

--- a/tests/test_screenshot_refresh_workflow_contract.py
+++ b/tests/test_screenshot_refresh_workflow_contract.py
@@ -1,5 +1,4 @@
 """Publication contract for the generated dashboard screenshots workflow."""
-import re
 from pathlib import Path
 
 from workflow_contract_helpers import assert_validator_step, step_block, step_run, steps, staged_paths

--- a/tests/test_sentiment_scan_workflow_contract.py
+++ b/tests/test_sentiment_scan_workflow_contract.py
@@ -1,5 +1,4 @@
 """Publication contract for the sentiment sidecar workflow."""
-import re
 from pathlib import Path
 
 from workflow_contract_helpers import assert_validator_step, step_run, steps

--- a/tests/test_signal_drift.py
+++ b/tests/test_signal_drift.py
@@ -12,7 +12,6 @@ rows reports `p < 1e-9` for an ordinary directional week, and an alert that fire
 every week is not an alert.
 """
 import random
-import statistics
 
 import pytest
 

--- a/tests/test_signal_quantiles_and_turnover.py
+++ b/tests/test_signal_quantiles_and_turnover.py
@@ -14,7 +14,6 @@ merges decide how a signal would actually be used:
 to the cases where the IC and the buckets disagree — which is the entire reason
 for adding them.
 """
-import statistics
 
 from clawock.evaluation import signal_panel
 

--- a/tests/test_system_check_reads_without_spawning.py
+++ b/tests/test_system_check_reads_without_spawning.py
@@ -25,7 +25,6 @@ defect was never visible in what the checks *said*, only in what they did.
 import importlib.util
 import json
 import sqlite3
-import subprocess
 import sys
 from pathlib import Path
 

--- a/tests/test_t0_setup_review.py
+++ b/tests/test_t0_setup_review.py
@@ -1,5 +1,4 @@
 import json
-import sys
 from datetime import date as real_date
 from pathlib import Path
 

--- a/tests/test_traces_drop_empty_keys.py
+++ b/tests/test_traces_drop_empty_keys.py
@@ -14,7 +14,6 @@ Controlled A/B on the same minute's data: only this block moved, −5,522 bytes.
 (Measured naively across two builds it looked like −27,408 — the payload itself
 swings up to 13,474 bytes run to run, #1399. The A/B is the number.)
 """
-import json
 import re
 from pathlib import Path
 

--- a/tests/test_triple_barrier_labels.py
+++ b/tests/test_triple_barrier_labels.py
@@ -12,9 +12,7 @@ path-aware column is worth trusting: the stop has to trail, an intraday touch
 has to count, and a bar that contains both barriers must not be resolved in the
 favourable direction.
 """
-import math
 
-import pytest
 
 from clawock.labeling import triple_barrier as tb
 

--- a/tests/test_walkforward_selection_rigor.py
+++ b/tests/test_walkforward_selection_rigor.py
@@ -9,7 +9,6 @@ it must say so and produce no number, because a decorated PBO on three sessions
 is worse than no PBO at all.
 """
 import random
-import statistics
 
 from clawock.evaluation import add_alpha_walkforward as wf
 

--- a/tests/test_weekly_review_index.py
+++ b/tests/test_weekly_review_index.py
@@ -18,7 +18,6 @@ import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
-import pytest
 import yaml
 
 ROOT = Path(__file__).resolve().parents[1]

--- a/tests/test_weekly_review_workflow_contract.py
+++ b/tests/test_weekly_review_workflow_contract.py
@@ -1,5 +1,4 @@
 """Publication contract for the off-host LLM weekly review workflow."""
-import re
 from pathlib import Path
 
 from workflow_contract_helpers import assert_validator_step, step_run, steps, staged_paths

--- a/tests/test_workflow_composites.py
+++ b/tests/test_workflow_composites.py
@@ -165,9 +165,9 @@ def test_the_playwright_composite_owns_the_version_and_the_cache_key():
     version = re.search(r"default: '(\d+\.\d+\.\d+)'", composite)
     assert version, "the playwright pin must be a plain default input"
     for marker in (
-        f"playwright-${{{{ inputs.version }}}}-${{{{ runner.os }}}}",
+        "playwright-${{ inputs.version }}-${{ runner.os }}",
         "path: ~/.cache/ms-playwright",
-        f"playwright@${{{{ inputs.version }}}}",
+        "playwright@${{ inputs.version }}",
     ):
         assert marker in composite, marker
 

--- a/tests/test_workflow_outcomes.py
+++ b/tests/test_workflow_outcomes.py
@@ -1,5 +1,4 @@
 import json
-import sys
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
@@ -841,7 +840,7 @@ def test_a_failed_reconcile_says_which_detector_it_disabled(tmp_path, monkeypatc
 
 def test_a_repeated_degradation_counts_rather_than_floods(tmp_path, monkeypatch):
     """Twenty identical rows would push the real ones out of the window."""
-    workspace = _isolate(tmp_path, monkeypatch)
+    _isolate(tmp_path, monkeypatch)
     ledger = outcomes._empty()
     for _ in range(5):
         outcomes.note_degradation(ledger, "kind_a", "same detail")


### PR DESCRIPTION
此前仓库**没有任何 Python linter**（CI 的 `lint` 只跑 actionlint）。

## 闸
- 只开正确性规则 `F` + `E9`：未定义名、语法错、重复定义、没用的 import/变量、无占位符 f-string。风格不管。
- 规则在 `pyproject.toml [tool.ruff.lint]`；`lint` job 新增一步 `pipx run --spec 'ruff==0.16.7' ruff check --output-format github .`（每个事件都跑，几秒）。

## 清理（174 → 0）
- 131 unused import（两个 re-export 保留：`report_postflight.CHAR_LIMITS`、`integrity._trade_cashflow_after`，标 `noqa: F401` 并写明用途）
- 23 f-string 无占位符；17 unused 变量（逐个看过，都是死变量，没有漏用结果的 bug）；3 重复定义
- `decision_map.build` 里结果从未使用的 `canonical_bar_manifest()` 读盘调用删掉 ⇒ 少一条 `publish → instruments` 包依赖边
- bug 类规则（B023/B008/B904…）扫到的都是误报或无害，未纳入闸

## 依赖
包级依赖边 80 → 79，零新增；`KNOWN_PACKAGE_CYCLES` 仍为空。

## 验证
本地全量 3682 passed；`ruff check .` All checks passed。

https://claude.ai/code/session_01Dkn6aA3Ru8AQUW8qoz7ryV
