### PR TITLE
providers: 读 cron 任务时带上已禁用的——主机触发的任务在 OpenClaw 里是禁用的（热修）

### DIFF
--- a/src/clawock/providers/openclaw.py
+++ b/src/clawock/providers/openclaw.py
@@ -549,6 +549,10 @@ def _fossil_runs(job_id, paths: OpenClawPaths | None = None):
     return None
 
 
+#: Disabled jobs included — see `read_jobs`.
+LIST_ALL_JOBS = ["list", "--all", "--json"]
+
+
 def read_jobs(source: str = "auto", *, paths: OpenClawPaths | None = None) -> CronRead:
     """Cron jobs from auto|cli|sqlite|fossil.
 
@@ -559,8 +563,12 @@ def read_jobs(source: str = "auto", *, paths: OpenClawPaths | None = None) -> Cr
     if source not in SOURCES:
         raise ValueError(f"unsupported cron source: {source}")
     if source in {"auto", "cli"}:
-        data = (cron_cli_json(["list", "--json"], binary=paths.binary)
-                if paths else cron_cli_json(["list", "--json"]))
+        # `--all`: without it the CLI omits disabled jobs, and a host-triggered job
+        # is disabled in OpenClaw on purpose (clawock.automation.cron_trigger). On
+        # 2026-09-12 that made the contract check report it as a missing live job
+        # (CRITICAL, which blocks every live push) the moment it was disabled.
+        data = (cron_cli_json(LIST_ALL_JOBS, binary=paths.binary)
+                if paths else cron_cli_json(LIST_ALL_JOBS))
         if isinstance(data, dict) and isinstance(data.get("jobs"), list):
             return CronRead(data["jobs"], "cli")
         if source == "cli":
@@ -630,7 +638,7 @@ def read_jobs_strict(*, paths: OpenClawPaths | None = None, runner=None) -> list
     to whoever calls which.
     """
     data = cron_cli_json(
-        ["list", "--json"], binary=paths.binary if paths else None, runner=runner)
+        LIST_ALL_JOBS, binary=paths.binary if paths else None, runner=runner)
     if not isinstance(data, dict):
         raise RuntimeError("openclaw cron list failed: no JSON object returned")
     jobs = data.get("jobs")

--- a/tests/test_cron_list_includes_disabled.py
+++ b/tests/test_cron_list_includes_disabled.py
@@ -1,0 +1,17 @@
+"""The CLI omits disabled jobs unless asked, and a host-triggered job is disabled
+in OpenClaw on purpose. Reading without `--all` made the contract check call it a
+missing live job — a CRITICAL that blocks every live push (2026-09-12 03:24)."""
+from clawock.providers import openclaw
+
+
+def test_both_job_reads_ask_for_disabled_jobs_too(monkeypatch):
+    seen = []
+
+    def fake(args, **kwargs):
+        seen.append(list(args))
+        return {"jobs": [{"name": "港股午后快报", "enabled": False}]}
+
+    monkeypatch.setattr(openclaw, "cron_cli_json", fake)
+    assert openclaw.read_jobs("cli").entries[0]["enabled"] is False
+    assert openclaw.read_jobs_strict()[0]["name"] == "港股午后快报"
+    assert seen and all("--all" in args for args in seen)


### PR DESCRIPTION
#1443 上线后把 港股午后快报 在 OpenClaw 里禁用，CLI 默认 `cron list` 不含禁用任务 ⇒ 契约比对报 missing live job（CRITICAL，卡 live 推送），sync 复核与 `cron-trigger --check` 也看不见它。

两处读取改为 `cron list --all --json`（实测只多出这一个任务）。本地对线上 openclaw 验证：system_check cron 三项 OK、`cron-trigger --check` 通过。

https://claude.ai/code/session_01Dkn6aA3Ru8AQUW8qoz7ryV