### PR TITLE
dashboard: 决策轨迹与计划时间线拆成独立 sidecar——dashboard.json 193KB → 144KB

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -573,11 +573,11 @@ jobs:
           PY
           strip="${RUNNER_TEMP:-/tmp}/strip_volatile.py"
           tmp="$(mktemp -d)"
-          for name in overview dashboard decision_audit shadow_portfolio; do
+          for name in overview dashboard decision_audit shadow_portfolio decision_trail; do
             python3 "$strip" "assets/data/$name.json" > "$tmp/$name.first"
           done
           clawock dashboard-build > /dev/null
-          for name in overview dashboard decision_audit shadow_portfolio; do
+          for name in overview dashboard decision_audit shadow_portfolio decision_trail; do
             if ! python3 "$strip" "assets/data/$name.json" | diff -u "$tmp/$name.first" -; then
               echo "::error::dashboard rebuild moved bytes beyond generation stamps ($name)"
               exit 1

--- a/.gitignore
+++ b/.gitignore
@@ -157,6 +157,7 @@ portfolio.json.bak
 /assets/data/dashboard.json
 /assets/data/decision_audit.json
 /assets/data/shadow_portfolio.json
+/assets/data/decision_trail.json
 # Written by the same tick as the four above and published with them (#325).
 # They were the publisher's entire commit pathspec, which is why moving only the
 # four barely changed the commit count.

--- a/config/dashboard-outputs.json
+++ b/config/dashboard-outputs.json
@@ -2,22 +2,41 @@
   "schema_version": 1,
   "outputs": {
     "assets/data/overview.json": {
-      "recursive_clock_fields": ["generated_at", "generation_id", "age_hours", "days_behind"],
+      "recursive_clock_fields": [
+        "generated_at",
+        "generation_id",
+        "age_hours",
+        "days_behind"
+      ],
       "top_level_clock_fields": [],
       "generation_group": "dashboard"
     },
     "assets/data/dashboard.json": {
-      "recursive_clock_fields": ["generated_at", "age_hours", "days_behind"],
+      "recursive_clock_fields": [
+        "generated_at",
+        "age_hours",
+        "days_behind"
+      ],
       "top_level_clock_fields": [],
       "generation_group": "dashboard"
     },
     "assets/data/decision_audit.json": {
       "recursive_clock_fields": [],
-      "top_level_clock_fields": ["as_of"]
+      "top_level_clock_fields": [
+        "as_of"
+      ]
     },
     "assets/data/shadow_portfolio.json": {
       "recursive_clock_fields": [],
-      "top_level_clock_fields": ["as_of"]
+      "top_level_clock_fields": [
+        "as_of"
+      ]
+    },
+    "assets/data/decision_trail.json": {
+      "recursive_clock_fields": [],
+      "top_level_clock_fields": [
+        "as_of"
+      ]
     }
   }
 }

--- a/config/dashboard-outputs.json
+++ b/config/dashboard-outputs.json
@@ -36,7 +36,15 @@
       "recursive_clock_fields": [],
       "top_level_clock_fields": [
         "as_of"
-      ]
+      ],
+      "split_from": {
+        "file": "assets/data/dashboard.json",
+        "keys": [
+          "decision_traces",
+          "decision_trace_scope",
+          "plan_timeline"
+        ]
+      }
     }
   }
 }

--- a/config/pages-public.json
+++ b/config/pages-public.json
@@ -10,6 +10,7 @@
     "assets/data/em_news.json",
     "assets/data/decision_audit.json",
     "assets/data/shadow_portfolio.json",
+    "assets/data/decision_trail.json",
     "assets/data/brief_projection.json",
     "assets/data/decision_map.json"
   ],

--- a/ops/pages/fetch_data_plane.py
+++ b/ops/pages/fetch_data_plane.py
@@ -24,6 +24,7 @@ Usage (see .github/workflows/pages.yml):
 from __future__ import annotations
 
 import argparse
+import json
 import subprocess
 import sys
 from pathlib import Path
