### PR TITLE
delivery: 发送、回执、账本收成一处——渠道策略表 + 回执唯一定义 + 账本唯一写入口

### DIFF
--- a/ops/host/cron_runs.py
+++ b/ops/host/cron_runs.py
@@ -87,15 +87,17 @@ def fmt_dur(ms):
 # `report-sent-<market>-<phase>-<date>.json` and the brief writes
 # `brief-sent-<date>.json`; both carry `sent_ok`. The crontab passes
 # --market/--phase per job, so this is the same pairing, written down once.
+# Derived, not re-typed: the names come from `delivery_receipts`, the jobs from
+# the ledger's own (market, phase) → job table (2026-09-12, one definition).
+from clawock.automation import delivery_receipts as _receipts  # noqa: E402
+from clawock.automation.workflow_outcomes import REPORT_JOBS as _REPORT_JOBS  # noqa: E402
+from clawock.automation.workflow_outcomes import job_for as _job_for  # noqa: E402
+
 RECEIPT_BY_JOB = {
-    '港股开盘报告': 'report-sent-hk-open-{date}.json',
-    '港股午盘报告': 'report-sent-hk-mid-{date}.json',
-    '港股午后快报': 'report-sent-hk-pm-{date}.json',
-    '港股收盘报告': 'report-sent-hk-close-{date}.json',
-    '美股开盘报告': 'report-sent-us-open-{date}.json',
-    '美股收盘报告': 'report-sent-us-close-{date}.json',
-    '盘前深度简报': 'brief-sent-{date}.json',
+    job: _receipts.receipt_name('report', market=market, phase=phase, date='{date}')
+    for (market, phase), job in _REPORT_JOBS.items()
 }
+RECEIPT_BY_JOB[_job_for(brief=True)] = _receipts.receipt_name('brief', date='{date}')
 # The live desk workspace, whose memory/.tmp holds the receipts. Resolved from
 # the environment rather than from this file's location: run out of an
 # interactive worktree, `parents[2]` is the worktree and every receipt lookup

--- a/ops/system_check.py
+++ b/ops/system_check.py
@@ -1626,14 +1626,16 @@ def check_delivered_but_unarchived(r):
     # 主机 TZ 是 Asia/Shanghai(+0800)，与 HKT 同偏移，所以本地日期就是场次日；
     # 不引 zoneinfo 是为了让这个文件在任何 checkout 上都零依赖地跑起来。
     today = date.today().strftime('%Y-%m-%d')
-    marker = WS / 'memory' / '.tmp' / f'brief-sent-{today}.json'
-    if not marker.is_file():
-        return  # not delivered (yet) — nothing is owed to git
     try:
-        sent = json.loads(marker.read_text())
+        sys.path.insert(0, str(_REPO_ROOT / 'src'))
+        from clawock.automation import delivery_receipts  # noqa: PLC0415
     except Exception:
         return
-    if not (sent.get('sent_ok') or sent.get('tg_ok')):
+    sent = delivery_receipts.read_receipt(delivery_receipts.receipt_path(
+        WS / 'memory' / '.tmp', 'brief', date=today))
+    if sent is None:
+        return  # not delivered (yet), or unreadable — nothing is owed to git
+    if not delivery_receipts.delivered(sent):
         return  # marker exists but nothing went out; a different failure owns it
     unarchived = []
     for rel in (f'memory/{today}-pre-open.md', f'memory/{today}-plan.json'):

