### PR TITLE
fix(harness): 把 #1457 的三个副作用收回来——跳过≠失败、本地提交≠没提交、闸不能空过

### DIFF
--- a/src/clawock/harness/brief_postflight.py
+++ b/src/clawock/harness/brief_postflight.py
@@ -850,6 +850,31 @@ def maybe_commit(status, today, dry_run=False):
     return False, f'committed (push failed: {push_out[-150:]})'
 
 
+def classify_commit_outcome(commit_ok, commit_msg):
+    """The data-plane state maybe_commit's outcome settles on its own.
+
+    `None` means it settles nothing — the commit landed, so the dashboard build
+    status file is the authority on whether the public data plane is current.
+
+    maybe_commit returns False for three different things, and #1457 printed all
+    three as `failed`: a push that did not reach origin (a real failure), but also
+    a dry run and a brief that was rejected before any commit was attempted —
+    neither of which touched the data plane. A `--dry-run` is the run you make
+    specifically to check the wiring, and it was reporting
+    `data_plane_status: failed` next to `commit_msg: skipped (dry-run)`: the same
+    run, two contradictory claims. `committed_local` is the vocabulary
+    report_postflight.classify_data_plane and intraday_postflight.publish_data_plane
+    already use for a commit that exists locally but lost its push.
+    """
+    if commit_msg.startswith('skipped'):
+        return 'skipped'
+    if 'push failed' in commit_msg:
+        return 'committed_local'
+    if not commit_ok:
+        return 'failed'
+    return None
+
+
 def _ensure_jekyll_front_matter(md_path, date):
     """Prepend Jekyll front matter so Pages can render the brief in-site (not via github.com blob)."""
     if not md_path.exists():
@@ -1199,8 +1224,9 @@ def main(argv=None):
     commit_ok, commit_msg = maybe_commit(
         publication_status, today, dry_run=args.dry_run
     )
-    if not commit_ok:
-        data_plane_status = 'failed'
+    settled = classify_commit_outcome(commit_ok, commit_msg)
+    if settled is not None:
+        data_plane_status = settled
     elif (status in ('pass', 'warn') and projection_ready
             and not args.dry_run):
         data_plane_status = dashboard_publication_state(WS)

--- a/src/clawock/harness/report_postflight.py
+++ b/src/clawock/harness/report_postflight.py
@@ -292,6 +292,18 @@ def maybe_commit(status, commit_msg):
 
 def classify_data_plane(commit_ok, commit_msg):
     """Return an explicit publication state independent of prose validation."""
+    # A failed push is read BEFORE `commit_ok`. #1457 made maybe_commit report it
+    # as commit_ok=False — correct, origin did not get the data — but routing it
+    # into `failed` threw away the one distinction the reader acts on: the commit
+    # exists locally and the next push carries it, versus nothing was committed at
+    # all and the data is gone until the next run rebuilds it. Both already grade
+    # the same (neither is in {'published', 'current'}, so the stage is `warning`
+    # and main() returns 2); only the label differs, and the label is the whole
+    # point of this function. intraday_postflight.publish_data_plane reports the
+    # same physical state as 'committed_local' too — one vocabulary across the
+    # three harnesses.
+    if 'push failed' in commit_msg:
+        return 'committed_local'
     if not commit_ok:
         return 'failed'
     if 'dashboard=publish_failed' in commit_msg:

--- a/tests/test_commit_push_state.py
+++ b/tests/test_commit_push_state.py
@@ -1,68 +1,178 @@
-"""maybe_commit() must return (False, ...) when git push fails.
+"""maybe_commit must never report a push that did not reach origin as a success.
 
