### PR TITLE
fix(harness): maybe_commit push 失败时返回 False 而非 True (#1450, #1451)

### DIFF
--- a/src/clawock/harness/brief_postflight.py
+++ b/src/clawock/harness/brief_postflight.py
@@ -847,7 +847,7 @@ def maybe_commit(status, today, dry_run=False):
     push_ok, push_out = push_with_rebase_retry()
     if push_ok:
         return True, 'committed + pushed'
-    return True, f'committed (push failed: {push_out[-150:]})'
+    return False, f'committed (push failed: {push_out[-150:]})'
 
 
 def _ensure_jekyll_front_matter(md_path, date):
@@ -1199,7 +1199,9 @@ def main(argv=None):
     commit_ok, commit_msg = maybe_commit(
         publication_status, today, dry_run=args.dry_run
     )
-    if (status in ('pass', 'warn') and projection_ready
+    if not commit_ok:
+        data_plane_status = 'failed'
+    elif (status in ('pass', 'warn') and projection_ready
             and not args.dry_run):
         data_plane_status = dashboard_publication_state(WS)
     else:

--- a/src/clawock/harness/report_postflight.py
+++ b/src/clawock/harness/report_postflight.py
@@ -286,8 +286,8 @@ def maybe_commit(status, commit_msg):
         if rebuild_ok:
             return True, 'committed + pushed'
         return True, f'committed + pushed (dashboard={publication_state})'
-    return True, (f'committed (push failed: {push_out[-150:]}; '
-                  f'dashboard={publication_state})')
+    return False, (f'committed (push failed: {push_out[-150:]}; '
+                   f'dashboard={publication_state})')
 
 
 def classify_data_plane(commit_ok, commit_msg):

--- a/tests/test_commit_push_state.py
+++ b/tests/test_commit_push_state.py
@@ -1,0 +1,68 @@
+"""maybe_commit() must return (False, ...) when git push fails.
+
+Both brief_postflight and report_postflight used to return (True, 'committed
+(push failed: ...)') — the caller treated commit_ok=True as "published to
+origin", but push had silently failed, leaving Pages serving stale data.
+
+These AST checks assert the invariant: any return whose first element is True
+must NOT appear in a branch guarded by push failure. The test must FAIL on
+unpatched code (return True on push failure) and PASS after the fix.
+"""
+import ast
+from pathlib import Path
+
+SRC = Path(__file__).resolve().parents[1] / "src"
+
+MODULES = [
+    "clawock/harness/brief_postflight.py",
+    "clawock/harness/report_postflight.py",
+]
+
+
+def _find_maybe_commit_returns(src_path: Path):
+    """Yield every (return_node, first_element_unparsed) in maybe_commit."""
+    tree = ast.parse(src_path.read_text())
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == "maybe_commit":
+            for ret in ast.walk(node):
+                if isinstance(ret, ast.Return) and isinstance(ret.value, ast.Tuple):
+                    if ret.value.elts:
+                        first = ret.value.elts[0]
+                        yield ret, ast.unparse(first)
+
+
+def test_maybe_commit_push_failure_returns_false():
+    """No maybe_commit should return True in a push-failure branch."""
+    for rel in MODULES:
+        src_path = SRC / rel
+        for ret, first_unparsed in _find_maybe_commit_returns(src_path):
+            full = ast.unparse(ret.value)
+            if "push failed" in full:
+                assert first_unparsed != "True", (
+                    f"{rel}: maybe_commit returns (True, ...) on push failure: "
+                    f"{full[:120]}"
+                )
+
+
+def test_maybe_commit_idempotent_returns_true():
+    """'nothing to commit' is idempotent — returning True is correct."""
+    for rel in MODULES:
+        src_path = SRC / rel
+        for ret, first_unparsed in _find_maybe_commit_returns(src_path):
+            full = ast.unparse(ret.value)
+            if "nothing to commit" in full:
+                assert first_unparsed == "True", (
+                    f"{rel}: idempotent path should return True, got {first_unparsed}"
+                )
+
+
+def test_maybe_commit_pushed_returns_true():
+    """Successful push — returning True is correct."""
+    for rel in MODULES:
+        src_path = SRC / rel
+        for ret, first_unparsed in _find_maybe_commit_returns(src_path):
+            full = ast.unparse(ret.value)
+            if "committed + pushed" in full:
+                assert first_unparsed == "True", (
+                    f"{rel}: push-ok path should return True, got {first_unparsed}"
+                )


### PR DESCRIPTION
## 问题

brief_postflight 和 report_postflight 的 `maybe_commit()` 在 `push_with_rebase_retry()` 失败时仍返回 `(True, ...)`。caller 把 `commit_ok=True` 当作「已发布到 origin」，导致：
- Pages dashboard 静默显示前一天的数据
- watchdog 不告警
- `workflow_outcomes` 标记 success

## 改法

| 文件 | 行 | 改动 |
|---|---|---|
| `brief_postflight.py` | 850 | push 失败分支 `return True` → `return False` |
| `report_postflight.py` | 289 | 同上 |
| `brief_postflight.py` | 1202-1206 | `commit_ok=False` 时 `data_plane_status='failed'` |
| `tests/test_commit_push_state.py` | 新增 | AST 静态闸验证 maybe_commit 返回值不变式 |

report_postflight 已有 `classify_data_plane()` 在 `commit_ok=False` 时返回 `'failed'`，无需额外改。

## 验证

### RED-CHECK 修前 → 修后

```
# brief_postflight only (issue 1450)
修前: BUG: maybe_commit returns True on push failure → exit 1
修后: OK: maybe_commit returns False on push failure → exit 0

# both files (issue 1451)
修前: BUG: brief_postflight.py::maybe_commit returns (True, ...) on push failure
      BUG: report_postflight.py::maybe_commit returns (True, ...) on push failure → exit 1
修后: OK → exit 0
```

### 新测试红→绿

```
修前 (unpatched origin/master): 1 FAILED (test_maybe_commit_push_failure_returns_false)
修后 (patched):                3 PASSED
```

### 现有测试

66 个 postflight/workflow 测试全部通过。

## 风险

- push 失败时 brief_postflight 退出码从 0 变为 2（因 `data_plane_status='failed'`）——这是正确行为：stale 数据不应静默通过。
- `classify_data_plane` 的 `'committed_local'` 分支变为 dead code（`commit_ok` 现在在 push 失败时为 False），保留不动以最小化 diff。