### PR TITLE
dashboard: 缺值不再印成 undefined/null——十一处裸插值改走空值安全格式化，加稀疏 payload 全 tab 测试

### DIFF
--- a/site/assets/js/dashboard.core.js
+++ b/site/assets/js/dashboard.core.js
@@ -16,6 +16,11 @@
     const s = v >= 0 ? "+" : "";
     return s + v.toFixed(digits) + "%";
   };
+  // A number printed as the producer wrote it, or DASH when it is missing. For the
+  // places that interpolate a raw field (`${r.pnl_pct}%`) instead of formatting it:
+  // there a missing field used to print "undefined%" / "null @ $null" (2026-09-12,
+  // found by rendering every tab with the numbers nulled out and then removed).
+  const numText = (v) => (v == null || (typeof v === "number" && !isFinite(v))) ? DASH : String(v);
   const fmtNum = (v, digits = 2) => {
     if (v == null || !isFinite(v)) return DASH;
     return v.toFixed(digits);

--- a/site/assets/js/dashboard.render.js
+++ b/site/assets/js/dashboard.render.js
@@ -130,9 +130,10 @@
       parts.push(`<div class="add-families">` + families.map(row => {
         const label = ADD_FAMILY_LABEL[row.name] || row.name;
         const progress = row.progress;
-        const pctDone = progress ? Math.min(100, Math.round(progress.have / progress.need * 100)) : (row.active ? 100 : 0);
+        const pctDone = progress && progress.need > 0 && progress.have != null
+          ? Math.min(100, Math.round(progress.have / progress.need * 100)) : (row.active ? 100 : 0);
         const detail = row.active ? "已激活"
-          : progress ? `${progress.counter} ${progress.have}/${progress.need}`
+          : progress ? `${progress.counter} ${numText(progress.have)}/${numText(progress.need)}`
           : (row.blockers || []).join("、") || "预热中";
         return `<div class="add-family">` +
           `<span class="add-family-name">${escapeHtml(label)}</span>` +
@@ -3396,7 +3397,7 @@
       `<div style="padding:8px 12px;border-radius:6px;background:color-mix(in srgb,var(--accent) 8%,transparent);border:1px solid color-mix(in srgb,var(--accent) 25%,transparent)">
          <span class="muted" style="font-size:var(--fs-micro);text-transform:none;letter-spacing:0">待布局弹药</span>
          <div style="font-size:var(--fs-lg);font-weight:700;margin-top:2px">${bits.join('  ·  ') || DASH}</div>
-         <div class="muted" style="font-size:var(--fs-micro);text-transform:none;letter-spacing:0;margin-top:2px">${r.triggered_count}/${r.total} 已触发 · 触发=收盘站回均线,右侧再布局</div>
+         <div class="muted" style="font-size:var(--fs-micro);text-transform:none;letter-spacing:0;margin-top:2px">${numText(r.triggered_count)}/${numText(r.total)} 已触发 · 触发=收盘站回均线,右侧再布局</div>
        </div>`;
     // 每个受监控标的一行
     const rows = r.watches.map(w => {
@@ -3822,7 +3823,7 @@
         <div class="muted">${ccy} · 严格配对 ${z.n_events || 0} 次 / ${z.n_blocks || 0} blocks</div>
         <div class="median">${z.median_bps == null ? DASH : `${z.median_bps >= 0 ? "+" : ""}${z.median_bps} bps`}</div>
         <div class="muted">paired CI ${ci ? `[${ci[0]}, ${ci[1]}] bps` : "—（blocks<3）"}</div>
-        <div class="muted">${dist ? `分布 p10 ${dist.p10} · p25 ${dist.p25} · p50 ${dist.median} · p75 ${dist.p75} · p90 ${dist.p90}` : "暂无可唯一匹配的真实成交"}</div>
+        <div class="muted">${dist ? `分布 p10 ${numText(dist.p10)} · p25 ${numText(dist.p25)} · p50 ${numText(dist.median)} · p75 ${numText(dist.p75)} · p90 ${numText(dist.p90)}` : "暂无可唯一匹配的真实成交"}</div>
       </div>`;
     }).join("");
 
@@ -3832,10 +3833,10 @@
       ? `<table><thead><tr><th>标的/日</th><th>方向·股数</th><th>AI 成交</th><th>同日收盘</th><th>好多少</th></tr></thead><tbody>`
         + timingEvents.map(e => `<tr>
           <td>${escapeHtml(e.ticker)}<div class="muted">${escapeHtml(e.session)} · ${e.currency}</div></td>
-          <td>${e.direction === "sell" ? "卖" : "买"} ${e.shares}</td>
-          <td class="num">${e.ai_execution_price}</td>
-          <td class="num">${e.same_day_close}</td>
-          <td class="num ${pnlClass(e.improvement_bps)}">${e.improvement_bps >= 0 ? "+" : ""}${e.improvement_bps} bps<div class="muted">${fmtMoney(e.improvement_amount, e.currency)}</div></td>
+          <td>${e.direction === "sell" ? "卖" : "买"} ${numText(e.shares)}</td>
+          <td class="num">${numText(e.ai_execution_price)}</td>
+          <td class="num">${numText(e.same_day_close)}</td>
+          <td class="num ${pnlClass(e.improvement_bps)}">${e.improvement_bps == null ? DASH : `${e.improvement_bps >= 0 ? "+" : ""}${e.improvement_bps} bps`}<div class="muted">${fmtMoney(e.improvement_amount, e.currency)}</div></td>
         </tr>`).join("")
         + `</tbody></table>`
       : '<div class="empty-state">暂无能按同票/同日/同方向/同股数唯一匹配的真实成交；不会拿 OHLC 假设成交冒充。</div>';
@@ -4364,7 +4365,7 @@
     if (provEl) {
       const led = prov.ledger || {}, win = prov.window || {};
       provEl.textContent = led.slice_digest
-        ? `这些数出自 ${led.path} 的 ${led.slice_rows} 行`
+        ? `这些数出自 ${led.path} 的 ${numText(led.slice_rows)} 行`
           + `（${win.first_plan_date} → ${win.last_plan_date}）`
           + ` · 代码 ${prov.code_commit || "—"}`
           + ` · 切片指纹 ${led.slice_digest}`
@@ -4566,9 +4567,9 @@
       const keys = Object.keys(tally || {});
       if (!keys.length) return "";
       const judged = keys.reduce((s, k) => s + tally[k], 0);
-      const denom = total != null && total !== judged ? `<b>${judged}</b>/${total}` : `<b>${judged}</b>`;
+      const denom = total != null && total !== judged ? `<b>${judged}</b>/${numText(total)}` : `<b>${judged}</b>`;
       return `${label} ${denom}: ` + keys.sort().map(k =>
-        `<b class="${k === "卖对" || k === "涨" ? "pos" : k === "持平" ? "na" : "neg"}">${tally[k]}</b>${k}`).join(" / ");
+        `<b class="${k === "卖对" || k === "涨" ? "pos" : k === "持平" ? "na" : "neg"}">${numText(tally[k])}</b>${k}`).join(" / ");
     };
     const statsEl = document.getElementById("trace-stats");
     if (statsEl) {
@@ -4597,7 +4598,7 @@
     // coerce, so they are escaped like any other untrusted string.
     function fillNode(t) {
       const sym = t.currency === "HKD" ? "HK$" : "$";
-      return `${esc(ACT[t.action] || t.action)} ${esc(String(t.shares))} 股 @ ${sym}${esc(String(t.price))}`;
+      return `${esc(ACT[t.action] || t.action)} ${esc(numText(t.shares))} 股 @ ${t.price == null ? DASH : sym + esc(String(t.price))}`;
     }
 
     // What actually happened to the money on this row. Two different
@@ -4709,7 +4710,7 @@
                 <span class="tr-dot ${t.decision ? "has" : ""}" title="${t.decision ? "有当日计划记录" : "无当日计划记录"}"></span>
                 <span class="tr-tk">${esc(t.ticker)}</span>
                 <span class="tr-act ${tone}">${esc(ACT[t.action] || t.action)}</span>
-                <span class="tr-qty">${esc(String(t.shares))} @${esc(String(t.price))}</span>
+                <span class="tr-qty">${esc(numText(t.shares))} @${esc(numText(t.price))}</span>
                 <span class="tr-spacer"></span>
                 ${alignTag}
                 ${t1tag}
@@ -4860,7 +4861,7 @@
       }
       return `<div class="risk-alert ${r.leveraged ? 'high' : 'medium'}">
          <span class="icon"></span>
-         <div><strong>${r.ticker}</strong> 浮亏 ${r.pnl_pct}% → 回本需 +${r.breakeven_need_pct}%${extra}</div>
+         <div><strong>${r.ticker}</strong> 浮亏 ${r.pnl_pct == null ? DASH : r.pnl_pct + "%"} → 回本需 ${r.breakeven_need_pct == null ? DASH : "+" + r.breakeven_need_pct + "%"}${extra}</div>
        </div>`;
     }).join('');
     document.getElementById('breakeven-list').innerHTML = html;

--- a/tests/dashboard_tab_runtime.spec.js
+++ b/tests/dashboard_tab_runtime.spec.js
@@ -1248,6 +1248,71 @@ async function testALeveragedRowWithoutVolatilityPrintsNoUndefined(browser, base
   await page.close();
 }
 
+// Every numeric field of every object in the payload, nulled out ("null") or
+// removed ("absent"). Array elements are left alone — a series of nulls is a
+// different contract (the charts own it) — and so are the counters the loader
+// itself validates.
+function sparsePayload(value, mode) {
+  if (Array.isArray(value)) {
+    return value.map(item => (item && typeof item === "object") ? sparsePayload(item, mode) : item);
+  }
+  if (!value || typeof value !== "object") return value;
+  const keep = /version|^v$|count$|_n$|^n$|^known$|limit|window|size|bytes/;
+  const out = {};
+  for (const [key, item] of Object.entries(value)) {
+    if (typeof item === "number" && !keep.test(key)) {
+      if (mode === "null") out[key] = null;
+      continue;
+    }
+    out[key] = sparsePayload(item, mode);
+  }
+  return out;
+}
+
+async function testNoTabPrintsAMissingNumber(browser, base) {
+  // 2026-09-11 live: 「横盘 decay ≈undefined%/月」 on the Holdings tab, because one
+  // renderer guarded a field and its twin did not. Rendering every tab with the
+  // numbers taken away found eleven more of the same shape the next day —
+  // `浮亏 undefined% → 回本需 +undefined%`, `卖出 null 股 @ $null`, `p10 null`…
+  // — none visible on real data, all one missing field away. `numText` /
+  // `fmtNum` / `fmtPct` / `fmtMoney` print DASH for a missing number; a raw
+  // `${field}` does not.
+  for (const mode of ["null", "absent"]) {
+    const context = await browser.newContext({ viewport: { width: 1280, height: 900 } });
+    const page = await context.newPage();
+    await stubLiveOrigin(page, { patch: (_name, json) => sparsePayload(json, mode) });
+    const state = observe(page);
+    await page.goto(base, { waitUntil: "networkidle" });
+    await waitForData(page);
+    const hits = [];
+    for (const tab of TABS) {
+      await page.click(`.tab-btn[data-tab="${tab}"]`);
+      await waitForTab(page, tab);
+      hits.push(...await page.evaluate(() => {
+        const out = [];
+        const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT);
+        let node;
+        while ((node = walker.nextNode())) {
+          if (node.parentElement.closest("script, style")) continue;
+          const text = node.textContent.trim();
+          // "null" only where it stands in for a number; model prose may say it.
+          if (/\bundefined\b|\bNaN\b|\bInfinity\b|\[object Object\]/.test(text)
+              || text === "null"
+              || /\bnull\s*(%|bps|股|\/)|[@$/+≈]\s*null\b/.test(text)) {
+            const holder = node.parentElement.closest("[id]");
+            out.push(`${holder ? holder.id : "?"}: ${text.slice(0, 80)}`);
+          }
+        }
+        return out;
+      }));
+    }
+    assert.deepEqual([...new Set(hits)], [],
+      `a missing number was printed as text (mode=${mode}) — format it with numText/fmtNum`);
+    assert.deepEqual(state.errors, [], `a renderer threw on a payload with ${mode} numbers`);
+    await context.close();
+  }
+}
+
 async function testAPanelSaysWhenItsDataDidNotLoad(browser, base) {
   // A detail tab needs dashboard.json (191 KB, normally from the data branch)
   // before it can paint. When that request failed the only trace was
@@ -2081,6 +2146,7 @@ async function main() {
     await testThePlanTimelineClampsItsRationales(browser, base);
     await testAddSideCardExplainsWhyThereIsNoAdd(browser, base);
     await testALeveragedRowWithoutVolatilityPrintsNoUndefined(browser, base);
+    await testNoTabPrintsAMissingNumber(browser, base);
     await testAPanelSaysWhenItsDataDidNotLoad(browser, base);
     await testCronRailAccountsForEverySlotWithoutASecondVerdict(browser, base);
     await testCronNeedsActionMergesIntoTheOneTodoListButWatchDoesNot(browser, base);


### PR DESCRIPTION
09-11 线上 `≈undefined%/月` 之后，把 payload 里所有对象字段的数字置空/删除再渲染全部 tab，又找到 11 处同形状裸插值（Risk 回本表、决策轨迹成交行与 T+1 计数、择时分布与成交表、加仓热身进度含 NaN% 宽度、再入场计数、计划来源行数）。真实数据上都有值，所以从没露出来。

- core 新增 `numText(v)`（有值原样、缺值 DASH，不改精度）；11 处改用或显式判空
- 新浏览器测试 `testNoTabPrintsAMissingNumber`：null/absent 两种模式 × 全部 tab；修复前的 render.js 跑是红的

https://claude.ai/code/session_01Dkn6aA3Ru8AQUW8qoz7ryV