--- a/src/clawock/automation/delivery_receipts.py
+++ b/src/clawock/automation/delivery_receipts.py
@@ -1,0 +1,100 @@
+"""Delivery receipts: where a send is filed, what a receipt says, which channels go.
+
+Three postflights send a report, three watchdogs decide whether to back one up, and
+the workflow ledger reconciles slots whose sender died before recording. Until
+2026-09-12 each of the seven spelled its own receipt path, parsed the JSON its own
+way and folded `sent_ok` / `tg_ok` into its own idea of "delivered" — the reason
+more than one incident in this repository's memory is a question of which file to
+believe (`sent_ok` is WeChat only; `tg_ok` is the channel that always lands). They
+now share this one definition. Storage is unchanged — the same file names and the
+same fields — so a receipt written before this module reads the same after it.
+
+Kept in `automation` on purpose: the harness already depends on this package and
+the ledger lives in it, so both sides can use it without a new dependency edge.
+
+`CHANNELS` is the delivery policy. Every kind goes to both channels today. How the
+WeChat allowance (about ten pushes per message kcn sends the bot,
+Tencent/openclaw-weixin#81) is spent is a change to this table, not to three
+postflights.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+KINDS = ("brief", "report", "intraday")
+
+#: kind -> the channels its report is sent to, in send order.
+CHANNELS: dict[str, tuple[str, ...]] = {
+    "brief": ("wechat", "telegram"),
+    "report": ("wechat", "telegram"),
+    "intraday": ("wechat", "telegram"),
+}
+
+
+def _slug(kind, market, phase, date):
+    if kind == "brief":
+        return date
+    if kind == "report":
+        return f"{market}-{phase}-{date}"
+    if kind == "intraday":
+        return market
+    raise ValueError(f"unknown delivery kind: {kind!r}")
+
+
+def receipt_name(kind, *, market=None, phase=None, date=None) -> str:
+    """`brief-sent-{date}.json`, `report-sent-{market}-{phase}-{date}.json`,
+    `intraday-sent-{market}.json` — the names every existing reader already uses."""
+    return f"{kind}-sent-{_slug(kind, market, phase, date)}.json"
+
+
+def parse_receipt_name(name) -> tuple[str, list[str]] | None:
+    """(kind, slug parts) for a receipt file name, or None if it is not one.
+
+    `report-sent-hk-open-2026-09-11.json` → ("report", ["hk", "open", "2026", "09", "11"]).
+    """
+    for kind in KINDS:
+        prefix = f"{kind}-sent-"
+        if name.startswith(prefix) and name.endswith(".json"):
+            return kind, name[len(prefix): -len(".json")].split("-")
+    return None
+
+
+def claim_name(kind, *, market=None, phase=None, date=None) -> str:
+    """The send-right lock taken before a send (#508), same naming as the receipt."""
+    return f"{kind}-send-{_slug(kind, market, phase, date)}.claim"
+
+
+def receipt_path(tmp, kind, **slot) -> Path:
+    return Path(tmp) / receipt_name(kind, **slot)
+
+
+def claim_path(tmp, kind, **slot) -> Path:
+    return Path(tmp) / claim_name(kind, **slot)
+
+
+def build_receipt(*, ts, sent_ok, tg_ok, out="", **fields) -> dict:
+    """The receipt body. `sent_ok` is WeChat, `tg_ok` is Telegram; the caller's own
+    identity fields (first line, context id, slot…) ride along unchanged."""
+    return {"ts": ts, "sent_ok": bool(sent_ok), "tg_ok": bool(tg_ok),
+            **fields, "out": (out or "")[-200:]}
+
+
+def read_receipt(path) -> dict | None:
+    """The receipt at `path`, or None when it is absent or unreadable."""
+    try:
+        payload = json.loads(Path(path).read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def channels(receipt) -> tuple[bool, bool]:
+    """(wechat_ok, telegram_ok) as the receipt proves them — True only when recorded True."""
+    receipt = receipt or {}
+    return receipt.get("sent_ok") is True, receipt.get("tg_ok") is True
+
+
+def delivered(receipt) -> bool:
+    """A receipt proves delivery when either channel reports a real send."""
+    return any(channels(receipt))

--- a/src/clawock/automation/workflow_outcomes.py
+++ b/src/clawock/automation/workflow_outcomes.py
@@ -29,6 +29,7 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from zoneinfo import ZoneInfo
 
+from clawock.automation import delivery_receipts
 from clawock.providers import openclaw
 from clawock.publish.outcomes import summarize_records
 from clawock.workspace import workspace_root
@@ -640,38 +641,64 @@ def reconcile_raw_execution():
 
 def _receipt_delivered(payload):
     """A receipt proves delivery when either channel reports a real send."""
-    return payload.get("sent_ok") is True or payload.get("tg_ok") is True
+    return delivery_receipts.delivered(payload)
+
+
+def record_primary_delivery(job_name, *, slot, wechat_ok, telegram_ok, dry_run=False,
+                            failed_status="failed", wechat_detail=None, **details):
+    """File a slot's delivery verdict — the one writer every postflight uses.
+
+    The brief and report postflights each built this stage by hand, with the same
+    fields in a different order and only one of them keeping WeChat's failure
+    text (#771 made that text the thing worth counting). `failed_status` is the
+    word for "nothing went out": `not_required` when the product itself failed
+    closed and there was nothing to send.
+    """
+    wechat_ok, telegram_ok = bool(wechat_ok), bool(telegram_ok)
+    if not wechat_ok and wechat_detail:
+        details["wechat_detail"] = str(wechat_detail)[-200:]
+    return record_stage(
+        job_name,
+        "primary_delivery",
+        "success" if (wechat_ok or telegram_ok) else failed_status,
+        slot=slot,
+        dry_run=dry_run,
+        channel=delivery_channel(wechat_ok, telegram_ok),
+        wechat_ok=wechat_ok,
+        telegram_ok=telegram_ok,
+        **details,
+    )
 
 
 def _receipt_claims(path):
     """Yield (job, slot_date_or_none, slot_or_none, receipt) for one receipt."""
-    try:
-        payload = json.loads(path.read_text())
-    except (OSError, json.JSONDecodeError):
+    payload = delivery_receipts.read_receipt(path)
+    if payload is None:
         return None
-    if not isinstance(payload, dict):
+    parsed = delivery_receipts.parse_receipt_name(path.name)
+    if parsed is None:
         return None
-    name = path.name
+    kind, parts = parsed
     # The whole receipt travels, not a pre-computed verdict: the caller needs
     # the per-channel flags too (#968), and `_receipt_delivered` is applied at
     # the point of use.
-    if name.startswith("report-sent-"):
+    if kind == "report":
         try:
             job = job_for(payload.get("market"), payload.get("phase"))
         except ValueError:
             return None
         # report-sent-{market}-{phase}-{YYYY-MM-DD}.json
-        return job, name[: -len(".json")].rsplit("-", 3)[-3:], None, payload
-    if name.startswith("intraday-sent-"):
+        return job, parts[-3:], None, payload
+    if kind == "intraday":
         # The intraday receipt names its own job and slot, so it needs no parsing.
         job, slot = payload.get("job"), payload.get("slot")
         if not job or not slot:
             return None
         return job, None, slot, payload
-    if name.startswith("brief-sent-"):
+    if kind == "brief":
         return (
             job_for(brief=True),
-            name[len("brief-sent-"): -len(".json")].split("-"),
+            parts,
             None,
             payload,
         )
@@ -718,8 +745,7 @@ def reconcile_delivery_receipts():
                 # through instead of the old constant "wechat_or_telegram",
                 # which made every reconciled slot invisible to the
                 # wechat-dropped / telegram-covered count.
-                wechat_ok = receipt.get("sent_ok") is True
-                telegram_ok = receipt.get("tg_ok") is True
+                wechat_ok, telegram_ok = delivery_receipts.channels(receipt)
                 record["stages"]["primary_delivery"] = _stage(
                     "success" if delivered else "failed",
                     at=_now().isoformat(),

--- a/src/clawock/harness/_watchdog_common.py
+++ b/src/clawock/harness/_watchdog_common.py
@@ -771,6 +771,40 @@ def _gh_run_failure_detail(run, max_len=300):
     return ' / '.join(lines[-3:])[:max_len]
 
 
+def send_per_policy(kind, message, *, tag, market=None, dry_run=False,
+                    wechat=None, telegram=None, resolve=None):
+    """Send one report to the channels the delivery policy names for its kind.
+
+    Returns `(wechat_ok, wechat_out, telegram_ok)`. The three postflights each
+    carried this sequence by hand — resolve the WeChat target, send, co-send to
+    Telegram — and the policy of which channels a kind goes to lived in all three.
+    It lives in `delivery_receipts.CHANNELS` now; this is the one place that
+    reads it.
+
+    `wechat` / `telegram` / `resolve` are the caller's own send functions, looked
+    up in the caller's module at call time. That is deliberate: the postflight
+    tests replace those names on the postflight module, and a helper that called
+    its own copies would route a test's "send" to the real WeChat.
+    """
+    from clawock.automation.delivery_receipts import CHANNELS
+    policy = CHANNELS[kind]
+    wechat = wechat or send_wechat
+    telegram = telegram or cosend_telegram
+    resolve = resolve or resolve_wechat_target
+    wechat_ok, wechat_out, telegram_ok = False, 'wechat is not in the delivery policy', False
+    if 'wechat' in policy:
+        try:
+            channel, to, account = resolve(market) if market else resolve()
+            wechat_ok, wechat_out = wechat(channel, to, account, message, dry_run=dry_run)
+        except Exception as e:  # noqa: BLE001 — a failed channel must not stop the other
+            wechat_ok, wechat_out = False, str(e)[:300]
+    if 'telegram' in policy:
+        # Same call shape the postflights always used: `dry_run` only when set.
+        telegram_ok, _ = (telegram(message, tag, dry_run=True) if dry_run
+                          else telegram(message, tag))
+    return wechat_ok, wechat_out, telegram_ok
+
+
 def cosend_telegram(message, tag, dry_run=False):
     """Unconditional Telegram co-send for high-value cron reports (brief / staged
     report / intraday). Called from each postflight RIGHT AFTER the WeChat send.

--- a/src/clawock/harness/brief_postflight.py
+++ b/src/clawock/harness/brief_postflight.py
@@ -41,6 +41,7 @@ WS = workspace_root()
 _CHECKOUT = WS
 
 from clawock.automation import workflow_outcomes  # noqa: E402
+from clawock.automation import delivery_receipts  # noqa: E402
 
 # Required concepts and the section labels the brief model may legitimately emit.
 # The canonical keys preserve the existing missing-section issue text.  The aliases
@@ -686,7 +687,7 @@ from ._harness_common import (  # noqa: E402
 from ._watchdog_common import (  # noqa: E402
     BRIEF_URL_TMPL,
     resolve_wechat_target, send_wechat, build_brief_card, cosend_telegram, already_delivered,
-    claim_send, mark_send_started, release_claim, log,
+    claim_send, mark_send_started, release_claim, log, send_per_policy,
 )
 from clawock.harness import brief_render  # noqa: E402
 
@@ -1111,11 +1112,12 @@ def main(argv=None):
     # deterministic compact card from plan.json (build_brief_card).
     wechat_sent = None
     tg_ok = None
+    send_out = None
     # Set when claim_send refuses this process the send right: it then holds no
     # delivery evidence and must not file a primary_delivery verdict over the
     # concurrent holder's (#1006).
     claim_declined = False
-    brief_marker = WS / 'memory' / '.tmp' / f'brief-sent-{today}.json'
+    brief_marker = delivery_receipts.receipt_path(WS / 'memory' / '.tmp', 'brief', date=today)
     # Idempotency: brief marker is per-date, fires once/day. If it already shows a
     # delivery this run is an openclaw auto-retry of a turn that errored only in
     # post-turn summary-gen — the card already went out. Skip re-send. See
@@ -1135,7 +1137,7 @@ def main(argv=None):
         # is written only once both channels have returned, so two postflights
         # racing on the same day would both read "not delivered yet" and both
         # send the card. A dry run sends nothing, so it takes no claim.
-        claim_path = brief_marker.parent / f'brief-send-{today}.claim'
+        claim_path = delivery_receipts.claim_path(brief_marker.parent, 'brief', date=today)
         if args.dry_run:
             claim_won, claim_reason = True, 'dry-run'
         else:
@@ -1150,16 +1152,12 @@ def main(argv=None):
         else:
             if not args.dry_run:
                 mark_send_started(claim_path)
-            try:
-                channel, to, account = resolve_wechat_target()
-                wechat_sent, send_out = send_wechat(channel, to, account, message,
-                                                    dry_run=args.dry_run)
-            except Exception as e:
-                wechat_sent, send_out = False, str(e)[:300]
-            # Always co-send to Telegram (cold-proof) — WeChat can't confirm real delivery.
-            # Record the Telegram result: it's the sole backstop brief_watchdog now uses
-            # (no more WeChat resend), so it needs to know if TG already got this card.
-            tg_ok, _tg_out = cosend_telegram(message, 'brief', dry_run=args.dry_run)
+            # WeChat, then Telegram (cold-proof — WeChat can't confirm real delivery), per
+            # the delivery policy. The Telegram result is recorded: it's the sole backstop
+            # brief_watchdog uses (no WeChat resend), so it needs to know if TG got this card.
+            wechat_sent, send_out, tg_ok = send_per_policy(
+                'brief', message, tag='brief', dry_run=args.dry_run,
+                wechat=send_wechat, telegram=cosend_telegram, resolve=resolve_wechat_target)
             # NEVER write the marker on a dry run (2026-07-16). send_wechat/cosend_telegram
             # return ok=True for a dry run (the CLI exits 0 without sending), so this used to
             # record sent_ok/tg_ok=true for a delivery that never happened. brief_watchdog
@@ -1174,13 +1172,12 @@ def main(argv=None):
             else:
                 try:
                     brief_marker.parent.mkdir(parents=True, exist_ok=True)
-                    safe_write_text(str(brief_marker), json.dumps({
-                        'ts': int(datetime.now().timestamp() * 1000),
-                        'sent_ok': bool(wechat_sent),
-                        'tg_ok': bool(tg_ok),
-                        'first_line': first_line,
-                        'out': (send_out or '')[-200:],
-                    }, ensure_ascii=False))
+                    safe_write_text(str(brief_marker), json.dumps(
+                        delivery_receipts.build_receipt(
+                            ts=int(datetime.now().timestamp() * 1000),
+                            sent_ok=wechat_sent, tg_ok=tg_ok, out=send_out,
+                            first_line=first_line),
+                        ensure_ascii=False))
                 except Exception as e:
                     print(f'warn: brief-sent marker write failed: {e}', file=sys.stderr)
             # Completed send: the marker owns idempotency from here. A dry run
@@ -1251,16 +1248,14 @@ def main(argv=None):
     # after the holder's `success` would stand (reconciliation only fills
     # unknown stages) even though kcn got the card (#1006).
     if not claim_declined:
-        workflow_outcomes.record_stage(
+        workflow_outcomes.record_primary_delivery(
             job_name,
-            'primary_delivery',
-            ('success' if (wechat_sent or tg_ok) else
-             ('not_required' if status == 'fail' else 'failed')),
             slot=slot,
             dry_run=args.dry_run,
-            channel=workflow_outcomes.delivery_channel(bool(wechat_sent), bool(tg_ok)),
-            wechat_ok=bool(wechat_sent),
-            telegram_ok=bool(tg_ok),
+            wechat_ok=wechat_sent,
+            telegram_ok=tg_ok,
+            failed_status='not_required' if status == 'fail' else 'failed',
+            wechat_detail=send_out,
         )
     print(json.dumps(result, ensure_ascii=False, indent=2))
     if (not args.dry_run and status in ('pass', 'warn')

--- a/src/clawock/harness/brief_watchdog.py
+++ b/src/clawock/harness/brief_watchdog.py
@@ -53,6 +53,7 @@ import os
 import sys
 from datetime import datetime
 
+from clawock.automation import delivery_receipts
 from clawock import sessions as trading_calendar
 
 from ._watchdog_common import (
@@ -505,13 +506,8 @@ def main():
         return retrigger_or_wait(today, args.dry_run)
 
     # Trust the postflight send-marker, not the poisoned run-record `delivered`.
-    marker_path = WS / 'memory' / '.tmp' / f'brief-sent-{today}.json'
-    marker = None
-    if marker_path.exists():
-        try:
-            marker = json.loads(marker_path.read_text())
-        except Exception:
-            marker = None
+    marker = delivery_receipts.read_receipt(delivery_receipts.receipt_path(
+        WS / 'memory' / '.tmp', 'brief', date=today))
     now_ms = int(datetime.now(HKT).timestamp() * 1000)
     fresh = bool(marker) and (now_ms - marker.get('ts', 0)) < MARKER_FRESH_MS
     # TG is covered iff postflight's cosend confirmably delivered today's card to

--- a/src/clawock/harness/intraday_postflight.py
+++ b/src/clawock/harness/intraday_postflight.py
@@ -63,7 +63,7 @@ from ._harness_common import (  # noqa: E402
 )
 from ._watchdog_common import (  # noqa: E402
     resolve_wechat_target, send_wechat, cosend_telegram, already_delivered,
-    claim_send, mark_send_started, release_claim, log,
+    claim_send, mark_send_started, release_claim, log, send_per_policy,
 )
 
 from clawock.workspace import workspace_root
@@ -75,6 +75,7 @@ _CHECKOUT = WS
 TMP = WS / 'memory' / '.tmp'
 
 from clawock.automation import cron_heartbeat  # noqa: E402
+from clawock.automation import delivery_receipts  # noqa: E402
 from clawock.harness import intraday_delta  # noqa: E402
 
 # A report file older than this is assumed to be a previous slot's leftover. Kept
@@ -300,19 +301,16 @@ def delivery_marker_payload(ctx, *, ts, sent_ok, tg_ok, first_line, market, out,
     away here.
     """
     heartbeat = ctx.get('heartbeat') or {}
-    return {
-        'ts': ts,
-        'sent_ok': bool(sent_ok),
-        'tg_ok': bool(tg_ok),
-        'first_line': first_line,
-        'market': market,
-        'job': heartbeat.get('job'),
-        'slot': heartbeat.get('slot'),
-        'context_id': ctx.get('context_id'),
-        'context_generated_at': ctx.get('generated_at'),
-        'delivery_state': delivery_state,
-        'out': (out or '')[-200:],
-    }
+    return delivery_receipts.build_receipt(
+        ts=ts, sent_ok=sent_ok, tg_ok=tg_ok, out=out,
+        first_line=first_line,
+        market=market,
+        job=heartbeat.get('job'),
+        slot=heartbeat.get('slot'),
+        context_id=ctx.get('context_id'),
+        context_generated_at=ctx.get('generated_at'),
+        delivery_state=delivery_state,
+    )
 
 
 def publish_data_plane(market):
@@ -476,7 +474,7 @@ def main(argv=None):
     # evidence about whether delivery happened and must not file a
     # primary_delivery verdict over the concurrent holder's (#1006).
     send_claim_declined = False
-    marker = TMP / f'intraday-sent-{args.market}.json'
+    marker = delivery_receipts.receipt_path(TMP, 'intraday', market=args.market)
     # Idempotency: if openclaw auto-retried this run (post-turn summary-gen failure),
     # the report already went out on the prior attempt — skip the re-send. Intraday's
     # marker is per-market, so use a 20min window (< the 30min slot cadence, > the
@@ -515,7 +513,7 @@ def main(argv=None):
             # is taken before the send. Its staleness window matches the
             # already_delivered one — intraday's claim is per-market, so it must
             # expire before the next 30min slot needs it.
-            claim_path = TMP / f'intraday-send-{args.market}.claim'
+            claim_path = delivery_receipts.claim_path(TMP, 'intraday', market=args.market)
             won, claim_reason = claim_send(claim_path, stale_after_ms=20 * 60 * 1000)
             if not won:
                 print(f'concurrency: intraday {args.market} send is already claimed '
@@ -527,17 +525,14 @@ def main(argv=None):
                 send_claim_declined = True
             else:
                 mark_send_started(claim_path)
-                try:
-                    channel, to, account = resolve_wechat_target(args.market)
-                    wechat_sent, send_out = send_wechat(channel, to, account, message,
-                                                        dry_run=False)
-                except Exception as e:
-                    wechat_sent, send_out = False, str(e)[:300]
-                # Always co-send to Telegram (cold-proof) — WeChat can't confirm real
-                # delivery. Record the Telegram result: it's the sole backstop
-                # intraday_watchdog now uses (no more WeChat resend), so it needs to
-                # know if TG already got this.
-                tg_ok, _tg_out = cosend_telegram(message, f'intraday-{args.market}')
+                # WeChat, then Telegram (cold-proof — WeChat can't confirm real
+                # delivery), per the delivery policy. The Telegram result is recorded:
+                # it's the sole backstop intraday_watchdog uses (no WeChat resend), so
+                # it needs to know if TG already got this.
+                wechat_sent, send_out, tg_ok = send_per_policy(
+                    'intraday', message, tag=f'intraday-{args.market}', market=args.market,
+                    wechat=send_wechat, telegram=cosend_telegram,
+                    resolve=resolve_wechat_target)
                 delivered_this_run = bool(wechat_sent or tg_ok)
                 # Only the process that actually sent may write the marker. A
                 # declined claim writing one would tell intraday_watchdog this

--- a/src/clawock/harness/intraday_watchdog.py
+++ b/src/clawock/harness/intraday_watchdog.py
@@ -73,6 +73,7 @@ import json
 import sys
 from datetime import datetime, timedelta
 
+from clawock.automation import delivery_receipts
 from ._watchdog_common import (
     WS, HKT, log, find_job_id, today_runs, KCN_TELEGRAM,
     transcript_loop_score, last_report_text, send_telegram,
@@ -330,13 +331,8 @@ def main():
     loop_score, _ = transcript_loop_score(session_id)
     looped = loop_score >= LOOP_THRESHOLD
 
-    marker_path = WS / 'memory' / '.tmp' / f'intraday-sent-{args.market}.json'
-    marker = None
-    if marker_path.exists():
-        try:
-            marker = json.loads(marker_path.read_text())
-        except Exception:
-            marker = None
+    marker = delivery_receipts.read_receipt(delivery_receipts.receipt_path(
+        WS / 'memory' / '.tmp', 'intraday', market=args.market))
     now_ms = int(watchdog_now.timestamp() * 1000)
     # A confirmed Telegram send for this exact slot, whichever attempt made it.
     # The evidence gate below can still decline to call the slot covered (stale

--- a/src/clawock/harness/report_postflight.py
+++ b/src/clawock/harness/report_postflight.py
@@ -50,6 +50,7 @@ _CHECKOUT = WS
 TMP = WS / 'memory' / '.tmp'
 
 from clawock.automation import workflow_outcomes  # noqa: E402
+from clawock.automation import delivery_receipts  # noqa: E402
 
 # The deterministic report core moved into the installed package so `clawock
 # report` can run it without a repository checkout. Re-exported here so this
@@ -98,7 +99,7 @@ from ._harness_common import (  # noqa: E402
 )
 from ._watchdog_common import (  # noqa: E402
     resolve_wechat_target, send_wechat, cosend_telegram, already_delivered,
-    claim_send, mark_send_started, release_claim, log,
+    claim_send, mark_send_started, release_claim, log, send_per_policy,
 )
 
 
@@ -203,29 +204,28 @@ def deliver_wechat(market, phase, date, wechat_prefix, text, delivery_state='del
     # "may already have reached WeChat" by whoever claims next.
     if claim_path is not None:
         mark_send_started(claim_path)
+    # WeChat, then Telegram, per the delivery policy. Telegram is never gated on
+    # WeChat — WeChat can't confirm real delivery (cold drop returns sent_ok=true).
+    # Its result is recorded too: it's the cold-proof channel and the ONLY backstop
+    # report_watchdog uses (no WeChat resend), so the watchdog needs to know
+    # whether THIS report already reached Telegram.
+    sent_ok, out, tg_ok = send_per_policy(
+        'report', message, tag=f'{market}-{phase}', market=market,
+        wechat=send_wechat, telegram=cosend_telegram, resolve=resolve_wechat_target)
+    marker = delivery_receipts.receipt_path(TMP, 'report', market=market, phase=phase,
+                                            date=date)
     try:
-        channel, to, account = resolve_wechat_target(market)
-        sent_ok, out = send_wechat(channel, to, account, message, dry_run=False)
-    except Exception as e:
-        sent_ok, out = False, str(e)[:300]
-    # Always co-send to Telegram — WeChat can't confirm real delivery (cold drop
-    # returns sent_ok=true), so we don't gate on it. See cosend_telegram docstring.
-    # Record the Telegram result too: it's the cold-proof channel and the ONLY
-    # backstop report_watchdog now uses (it no longer re-sends WeChat), so the
-    # watchdog needs to know whether THIS report already reached Telegram.
-    tg_ok, _tg_out = cosend_telegram(message, f'{market}-{phase}')
-    marker = TMP / f'report-sent-{market}-{phase}-{date}.json'
-    try:
-        safe_write_text(str(marker), json.dumps({
-            'ts': int(datetime.now().timestamp() * 1000),
-            'sent_ok': bool(sent_ok),
-            'tg_ok': bool(tg_ok),
-            'first_line': sent_first,
-            'delivery_state': delivery_state,
+        safe_write_text(str(marker), json.dumps(delivery_receipts.build_receipt(
+            ts=int(datetime.now().timestamp() * 1000),
+            sent_ok=sent_ok,
+            tg_ok=tg_ok,
+            out=out,
+            first_line=sent_first,
+            delivery_state=delivery_state,
             # Exact slot identity for report_watchdog. In prose mode the sent body
             # starts with the title, so first_line no longer matches the context's
             # block and a string compare would mirror a duplicate to Telegram.
-            'context_id': context_id,
+            context_id=context_id,
             # When the id alone can't decide, this dates the DATA we sent, not the
             # send. `context_id` is strictly per-preflight-invocation, so an
             # openclaw auto-retry (which re-runs preflight but is blocked from
@@ -235,11 +235,10 @@ def deliver_wechat(market, phase, date, wechat_prefix, text, delivery_state='del
             # hk-pm, both double-sent a deterministic fallback). The watchdog needs
             # to tell that two-minute regeneration apart from the genuinely stale
             # body of 2026-07-24, and only the source context's own timestamp can.
-            'context_generated_at': context_generated_at,
-            'market': market,
-            'phase': phase,
-            'out': (out or '')[-200:],
-        }, ensure_ascii=False))
+            context_generated_at=context_generated_at,
+            market=market,
+            phase=phase,
+        ), ensure_ascii=False))
     except Exception as e:
         print(f'warn: report send marker write failed: {e}', file=sys.stderr)
     # This send ran to completion, so the marker now owns the idempotency question
@@ -456,7 +455,8 @@ def main(argv=None):
     # so if it already shows a delivery this is an openclaw auto-retry of a run that
     # errored only in post-turn summary-gen — the report already went out. Skip the
     # re-send (watchdog still backstops a genuine miss). See already_delivered.
-    report_marker = TMP / f'report-sent-{args.market}-{args.phase}-{today}.json'
+    report_marker = delivery_receipts.receipt_path(TMP, 'report', market=args.market,
+                                                   phase=args.phase, date=today)
     delivery_state = 'failed' if status == 'fail' else 'delivered'
     blocked = already_delivered(report_marker)
 
@@ -503,7 +503,8 @@ def main(argv=None):
         # The marker only proves a send that FINISHED. A concurrent postflight
         # that is still mid-send leaves no marker at all, so the claim is what
         # keeps the second one quiet (#508).
-        claim_path = TMP / f'report-send-{args.market}-{args.phase}-{today}.claim'
+        claim_path = delivery_receipts.claim_path(TMP, 'report', market=args.market,
+                                                  phase=args.phase, date=today)
         won, send_claim = claim_send(claim_path)
         if not won:
             print(f'concurrency: {args.market}-{args.phase} send is already claimed '
@@ -536,25 +537,15 @@ def main(argv=None):
     # verdict, and a late false `failed` would stand forever because receipt
     # reconciliation only fills unknown stages (#1006).
     if not claim_declined:
-        wechat_ok = bool(wechat_sent)
-        telegram_ok = False
-        try:
-            telegram_ok = json.loads(report_marker.read_text()).get('tg_ok') is True
-        except Exception:
-            pass
-        primary_delivery_ok = wechat_ok or telegram_ok
-        workflow_outcomes.record_stage(
+        _, telegram_ok = delivery_receipts.channels(
+            delivery_receipts.read_receipt(report_marker))
+        workflow_outcomes.record_primary_delivery(
             job_name,
-            'primary_delivery',
-            'success' if primary_delivery_ok else 'failed',
             slot=slot,
-            channel=workflow_outcomes.delivery_channel(wechat_ok, telegram_ok),
-            wechat_ok=wechat_ok,
+            wechat_ok=wechat_sent,
             telegram_ok=telegram_ok,
-            # Only on failure: a reason on a send that worked is noise in a
-            # record read by eye.
-            **({} if wechat_ok else {
-                'wechat_detail': (send_out or 'no output from the transport')[-200:]}),
+            # Kept only on failure: a reason on a send that worked is noise.
+            wechat_detail=send_out or 'no output from the transport',
             deterministic_fallback=(status == 'fail'),
         )
 

--- a/src/clawock/harness/report_preflight.py
+++ b/src/clawock/harness/report_preflight.py
@@ -42,6 +42,7 @@ Output keys:
   needs_risk_section: bool (true if any ALERT, or STOP+TRIM >= 2)
 """
 
+from clawock.automation import delivery_receipts
 from clawock.harness import _harness_common
 from clawock.harness._harness_common import run_analyze
 import argparse
@@ -100,7 +101,8 @@ def drop_stale_contexts(market, phase, today):
     # today's are written LATER by postflight, so dropping other-date ones is safe.
     patterns = [
         (f'report-context-{market}-{phase}-*.json', context_path(market, phase, today).name),
-        (f'report-sent-{market}-{phase}-*.json',    f'report-sent-{market}-{phase}-{today}.json'),
+        (delivery_receipts.receipt_name('report', market=market, phase=phase, date='*'),
+         delivery_receipts.receipt_name('report', market=market, phase=phase, date=today)),
         (f'report-upgrade-{market}-{phase}-*.claim', f'report-upgrade-{market}-{phase}-{today}.claim'),
     ]
     dropped = []

--- a/src/clawock/harness/report_watchdog.py
+++ b/src/clawock/harness/report_watchdog.py
@@ -47,6 +47,7 @@ import sys
 import time
 from datetime import datetime
 
+from clawock.automation import delivery_receipts
 from ._watchdog_common import (
     WS, HKT, log, find_job_id, today_runs,
     transcript_loop_score, last_report_text, send_telegram, KCN_TELEGRAM,
@@ -270,13 +271,9 @@ def main():
 
     ctx_id = ctx.get('context_id')
 
-    marker_path = WS / 'memory' / '.tmp' / f'report-sent-{args.market}-{args.phase}-{today}.json'
-    marker = None
-    if marker_path.exists():
-        try:
-            marker = json.loads(marker_path.read_text())
-        except Exception:
-            marker = None
+    marker = delivery_receipts.read_receipt(delivery_receipts.receipt_path(
+        WS / 'memory' / '.tmp', 'report', market=args.market,
+        phase=args.phase, date=today))
     now_ms = int(datetime.now(HKT).timestamp() * 1000)
     delivered_this_slot, delivery_judge = slot_delivered(
         marker, ctx_id, raw_block_first, now_ms,
@@ -344,8 +341,8 @@ def main():
               else 'marker stale/mismatch')
     # #544: with no marker, a claim whose holder died mid-send is the explicit
     # "WeChat delivery unconfirmed" case — say it instead of silently mirroring.
-    claim_path = WS / 'memory' / '.tmp' / \
-        f'report-send-{args.market}-{args.phase}-{today}.claim'
+    claim_path = delivery_receipts.claim_path(
+        WS / 'memory' / '.tmp', 'report', market=args.market, phase=args.phase, date=today)
     claim = None
     try:
         if claim_path.exists():

--- a/tests/test_delivery_receipts.py
+++ b/tests/test_delivery_receipts.py
@@ -1,0 +1,104 @@
+"""One definition of where a send is filed, what a receipt says, which channels go.
+
+Seven modules used to spell the receipt names and fold `sent_ok`/`tg_ok` their own
+way (2026-09-12 architecture pass). They share `delivery_receipts` now; the last test
+keeps it that way.
+"""
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+from clawock.automation import delivery_receipts as receipts
+from clawock.harness import _watchdog_common as common
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_the_names_are_the_ones_every_existing_receipt_already_has():
+    assert receipts.receipt_name("brief", date="2026-09-11") == "brief-sent-2026-09-11.json"
+    assert (receipts.receipt_name("report", market="hk", phase="open", date="2026-09-11")
+            == "report-sent-hk-open-2026-09-11.json")
+    assert receipts.receipt_name("intraday", market="us") == "intraday-sent-us.json"
+    assert receipts.claim_name("brief", date="2026-09-11") == "brief-send-2026-09-11.claim"
+    assert (receipts.claim_name("report", market="us", phase="close", date="2026-09-11")
+            == "report-send-us-close-2026-09-11.claim")
+    assert receipts.claim_name("intraday", market="hk") == "intraday-send-hk.claim"
+    with pytest.raises(ValueError):
+        receipts.receipt_name("weekly", date="x")
+
+
+def test_parsing_round_trips_every_kind():
+    assert receipts.parse_receipt_name("report-sent-hk-open-2026-09-11.json") == (
+        "report", ["hk", "open", "2026", "09", "11"])
+    assert receipts.parse_receipt_name("brief-sent-2026-09-11.json") == (
+        "brief", ["2026", "09", "11"])
+    assert receipts.parse_receipt_name("intraday-sent-us.json") == ("intraday", ["us"])
+    assert receipts.parse_receipt_name("wechat-sends.json") is None
+
+
+def test_sent_ok_is_wechat_and_tg_ok_is_telegram_and_only_true_counts(tmp_path):
+    body = receipts.build_receipt(ts=1, sent_ok=0, tg_ok="yes", out="x" * 300, first_line="L")
+    assert body["sent_ok"] is False and body["tg_ok"] is True and len(body["out"]) == 200
+    path = tmp_path / "r.json"
+    path.write_text(json.dumps(body))
+    assert receipts.channels(receipts.read_receipt(path)) == (False, True)
+    assert receipts.delivered(receipts.read_receipt(path))
+    assert receipts.channels({"sent_ok": "true", "tg_ok": 1}) == (False, False)
+    (tmp_path / "bad.json").write_text("[1, 2]")
+    assert receipts.read_receipt(tmp_path / "bad.json") is None
+    assert receipts.read_receipt(tmp_path / "absent.json") is None
+
+
+def test_the_policy_table_decides_which_channels_are_called(monkeypatch):
+    calls = []
+
+    def wechat(channel, to, account, message, dry_run=False):
+        calls.append("wechat")
+        return True, "ok"
+
+    def telegram(message, tag):
+        calls.append("telegram")
+        return True, "ok"
+
+    def resolve(market=None):
+        return "openclaw-weixin", "kcn", None
+
+    monkeypatch.setitem(receipts.CHANNELS, "intraday", ("telegram",))
+    result = common.send_per_policy("intraday", "m", tag="t", market="hk",
+                                    wechat=wechat, telegram=telegram, resolve=resolve)
+    assert calls == ["telegram"] and result == (False, "wechat is not in the delivery policy", True)
+
+    calls.clear()
+    monkeypatch.setitem(receipts.CHANNELS, "intraday", ("wechat", "telegram"))
+    assert common.send_per_policy("intraday", "m", tag="t", market="hk", wechat=wechat,
+                                  telegram=telegram, resolve=resolve) == (True, "ok", True)
+    assert calls == ["wechat", "telegram"]
+
+
+def test_a_failed_wechat_never_stops_telegram():
+    def wechat(*a, **k):
+        raise RuntimeError("gateway gone")
+
+    def resolve(market=None):
+        return "c", "t", None
+
+    ok, out, tg = common.send_per_policy("brief", "m", tag="brief", wechat=wechat,
+                                         telegram=lambda m, t: (True, ""), resolve=resolve)
+    assert (ok, tg) == (False, True) and "gateway gone" in out
+
+
+def test_no_module_spells_a_receipt_name_of_its_own():
+    """The names live in `delivery_receipts`. A second spelling is how the seven
+    readers drifted apart in the first place; prose in docstrings is fine."""
+    pattern = re.compile(r"""(f?['"])(brief|report|intraday)-(sent|send)-""")
+    offenders = []
+    for path in list((ROOT / "src").rglob("*.py")) + list((ROOT / "ops").rglob("*.py")):
+        if path.name == "delivery_receipts.py":
+            continue
+        for number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+            code = line.split("#", 1)[0]
+            if pattern.search(code):
+                offenders.append(f"{path.relative_to(ROOT)}:{number}: {line.strip()[:90]}")
+    assert not offenders, "use delivery_receipts.receipt_name / claim_name:\n" + "\n".join(offenders)


### PR DESCRIPTION
「送没送到」原来由七个模块各自回答（三个 postflight 各写一遍发送与三种回执、三个 watchdog 各自读、账本对账一套解析、system_check 与 cron_runs 各一张手抄表）。

- `automation/delivery_receipts.py`：回执/锁文件名（生成+解析）、回执构造/读取、`channels()`/`delivered()` 唯一判定、渠道策略表 `CHANNELS`（放 automation ⇒ 不新增依赖边）
- `workflow_outcomes.record_primary_delivery`：账本 primary_delivery 唯一写入口（brief 也开始记微信失败原因）
- `_watchdog_common.send_per_policy`：按策略表发送；发送函数由调用方传入，测试桩照样生效
- 存储不变（文件名/字段一致）
- 闸：任何代码手拼回执/锁文件名即红（当场抓到 report_watchdog 一处）

全量 3697 passed；依赖边清单不变。

https://claude.ai/code/session_01Dkn6aA3Ru8AQUW8qoz7ryV