### PR TITLE
fix(harness): dashboard build status 改原子写——判红的那份证据自己会被写成半截 (#1455)

### DIFF
--- a/src/clawock/harness/_harness_common.py
+++ b/src/clawock/harness/_harness_common.py
@@ -257,9 +257,21 @@ def _record_dashboard_build(build_ok, publish_ok, output, ws=None, timings=None)
             # same fact.
             'timings_s': dict(timings or {}),
         }
+        # Atomic (#1455). This file is the ONLY evidence cron_health_check has
+        # about the data plane, and `json.loads` failing on it is graded
+        # `failed` — a red line about a dashboard that may be perfectly fine.
+        # It has five writers (three postflights plus the host publisher's
+        # `0,20,40 * * * *` tick, and the off-host brief fallback), so two of
+        # them overlapping is not exotic: a plain `write_text` truncates first
+        # and writes after, and any reader in that window gets an empty or
+        # half file. `os.replace` makes the worst case "old status or new
+        # status", never "half a status". The module already re-exports
+        # `safe_write_text` for harness scripts (below) while this write, the
+        # one a gate reads, went around it.
+        from clawock.safe_io import safe_write_json
         path = ws / DASHBOARD_BUILD_STATUS
         path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(json.dumps(status, ensure_ascii=False, indent=2))