@@ -54,6 +55,35 @@ def note_failure(reason: str) -> None:
         pass
 
 
+def pre_split_members(store, error) -> list[str]:
+    """Outputs the published generation may lack because it was built before them.
+
+    A new output split out of an existing one (`split_from` in
+    config/dashboard-outputs.json) cannot be on the data branch until the host
+    publisher runs the code that writes it — and that code cannot merge while this
+    step refuses every generation without it. The generation says which side of
+    the split it is on: if the parent file still carries the sections, it predates
+    the split and the missing member is expected. Anything else stays a failure.
+    """
+    missing = [name for name in DATA_PLANE_FILES if name in str(error)]
+    if not missing:
+        return []
+    try:
+        outputs = json.loads((ROOT / "config" / "dashboard-outputs.json")
+                             .read_text(encoding="utf-8"))["outputs"]
+    except (OSError, ValueError, KeyError):
+        return []
+    for name in missing:
+        split = (outputs.get(name) or {}).get("split_from") or {}
+        try:
+            parent = json.loads(store._git_blob("FETCH_HEAD", split["file"]))
+        except Exception:
+            return []
+        if not all(key in parent for key in split.get("keys") or ["\0"]):
+            return []
+    return missing
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--repo", type=Path, default=ROOT)
@@ -64,8 +94,18 @@ def main() -> int:
     args = parser.parse_args()
 
     store = GitBranchStore(args.repo, args.branch, remote=args.remote)
+    names = list(DATA_PLANE_FILES)
     try:
-        written = store.fetch(args.into or args.repo, names=DATA_PLANE_FILES)
+        try:
+            written = store.fetch(args.into or args.repo, names=names)
+        except FileNotFoundError as exc:
+            excused = pre_split_members(store, exc)
+            if not excused:
+                raise
+            print(f"· data-plane: the published generation predates {excused} "
+                  "(its parent still carries the sections) — fetching the rest")
+            written = store.fetch(args.into or args.repo,
+                                  names=[n for n in names if n not in excused])
     except subprocess.TimeoutExpired as exc:
         # Same sibling-not-subclass trap as publish_data_branch: a hung remote
         # reached the caller as a traceback instead of a diagnosis (2026-09-07).

--- a/ops/pages/fetch_data_plane.py
+++ b/ops/pages/fetch_data_plane.py
@@ -84,6 +84,32 @@ def pre_split_members(store, error) -> list[str]:
     return missing
 
 
+def _split_specs() -> dict:
+    outputs = json.loads((ROOT / "config" / "dashboard-outputs.json")
+                         .read_text(encoding="utf-8"))["outputs"]
+    return {name: spec["split_from"] for name, spec in outputs.items()
+            if spec.get("split_from")}
+
+
+def materialize_split_members(into: Path, names) -> list[str]:
+    """Write a pre-split generation's missing members from the parent's sections.
+
+    The page and the browser contract then see the post-split shape — the new file
+    is there, carrying exactly what the parent carried — instead of a 404 during the
+    one publisher cycle it takes the host to start writing the file itself.
+    """
+    specs, written = _split_specs(), []
+    for name in names:
+        spec = specs[name]
+        parent = json.loads((into / spec["file"]).read_text(encoding="utf-8"))
+        body = {"as_of": parent.get("generated_at"),
+                **{key: parent[key] for key in spec["keys"] if key in parent}}
+        (into / name).write_text(json.dumps(body, ensure_ascii=False, separators=(",", ":")),
+                                 encoding="utf-8")
+        written.append(name)
+    return written
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--repo", type=Path, default=ROOT)
@@ -103,9 +129,11 @@ def main() -> int:
             if not excused:
                 raise
             print(f"· data-plane: the published generation predates {excused} "
-                  "(its parent still carries the sections) — fetching the rest")
+                  "(its parent still carries the sections) — fetching the rest and "
+                  "deriving them from it")
             written = store.fetch(args.into or args.repo,
                                   names=[n for n in names if n not in excused])