-Both brief_postflight and report_postflight used to return (True, 'committed
-(push failed: ...)') — the caller treated commit_ok=True as "published to
-origin", but push had silently failed, leaving Pages serving stale data.
+Both postflights used to return `(True, 'committed (push failed: ...)')`: the
+caller read commit_ok=True as "published to origin", so a lost push left Pages
+serving yesterday's data with a green exit code (#1450, #1451; fixed in #1457).
 
-These AST checks assert the invariant: any return whose first element is True
-must NOT appear in a branch guarded by push failure. The test must FAIL on
-unpatched code (return True on push failure) and PASS after the fix.
+The first version of this gate asserted that no `return` whose message contains
+the literal `push failed` yields True. That gate passes on the bug: restore the
+old `return True, ...` and reword the message (`'committed (推送失败: ...)'`) and
+all of it goes green, because nothing required it to find anything — the failure
+mode the repo has hit before ("a count of 0 has two causes, and the gate only
+credits the flattering one"). So the checks below:
+
+  * find the push-failure branch STRUCTURALLY — the `push_with_rebase_retry()`
+    call, the flag it binds, the `if <flag>:` that guards the success returns —
+    and fail loudly when that shape is not found, instead of passing quietly;
+  * feed every message maybe_commit can actually return through the module's own
+    data-plane classifier and assert a return that did not reach origin never
+    lands in a published state, whatever the wording is;
+  * enumerate the harnesses that own a `maybe_commit`, so a new one cannot slip
+    past the gate by not being on the list.
 """
 import ast
+import importlib
 from pathlib import Path
+
+import pytest
 
 SRC = Path(__file__).resolve().parents[1] / "src"
 
-MODULES = [
-    "clawock/harness/brief_postflight.py",
-    "clawock/harness/report_postflight.py",
-]
+#: module path -> the classifier that turns its maybe_commit outcome into a
+#: data-plane state. `test_no_unlisted_maybe_commit` keeps this list complete.
+MODULES = {
+    "clawock/harness/brief_postflight.py": "classify_commit_outcome",
+    "clawock/harness/report_postflight.py": "classify_data_plane",
+}
+
+#: Everything the panel and the ledger know how to read. `None` is
+#: brief_postflight's "settles nothing, ask the dashboard build status file".
+KNOWN_STATES = {
+    None, "published", "current", "skipped",
+    "committed_local", "failed", "publish_failed", "rebuild_failed",
+    "unavailable",
+}
+
+#: The two states that claim origin has the data.
+PUBLISHED_STATES = {"published", "current"}
 
 
-def _find_maybe_commit_returns(src_path: Path):
-    """Yield every (return_node, first_element_unparsed) in maybe_commit."""
-    tree = ast.parse(src_path.read_text())
-    for node in ast.walk(tree):
-        if isinstance(node, ast.FunctionDef) and node.name == "maybe_commit":
-            for ret in ast.walk(node):
-                if isinstance(ret, ast.Return) and isinstance(ret.value, ast.Tuple):
-                    if ret.value.elts:
-                        first = ret.value.elts[0]
-                        yield ret, ast.unparse(first)
+def _maybe_commit(rel):
+    tree = ast.parse((SRC / rel).read_text())
+    fns = [n for n in ast.walk(tree)
+           if isinstance(n, ast.FunctionDef) and n.name == "maybe_commit"]
+    assert len(fns) == 1, f"{rel}: expected exactly one maybe_commit, found {len(fns)}"
+    return fns[0]
 
 
-def test_maybe_commit_push_failure_returns_false():
-    """No maybe_commit should return True in a push-failure branch."""
-    for rel in MODULES:
-        src_path = SRC / rel
-        for ret, first_unparsed in _find_maybe_commit_returns(src_path):
-            full = ast.unparse(ret.value)
-            if "push failed" in full:
-                assert first_unparsed != "True", (
-                    f"{rel}: maybe_commit returns (True, ...) on push failure: "
-                    f"{full[:120]}"
-                )
+def _returns_below(nodes):
+    out = []
+    for node in nodes:
+        out.extend(n for n in ast.walk(node) if isinstance(n, ast.Return))
+    return out
 
 
-def test_maybe_commit_idempotent_returns_true():
-    """'nothing to commit' is idempotent — returning True is correct."""
-    for rel in MODULES:
-        src_path = SRC / rel
-        for ret, first_unparsed in _find_maybe_commit_returns(src_path):
-            full = ast.unparse(ret.value)
-            if "nothing to commit" in full:
-                assert first_unparsed == "True", (
-                    f"{rel}: idempotent path should return True, got {first_unparsed}"
-                )
+def _push_failure_returns(fn, rel):
+    """Every `return` reachable once push_with_rebase_retry() reported failure."""
+    for i, stmt in enumerate(fn.body):
+        if not (isinstance(stmt, ast.Assign)
+                and isinstance(stmt.value, ast.Call)
+                and getattr(stmt.value.func, "id", None) == "push_with_rebase_retry"):
+            continue
+        target = stmt.targets[0]
+        assert isinstance(target, ast.Tuple) and isinstance(target.elts[0], ast.Name), (
+            f"{rel}: push_with_rebase_retry()'s result is not unpacked into "
+            f"(ok, output) — this gate can no longer tell which branch is the "
+            f"failure one; teach it the new shape."
+        )
+        flag = target.elts[0].id
+        rest = fn.body[i + 1:]
+        guard = rest[0] if rest else None
+        assert (isinstance(guard, ast.If)
+                and isinstance(guard.test, ast.Name)
+                and guard.test.id == flag), (
+            f"{rel}: the statement after push_with_rebase_retry() is not "
+            f"`if {flag}:` — this gate can no longer tell which branch is the "
+            f"failure one; teach it the new shape."
+        )
+        return _returns_below(list(guard.orelse) + list(rest[1:]))
+    return None
 
 
-def test_maybe_commit_pushed_returns_true():
-    """Successful push — returning True is correct."""
-    for rel in MODULES:
-        src_path = SRC / rel
-        for ret, first_unparsed in _find_maybe_commit_returns(src_path):
-            full = ast.unparse(ret.value)
-            if "committed + pushed" in full:
-                assert first_unparsed == "True", (
-                    f"{rel}: push-ok path should return True, got {first_unparsed}"
-                )
+def _message_text(node):
+    """A representative string for a return's message, literal or f-string."""
+    if isinstance(node, ast.Constant):
+        return str(node.value)
+    if isinstance(node, ast.JoinedStr):
+        return "".join(v.value if isinstance(v, ast.Constant) else "<runtime>"
+                       for v in node.values)
+    return ast.unparse(node)
+
+
+@pytest.mark.parametrize("rel", sorted(MODULES))
+def test_push_failure_never_returns_true(rel):
+    """The branch taken when the push failed must not report success."""
+    returns = _push_failure_returns(_maybe_commit(rel), rel)
+    assert returns, (
+        f"{rel}: no push_with_rebase_retry() call found in maybe_commit. Either "
+        f"the push moved elsewhere or the function was renamed — until this gate "
+        f"is pointed at the new push path it proves nothing, so it fails instead "
+        f"of passing on zero findings."
+    )
+    for ret in returns:
+        assert isinstance(ret.value, ast.Tuple), (
+            f"{rel}: maybe_commit's push-failure branch returns "
+            f"{ast.unparse(ret.value)}, not a (ok, message) tuple"
+        )
+        first = ret.value.elts[0]
+        assert not (isinstance(first, ast.Constant) and first.value is True), (
+            f"{rel}: maybe_commit reports success on a failed push: "
+            f"{ast.unparse(ret.value)[:120]}"
+        )
+
+
+@pytest.mark.parametrize("rel", sorted(MODULES))
+def test_every_outcome_is_classified_and_unreached_origin_is_never_published(rel):
+    """Each message maybe_commit can return maps to a state, and only a landed
+    push maps to a published one.
+
+    This is the wording-proof half: renaming `push failed` cannot make the
+    failure look published, because the assertion is about what the module's own
+    classifier does with the message the module itself returns.
+    """
+    module = importlib.import_module(
+        rel.removesuffix(".py").replace("/", ".")
+    )
+    classify = getattr(module, MODULES[rel])
+    fn = _maybe_commit(rel)
+    returns = [n for n in ast.walk(fn) if isinstance(n, ast.Return)]
+    assert len(returns) >= 4, (
+        f"{rel}: maybe_commit has {len(returns)} returns; the outcomes this gate "
+        f"is meant to enumerate are gone or moved"
+    )
+    seen_unlanded = 0
+    for ret in returns:
+        assert isinstance(ret.value, ast.Tuple), (
+            f"{rel}: maybe_commit returns {ast.unparse(ret.value)}, not a tuple"
+        )
+        first, message = ret.value.elts[0], _message_text(ret.value.elts[1])
+        ok = first.value if isinstance(first, ast.Constant) else None
+        state = classify(ok, message)
+        assert state in KNOWN_STATES, (
+            f"{rel}: {classify.__name__}({ok!r}, {message!r}) -> {state!r}, "
+            f"which no reader maps. Add it to the panel's vocabulary or return "
+            f"an existing state."
+        )
+        if ok is True:
+            continue
+        seen_unlanded += 1
+        assert state not in PUBLISHED_STATES, (
+            f"{rel}: {message!r} does not reach origin but classifies as "
+            f"{state!r} — the exact claim #1450/#1451 were about"
+        )
+    assert seen_unlanded, (
+        f"{rel}: maybe_commit has no non-success return left to check"
+    )
+
+
+def test_no_unlisted_maybe_commit():
+    """A new harness with its own maybe_commit joins the gate, not bypasses it."""
+    found = {
+        path.relative_to(SRC).as_posix()
+        for path in SRC.rglob("*.py")
+        if "def maybe_commit(" in path.read_text()
+    }
+    assert found == set(MODULES), (
+        f"maybe_commit exists in {sorted(found - set(MODULES))} but is not covered "
+        f"by this gate (or {sorted(set(MODULES) - found)} no longer defines one)"
+    )


### PR DESCRIPTION
## 问题

#1457 的核心是对的：`brief_postflight.maybe_commit` 在 push 失败时返回 `True`，而 `data_plane_status` 来自 `logs/dashboard_build_status.json`（dashboard 重建的状态，和这次 `git push` 是**两次不同的推送**），所以推送丢了照样 exit 0 + stage success。这半保留。

但它带进来三个副作用：

| # | 位置 | 问题 |
|---|---|---|
| 1 | `report_postflight.classify_data_plane` | 先判 `not commit_ok` 返回 `failed`，`'push failed'` 分支再也到不了 → `committed_local` 变死代码 |
| 2 | `brief_postflight.main` | `if not commit_ok: data_plane_status='failed'` 把 dry-run / 简报判 fail 这两个**没碰数据面**的跳过也染成 failed |
| 3 | `tests/test_commit_push_state.py` | 三个断言都是 `if "push failed" in <text>: assert ...`，没有一条要求「至少匹配到一个 return」——改文案即空过 |

补充：#1457 正文给 report_postflight 列的三条症状（Pages 静默旧数据 / watchdog 不告警 / outcomes 标 success）**对 report_postflight 不成立**——`classify_data_plane` 早就把 push 失败判成 `committed_local`，而 `report_postflight.py:593` 是 `if data_plane_status not in {'published','current'}: return 2`，stage 也已经是 `warning`。那半改动的净效果只有「丢标签」。

## 改法

1. `classify_data_plane` 先判 `'push failed'` 再判 `commit_ok` —— 恢复 `committed_local`。两档本来就同一个 grading 桶（都不在 `{published,current}`），差别只在标签，而标签是这个函数唯一的产出；`intraday_postflight.publish_data_plane` 也一直用这个词。
2. 新增 `brief_postflight.classify_commit_outcome(commit_ok, commit_msg)`：`skipped` / `committed_local` / `failed` / `None`（= 提交落地了，去问 dashboard build status）。三个 harness 一套词表。
3. 重写 `tests/test_commit_push_state.py`，三条都不靠文案：
   - **结构定位** push 失败分支：找 `push_with_rebase_retry()` 调用 → 它绑定的 flag → 紧跟的 `if <flag>:`；形状对不上就断言失败，而不是静默通过
   - 把 `maybe_commit` 能返回的**每条**消息喂给该模块自己的分类器，断言「没到 origin 的返回不得分类成 `published`/`current`」
   - 枚举 `src/` 下所有 `def maybe_commit`，必须与清单相等——新 harness 不能靠「不在名单里」绕开

## 验证

### 闸的红→绿（关键证据）

同一份代码（bug 原样放回 + 文案改成「推送失败」）：

```
旧闸: 3 passed          ← 空过
新闸: 1 failed
  AssertionError: clawock/harness/brief_postflight.py: maybe_commit reports
  success on a failed push: (True, f'committed (推送失败: {push_out[-150:]})')
```

### dry-run 不再自相矛盾

```
maybe_commit(status='pass', dry_run=True)  -> (False, 'skipped (dry-run)')     => data_plane 'skipped'
maybe_commit(status='fail', dry_run=False) -> (False, 'skipped (status=fail)') => data_plane 'skipped'
push 失败                                                                       => 'committed_local'
git add 失败                                                                    => 'failed'
```

### 现有测试

`test_commit_push_state` / `test_report_assembly` / `test_brief_projection_publication_gate` / `test_cron_schedule_panel` / `test_workflow_outcomes` / `test_brief_postflight_fail_closed` / `test_push_budget_covers_its_retry_ladder` = **103 passed**。

## 风险

- `committed_local` 与 `failed` 在 ledger 和退出码上同档，这次只换标签，不改判定。
- `brief_postflight` 的 `data_plane_status` 在 push 失败时仍是非 `published` ⇒ #1457 拿到的 exit 2 保留。

## 没改的

`cron_schedule._narrate_degraded` 对 `committed_local` 说「几分钟内自动追上，无需处理」——一度改了又撤回：`publish_dashboard.sh` 每 20 分钟推一次，滞留提交确实会被下一次推送带走，`test_cron_schedule_panel` 的 docstring 也把这个意图写死了。原文案是对的。

https://claude.ai/code/session_01EVgkbxu7uktmDiFN9fHwhq