+        safe_write_json(str(path), status)
         if not build_ok:
             print(f'🔴 dashboard build FAILED — recorded to {DASHBOARD_BUILD_STATUS}; '
                   f'local outputs were not refreshed. tail: {(output or "")[-500:]}',

--- a/tests/test_dashboard_build_status_atomicity.py
+++ b/tests/test_dashboard_build_status_atomicity.py
@@ -16,8 +16,6 @@ import json
 import threading
 from pathlib import Path
 
-import pytest
-
 from clawock.harness import _harness_common
 
 SRC = Path(__file__).resolve().parents[1] / "src"

--- a/tests/test_dashboard_build_status_atomicity.py
+++ b/tests/test_dashboard_build_status_atomicity.py
@@ -1,0 +1,110 @@
+"""`logs/dashboard_build_status.json` must never be readable as half a file.
+
+It is the only evidence `cron_health_check.check_dashboard_build` has about the
+data plane, and an unparseable status file is graded `failed` — a red line about
+a dashboard that may be perfectly healthy, produced by nothing but the writing.
+
+Five writers touch it: brief / report / intraday postflight, the host
+publisher's `0,20,40 * * * *` tick, and the off-host brief fallback. A plain
+`Path.write_text` truncates the file and writes after, so a reader landing in
+that window gets an empty or partial file. `safe_io.safe_write_json` writes a
+temp file in the same directory and `os.replace`s it: the worst case becomes
+"the old status or the new status" (#1455).
+"""
+import ast
+import json
+import threading
+from pathlib import Path
+
+import pytest
+
+from clawock.harness import _harness_common
+
+SRC = Path(__file__).resolve().parents[1] / "src"
+MODULE = SRC / "clawock/harness/_harness_common.py"
+WRITER = "_record_dashboard_build"
+ATOMIC_WRITERS = {"safe_write_json", "safe_write_text"}
+
+
+def _writer_fn():
+    tree = ast.parse(MODULE.read_text())
+    fns = [n for n in ast.walk(tree)
+           if isinstance(n, ast.FunctionDef) and n.name == WRITER]
+    assert len(fns) == 1, f"{WRITER} is gone or duplicated — this gate is pointed at nothing"
+    return fns[0]
+
+
+def test_status_writer_goes_through_an_atomic_writer():
+    fn = _writer_fn()
+    src = ast.unparse(fn)
+    assert "DASHBOARD_BUILD_STATUS" in src, (
+        f"{WRITER} no longer names the status file; the write moved and this "
+        f"gate must be pointed at wherever it went"
+    )
+    calls = {node.func.attr if isinstance(node.func, ast.Attribute)
+             else getattr(node.func, "id", None)
+             for node in ast.walk(fn) if isinstance(node, ast.Call)}
+    assert calls & ATOMIC_WRITERS, (
+        f"{WRITER} writes the status file without an atomic writer "
+        f"({' / '.join(sorted(ATOMIC_WRITERS))})"
+    )
+    assert "write_text" not in calls and "write_bytes" not in calls, (
+        f"{WRITER} still has a non-atomic write; a reader can catch the file "
+        f"between truncate and write"
+    )
+
+
+def test_a_reader_never_catches_a_half_written_status(tmp_path):
+    """The behavioural half: hammer the real writer while parsing the file.
+
+    On a plain `write_text` this fails within a few hundred iterations (the
+    reader sees a 0-byte file). Through `os.replace` there is no window at all,
+    so this is deterministic rather than lucky.
+    """
+    (tmp_path / "logs").mkdir()
+    path = tmp_path / _harness_common.DASHBOARD_BUILD_STATUS
+    # A payload the size of a real one: `tail` alone is capped at 4000 chars.
+    output = "warn: section degraded\n" + ("x" * 4000)
+    stop = threading.Event()
+    failures = []
+
+    def write():
+        i = 0
+        while not stop.is_set() and i < 400:
+            _harness_common._record_dashboard_build(
+                True, True, output, ws=tmp_path, timings={"dashboard_build": i}
+            )
+            i += 1
+
+    writer = threading.Thread(target=write)
+    writer.start()
+    try:
+        reads = 0
+        while writer.is_alive() and reads < 4000:
+            try:
+                text = path.read_text()
+            except FileNotFoundError:
+                continue
+            reads += 1
+            try:
+                json.loads(text)
+            except json.JSONDecodeError as exc:
+                failures.append(f"{exc} — {len(text)} bytes: {text[:80]!r}")
+                break
+    finally:
+        stop.set()
+        writer.join(timeout=30)
+
+    assert not failures, (
+        "cron_health_check would grade this read as `failed`: " + failures[0]
+    )
+    assert path.exists() and json.loads(path.read_text())["ok"] is True
+
+
+def test_no_temp_files_are_left_behind(tmp_path):
+    """`os.replace` writes a sibling temp file; it must not survive the write."""
+    (tmp_path / "logs").mkdir()
+    _harness_common._record_dashboard_build(True, True, "", ws=tmp_path)
+    leftovers = [p.name for p in (tmp_path / "logs").iterdir()
+                 if p.name.startswith(".tmp-")]
+    assert not leftovers, f"temp files left in logs/: {leftovers}"


### PR DESCRIPTION
## 问题

`logs/dashboard_build_status.json` 是 `cron_health_check.check_dashboard_build` 唯一的判据，`json.loads` 失败直接 `state='failed'` / `ok=False`——一条关于「dashboard 可能好好的」的红线，成因只是写入本身。

`_harness_common.py:262` 用 `Path.write_text`：先 truncate 再写。这个文件有**五个写入方**（brief / report / intraday 三个 postflight、主机 publisher 的 `0,20,40 * * * *`、off-host brief fallback），两个撞上不算稀奇；落在 truncate 与 write 之间的读者拿到空文件或半截。

同一个模块在 `:542` 还**给 harness 脚本 re-export 了 `safe_write_text`**——而这条被闸读的写入自己绕开了它。

## 改法

`safe_io.safe_write_json(str(path), status)`：同目录临时文件 + `os.replace`，最坏是「旧状态或新状态」，不存在「半个状态」。

## 验证（RED-CHECK 修前 → 修后）

未打补丁（`origin/master` 的写法）：

```
FAILED test_status_writer_goes_through_an_atomic_writer
FAILED test_a_reader_never_catches_a_half_written_status
  AssertionError: cron_health_check would grade this read as `failed`:
    Expecting value: line 1 column 1 (char 0) — 0 bytes: ''
```

修后：`3 passed`。

新测试两条腿，都不空过：

| 腿 | 做法 |
|---|---|
| 静态 | AST 定位 `_record_dashboard_build`，要求它仍指名 `DASHBOARD_BUILD_STATUS`（写入搬走了就**断言失败**而不是静默通过）、必须调到 `safe_write_json`/`safe_write_text`、不得再出现 `write_text`/`write_bytes` |
| 行为 | 真起一个写线程打 400 次真实大小的 payload（`tail` 上限 4000 字符），主线程同时 `json.loads`，读到半截就红 |

既有测试：**73 passed**（`import_layering` / `cron_health_check` / `safe_io_*` / `workflow_health`）。

## 风险

`safe_write_json` 会在末尾补一个换行，且 `allow_nan=False`。这个文件本来就只放 bool / int / str / dict，没有浮点；换行只会让下一次写入时的 git diff 干净一行。

## 没做的

issue 的建议 2（把整个 `rebuild_dashboard` 包进 `flock`）没做：`os.replace` 已经把「半截文件」这条路径消掉了，而 build 子进程本来就跑在 `flock DASHBOARD_PUBLISH_LOCK` 里；再加一层锁改的是并发语义，不是原子性。

Closes #1455

https://claude.ai/code/session_01EVgkbxu7uktmDiFN9fHwhq