+            written += materialize_split_members(Path(args.into or args.repo), excused)
     except subprocess.TimeoutExpired as exc:
         # Same sibling-not-subclass trap as publish_data_branch: a hung remote
         # reached the caller as a traceback instead of a diagnosis (2026-09-07).

--- a/site/assets/js/dashboard.core.js
+++ b/site/assets/js/dashboard.core.js
@@ -21,6 +21,14 @@
   // there a missing field used to print "undefined%" / "null @ $null" (2026-09-12,
   // found by rendering every tab with the numbers nulled out and then removed).
   const numText = (v) => (v == null || (typeof v === "number" && !isFinite(v))) ? DASH : String(v);
+  // The decision trail (fills, their scope, the plan timeline) ships in its own
+  // sidecar since 2026-09-12. A generation published before the move still has
+  // the sections on the main document, so read the sidecar first and fall back.
+  const trail = (key) => {
+    const side = DATA && DATA.decision_trail;
+    if (side && side[key] != null) return side[key];
+    return DATA ? DATA[key] : undefined;
+  };
   const fmtNum = (v, digits = 2) => {
     if (v == null || !isFinite(v)) return DASH;
     return v.toFixed(digits);

--- a/site/assets/js/dashboard.render.js
+++ b/site/assets/js/dashboard.render.js
@@ -2350,12 +2350,12 @@
     (safe(DATA, "weight_confidence") || []).forEach(w => put(w.ticker, "conv", w));
     const t0rows = (safe(DATA, "t0_setups") || {}).rows || {};
     Object.entries(t0rows).forEach(([k, v]) => put(k, "t0", v));
-    (safe(DATA, "plan_timeline") || []).forEach(a => {
+    (trail("plan_timeline") || []).forEach(a => {
       if (!a.ticker) return;
       const e = (ev[a.ticker] = ev[a.ticker] || {});
       (e.plans = e.plans || []).push(a);
     });
-    (safe(DATA, "decision_traces") || []).forEach(t => {
+    (trail("decision_traces") || []).forEach(t => {
       if (!t.ticker) return;
       const e = (ev[t.ticker] = ev[t.ticker] || {});
       (e.fills = e.fills || []).push(t);
@@ -4382,7 +4382,7 @@
     const wrap = document.getElementById("plan-timeline");
     if (!wrap) return;
     const card = wrap.closest('.card');
-    const list = safe(DATA, "plan_timeline") || [];
+    const list = trail("plan_timeline") || [];
     if (!list.length) { if (card) card.style.display = 'none'; return; }
     if (card) card.style.display = '';
     const fmtConf = c => (c == null ? DASH : (c * 100).toFixed(0) + "%");
@@ -4528,7 +4528,7 @@
     const wrap = document.getElementById("trace-list");
     if (!wrap) return;
     const card = wrap.closest(".card");
-    const list = safe(DATA, "decision_traces") || [];
+    const list = trail("decision_traces") || [];
     if (!list.length) { if (card) card.style.display = "none"; return; }
     if (card) card.style.display = "";
     const ACT = {buy:"买入",add:"加仓",trim:"减仓",sell:"卖出",cut:"割肉",hold:"持有",hold_and_watch:"持有",trim_on_rebound:"反弹减仓",t_only:"仅T+0",add_only_on_trigger:"触发加仓",reject:"不加",watch:"观望",abstain:"弃权"};
@@ -4547,7 +4547,7 @@
     // renders a window (the newest `limit` fills), and summing that window into
     // an unqualified 已实现 total is how it came to print $926.3 while the
     // ledger held US $2,347.68 + HK$7,259.16 (#737).
-    const sc = safe(DATA, "decision_trace_scope") || {};
+    const sc = trail("decision_trace_scope") || {};
     const shown = sc.fillsShown || list.length;
     const total = sc.fillsTotal || shown;
     const realShown = sc.realizedShown || {};

--- a/site/assets/js/dashboard.ui.js
+++ b/site/assets/js/dashboard.ui.js
@@ -219,11 +219,16 @@
   // user whether a refresh actually pulled new data vs. they got the same JSON.
   let LAST_LOADED_AT = null;
   let AUTO_REFRESH_TIMER = null;
+  // A value may list several tabs. `decision_trail` (fills, their scope and the
+  // plan timeline — out of dashboard.json on 2026-09-12) is read by Holdings'
+  // per-name drawer, Plan's timeline and Reflect's trace card. Keep comments out of
+  // the object literal: tests read its keys with a regex.
   const SIDECAR_TAB = {
     macro: "market", sentiment: "market", influencer_feed: "market",
     us_news_digest: "market", em_news: "market",
     decision_audit: "reflect", decision_map: "reflect", shadow_portfolio: "drill",
     brief_projection: "drill",
+    decision_trail: ["drill", "plan", "reflect"],
   };
   const SIDECAR_STATE = new Map();
   let TAB_ACTIVATION_VERSION = 0;
@@ -248,7 +253,7 @@
   // first cross-origin request happens 60 s in, far outside the load window.
   const DATA_PLANE_ORIGIN = "https://raw.githubusercontent.com/KCNyu/clawock/data-plane/";
   const DATA_PLANE_FILES = new Set([
-    "cron-heartbeats", "dashboard", "decision_audit",
+    "cron-heartbeats", "dashboard", "decision_audit", "decision_trail",
     "overview", "shadow_portfolio", "workflow-outcomes",
   ]);
   // null until the first paint succeeds, and back to null for good if that
@@ -352,7 +357,7 @@
   }
 
   function _sidecarsForTab(t) {
-    return Object.keys(SIDECAR_TAB).filter(k => SIDECAR_TAB[k] === t);
+    return Object.keys(SIDECAR_TAB).filter(k => [].concat(SIDECAR_TAB[k]).includes(t));
   }
 
   function _sidecarState(k) {

--- a/src/clawock/publish/dashboard.py
+++ b/src/clawock/publish/dashboard.py
@@ -45,6 +45,12 @@ OUT_DIR = WS_ROOT / 'assets' / 'data'
 OUT_FILE = OUT_DIR / 'dashboard.json'
 OVERVIEW_FILE = OUT_DIR / 'overview.json'
 AUDIT_FILE = OUT_DIR / 'decision_audit.json'
+TRAIL_FILE = OUT_DIR / 'decision_trail.json'
+#: Sections only the Holdings / Plan / Reflect tabs read, shipped in their own
+#: sidecar (2026-09-12). They were 52KB of a 195KB dashboard.json sitting 5KB under
+#: its 200KB cap, where the next degradation lever drops `recent_plans`. Moving
+#: them is not a trim: every byte still ships, to the tabs that read it.
+TRAIL_KEYS = ('decision_traces', 'decision_trace_scope', 'plan_timeline')
 
 # ── Leg shape ────────────────────────────────────────────────────────────
 # The ledger declares its own legs: `portfolio.json`'s `portfolios` is a mapping
@@ -3537,7 +3543,7 @@ def parse_args(argv=None):
              'the guarantee explicitly')
     parser.add_argument(
         '--out-dir', metavar='DIR', default=None,
-        help='write the four outputs of this generation into DIR instead of the '
+        help='write the five outputs of this generation into DIR instead of the '
              'published location. Beats the BUILD_DASHBOARD_OUT / '
              'DECISION_AUDIT_OUT / SHADOW_PORTFOLIO_OUT redirects')
     parser.add_argument(
@@ -3574,6 +3580,7 @@ def resolve_output_paths(out_dir=None):
             'dashboard': directory / OUT_FILE.name,
             'audit': directory / AUDIT_FILE.name,
             'shadow': directory / 'shadow_portfolio.json',
+            'trail': directory / TRAIL_FILE.name,
         }
     out_file = Path(os.environ.get('BUILD_DASHBOARD_OUT') or OUT_FILE)
     return {
@@ -3583,6 +3590,8 @@ def resolve_output_paths(out_dir=None):
                       or (out_file.parent / AUDIT_FILE.name)),
         'shadow': Path(os.environ.get('SHADOW_PORTFOLIO_OUT')
                        or (out_file.parent / 'shadow_portfolio.json')),
+        'trail': Path(os.environ.get('DECISION_TRAIL_OUT')
+                      or (out_file.parent / TRAIL_FILE.name)),
     }
 
 
@@ -3751,6 +3760,20 @@ class UnsupportedLegShape(ProjectionInputError):
     """
 
 
+def split_decision_trail(out):
+    """Move the detail-only sections out of `out` into the trail sidecar.
+
+    Mutates `out` (the sections leave dashboard.json) and returns the sidecar
+    payload. `as_of` is the generation's own stamp, so a reader can tell a trail
+    from an older generation apart from the current one.
+    """
+    trail = {'as_of': out.get('generated_at')}
+    for key in TRAIL_KEYS:
+        if key in out:
+            trail[key] = out.pop(key)
+    return trail
+
+
 def apply_size_budget(out):
     """Spend the size-cap levers, in order, and return `(payload, size_bytes)`.
 
@@ -3843,7 +3866,7 @@ def apply_size_budget(out):
 
 
 def build_projection(previous_source=None, shadow_previous=None):
-    """Compute the four public payloads from the workspace. Writes nothing.
+    """Compute the five public payloads from the workspace. Writes nothing.
 
     Returns `{dashboard, overview, audit, shadow, preservation, summary}` — the
     complete generation, in memory. Which files those payloads end up in, and
@@ -4302,6 +4325,7 @@ def build_projection(previous_source=None, shadow_previous=None):
     # dashboard.json is the canonical cross-tab browser document. Keep it compact:
     # detail activation still pays this parse, and producers should not spend
     # recovered headroom on indentation that adds no user value.
+    _trail = split_decision_trail(out)
     payload, size_bytes = apply_size_budget(out)
 
     overview_payload = serialize_dashboard_payload(compile_overview_projection(out))
@@ -4319,6 +4343,7 @@ def build_projection(previous_source=None, shadow_previous=None):
         'overview': overview_payload,
         'audit': json.dumps(_audit, ensure_ascii=False, separators=(',', ':')),
         'shadow': json.dumps(_shadow, ensure_ascii=False, indent=2) + '\n',
+        'trail': json.dumps(_trail, ensure_ascii=False, separators=(',', ':')),
         # What the caller needs to record the slice-2 telemetry without knowing
         # how the merge works.
         'preservation': {'presence': _presence, 'preserved': _preserved,
@@ -4361,12 +4386,13 @@ def main(argv=None):
             print('dashboard-build: inputs unchanged — skipping rebuild (#846)')
             return 0
     previous_source = resolve_previous_source(args)
-    # The four outputs are one logical generation (clawock.publish.outputs owns that
+    # The five outputs are one logical generation (clawock.publish.outputs owns that
     # contract). Their paths are resolved together, here, so that the projection
     # never learns where it is going to land.
     paths = resolve_output_paths(args.out_dir)
     out_file, overview_file = paths['dashboard'], paths['overview']
     audit_file, shadow_file = paths['audit'], paths['shadow']
+    trail_file = paths['trail']
     out_file.parent.mkdir(parents=True, exist_ok=True)
 
     try:
@@ -4396,6 +4422,7 @@ def main(argv=None):
         str(out_file): projection['dashboard'],
         str(audit_file): projection['audit'],
         str(shadow_file): projection['shadow'],
+        str(trail_file): projection['trail'],
     })
 
     record_preservation(
@@ -4409,6 +4436,7 @@ def main(argv=None):
     print(f'✓ wrote {out_file} ({s["dashboard_bytes"]:,} bytes)')
     print(f'✓ wrote {audit_file} (decision audit sidecar)')
     print(f'✓ wrote {shadow_file} (shadow portfolio sidecar, 模拟·非实盘)')
+    print(f'✓ wrote {trail_file} (decision trail sidecar: traces + plan timeline)')
     print(f'  US: {s["us_holdings"]} holdings, {s["us_active"]} active, value ${s["us_value"]:.0f}')
     print(f'  HK: {s["hk_holdings"]} holdings, {s["hk_active"]} active, value HK${s["hk_value"]:.0f}')
     print(f'  Snapshots: {s["snapshots_embedded"]} embedded / {s["snapshots_total"]} on disk')

--- a/tests/dashboard_tab_runtime.spec.js
+++ b/tests/dashboard_tab_runtime.spec.js
@@ -1910,7 +1910,8 @@ async function testThePlanTimelineClampsItsRationales(browser, base) {
   const page = await context.newPage();
   await stubLiveOrigin(page, {
     patch: (name, json) => {
-      if (name !== "dashboard.json") return null;
+      // The timeline ships in the decision-trail sidecar since 2026-09-12.
+      if (name !== "decision_trail.json") return null;
       json.plan_timeline = plan;
       return json;
     },

--- a/tests/test_build_dashboard.py
+++ b/tests/test_build_dashboard.py
@@ -1403,11 +1403,12 @@ def test_an_explicit_out_dir_keeps_the_generation_together(monkeypatch, tmp_path
 
     paths = dashboard.resolve_output_paths(tmp_path / "cli")
 
-    assert set(paths) == {"overview", "dashboard", "audit", "shadow"}
+    assert set(paths) == {"overview", "dashboard", "audit", "shadow", "trail"}
     assert {p.parent for p in paths.values()} == {tmp_path / "cli"}, (
         "an inherited redirect must not split one generation across two directories")
     assert sorted(p.name for p in paths.values()) == [
-        "dashboard.json", "decision_audit.json", "overview.json", "shadow_portfolio.json",
+        "dashboard.json", "decision_audit.json", "decision_trail.json", "overview.json",
+        "shadow_portfolio.json",
     ]
 
 

--- a/tests/test_dashboard_output_ownership.py
+++ b/tests/test_dashboard_output_ownership.py
@@ -1,4 +1,4 @@
-"""One build, four public outputs, one semantic publication contract."""
+"""One build, five public outputs, one semantic publication contract."""
 import json
 import re
 import pytest
@@ -16,6 +16,7 @@ EXPECTED = {
     "assets/data/dashboard.json",
     "assets/data/decision_audit.json",
     "assets/data/shadow_portfolio.json",
+    "assets/data/decision_trail.json",
 }
 
 
@@ -63,6 +64,10 @@ def _repo(tmp_path):
         "assets/data/shadow_portfolio.json": {
             "as_of": "old",
             "curves": {"USD": [{"date": "2026-07-17", "value": 10}]},
+        },
+        "assets/data/decision_trail.json": {
+            "as_of": "old",
+            "decision_traces": [{"ticker": "SPCH", "date": "2026-08-20", "action": "buy"}],
         },
     }
     for path, value in values.items():
@@ -322,7 +327,7 @@ def _generation(directory, *, clock, value):
         encoding="utf-8")
     (directory / "dashboard.json").write_text(
         json.dumps({"generated_at": clock, "totals": value}), encoding="utf-8")
-    for name in ("decision_audit.json", "shadow_portfolio.json"):
+    for name in ("decision_audit.json", "shadow_portfolio.json", "decision_trail.json"):
         (directory / name).write_text(
             json.dumps({"as_of": clock, "totals": value}), encoding="utf-8")
 
@@ -350,7 +355,7 @@ def test_the_diff_baseline_can_be_a_directory_instead_of_this_repository(tmp_pat
     # Exactly one output genuinely changed. Asserting the precise subset is what
     # makes this test mean anything: `tmp_path` is not a git repository, so the
     # default GitBaseline cannot read any previous version and conservatively
-    # reports ALL FOUR as changed. A test that expected "everything" would pass
+    # reports ALL FIVE as changed. A test that expected "everything" would pass
     # with the baseline argument ignored entirely.
     (worktree / "dashboard.json").write_text(
         json.dumps({"generated_at": "2026-08-05T03:00:00Z", "totals": 2}),

--- a/tests/test_fetch_data_plane_split.py
+++ b/tests/test_fetch_data_plane_split.py
@@ -1,0 +1,41 @@
+"""A generation published before an output was split out of dashboard.json may
+lack it; any other missing member is still a partial generation (#314)."""
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "ops" / "pages"))
+sys.path.insert(0, str(ROOT / "ops" / "publish"))
+import fetch_data_plane  # noqa: E402
+
+TRAIL = "assets/data/decision_trail.json"
+
+
+class _Store:
+    def __init__(self, dashboard):
+        self.dashboard = dashboard
+
+    def _git_blob(self, ref, name):
+        assert name == "assets/data/dashboard.json"
+        return json.dumps(self.dashboard)
+
+
+def _missing(*names):
+    return FileNotFoundError(f"origin/data-plane does not carry {list(names)}")
+
+
+def test_a_pre_split_generation_may_lack_the_new_sidecar():
+    store = _Store({"decision_traces": [], "decision_trace_scope": {}, "plan_timeline": []})
+    assert fetch_data_plane.pre_split_members(store, _missing(TRAIL)) == [TRAIL]
+
+
+def test_a_post_split_generation_without_it_is_still_partial():
+    store = _Store({"generated_at": "x"})
+    assert fetch_data_plane.pre_split_members(store, _missing(TRAIL)) == []
+
+
+def test_other_missing_members_are_never_excused():
+    store = _Store({"decision_traces": [], "decision_trace_scope": {}, "plan_timeline": []})
+    assert fetch_data_plane.pre_split_members(
+        store, _missing(TRAIL, "assets/data/overview.json")) == []

--- a/tests/test_fetch_data_plane_split.py
+++ b/tests/test_fetch_data_plane_split.py
@@ -39,3 +39,15 @@ def test_other_missing_members_are_never_excused():
     store = _Store({"decision_traces": [], "decision_trace_scope": {}, "plan_timeline": []})
     assert fetch_data_plane.pre_split_members(
         store, _missing(TRAIL, "assets/data/overview.json")) == []
+
+
+def test_a_pre_split_generation_is_materialised_in_the_post_split_shape(tmp_path):
+    data = tmp_path / "assets" / "data"
+    data.mkdir(parents=True)
+    (data / "dashboard.json").write_text(json.dumps({
+        "generated_at": "2026-09-12T02:00:00Z", "decision_traces": [{"ticker": "SPCH"}],
+        "decision_trace_scope": {"total": 1}, "plan_timeline": [{"ticker": "07226"}]}))
+    assert fetch_data_plane.materialize_split_members(tmp_path, [TRAIL]) == [TRAIL]
+    trail = json.loads((tmp_path / TRAIL).read_text())
+    assert trail == {"as_of": "2026-09-12T02:00:00Z", "decision_traces": [{"ticker": "SPCH"}],
+                     "decision_trace_scope": {"total": 1}, "plan_timeline": [{"ticker": "07226"}]}


### PR DESCRIPTION
dashboard.json 在 200KB 上限下只剩 5KB（下一档降级删 `recent_plans`）。`decision_traces`(33KB)、`plan_timeline`(18KB)、`decision_trace_scope` 只有 Holdings/Plan/Reflect 读，挪进 `decision_trail.json`——每个字节照发，只是发给读它的 tab。

- 构建器 `split_decision_trail`（限流前移出）+ 第五个输出；`config/dashboard-outputs.json` 登记 ⇒ data-plane 发布、语义差分、Pages 清单、CI 确定性检查自动覆盖
- 前端 `SIDECAR_TAB` 支持一对多；`trail(key)` 先读 sidecar，老一代 payload 回退
- 实测 dashboard.json 144,058 B，trail 48,934 B；全量 3691 passed，浏览器契约全过

https://claude.ai/code/session_01Dkn6aA3Ru8AQUW8qoz7ryV