### PR TITLE
a11y(dashboard): tab 与面板互指，焦点环收成一条基线 (#1446, #1453)

### DIFF
--- a/site/assets/css/dashboard.css
+++ b/site/assets/css/dashboard.css
@@ -243,6 +243,25 @@
 
   * { box-sizing: border-box; }
   html, body { margin: 0; padding: 0; }
+
+  /* 键盘焦点基线（#1453）。在这之前每个交互组件都得自己记得写
+     :focus-visible —— #1316 给排序表头补了一条、#1331 给 ECharts 补了一条，
+     都是单点修，于是 .refresh-btn / .dh-toggle / .panel-load-retry / .nav-link
+     四个真能聚焦的控件一直没有焦点环：鼠标用户看得见 hover 高亮，键盘用户
+     什么都看不见（WCAG 2.4.7）。基线按元素选择器写（特指度 0-0-1），所以任何
+     组件自己的 .foo:focus-visible 规则照旧覆盖它 —— 包括 .dm-dot 那条
+     `outline: none`（它用 ::before 放大代替焦点环）。新组件从此默认有环，
+     忘了写才是安全的那一侧。 */
+  a:focus-visible,
+  button:focus-visible,
+  summary:focus-visible,
+  input:focus-visible,
+  select:focus-visible,
+  textarea:focus-visible,
+  [tabindex]:focus-visible {
+    outline: 2px solid var(--focus);
+    outline-offset: 2px;
+  }
   /* 手机（≤560px）blur 减半保 saturate（#995 同款判据）：小屏上大面积
      blur 的渲染代价与玻璃读感不成比例，半径减半、饱和保留——色度差才是
      「这是玻璃」的真凭据。 */
@@ -406,6 +425,8 @@
     transition: background var(--duration-fast) ease, color var(--duration-fast) ease, transform var(--duration-fast) var(--ease-out);
   }
   .refresh-btn:active { transform: scale(0.92); }
+  /* 圆形按钮：环贴着边走，2px 外扩会切到相邻的 asof 文本。 */
+  .refresh-btn:focus-visible { outline: 2px solid var(--focus); outline-offset: 1px; }
   @media (hover: hover) and (pointer: fine) {
     .refresh-btn:hover { background: var(--surface-2); color: var(--text); }
   }
@@ -426,6 +447,7 @@
   @media (hover: hover) and (pointer: fine) {
     .nav-link:hover { color: var(--text); background: var(--card-2); }
   }
+  .nav-link:focus-visible { outline: 2px solid var(--focus); outline-offset: -2px; }
   @media (max-width: 480px) {
     .nav-link { padding: var(--space-2); font-size: var(--fs-sm); }
   }
@@ -572,6 +594,7 @@
     padding: 4px 12px;
   }
   .panel-load-retry:hover { background: var(--border); }
+  .panel-load-retry:focus-visible { outline: 2px solid var(--focus); outline-offset: 2px; }
 
   /* ── Mobile (<1024px): iOS-native paged tabs ──
      Fixed chrome (header + footer), the content area is a horizontal
@@ -2710,6 +2733,7 @@
     transition: transform var(--duration-fast) var(--ease-out), color var(--duration-fast) ease, border-color var(--duration-fast) ease;
   }
   .dh-toggle:active { transform: scale(.97); }
+  .dh-toggle:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
   @media (hover: hover) and (pointer: fine) {
     .dh-toggle:hover { color: var(--text); border-color: var(--text-tertiary); }
   }

--- a/site/index.html
+++ b/site/index.html
@@ -117,12 +117,12 @@ layout: null
     </div>
   </div>
   <nav class="tabs" role="tablist">
-    <button class="tab-btn active" data-tab="hero" role="tab" aria-selected="true">Overview</button>
-    <button class="tab-btn" data-tab="drill" role="tab">Holdings</button>
-    <button class="tab-btn" data-tab="risk" role="tab">Risk</button>
-    <button class="tab-btn" data-tab="market" role="tab">Signals</button>
-    <button class="tab-btn" data-tab="plan" role="tab">Plan</button>
-    <button class="tab-btn" data-tab="reflect" role="tab">Reflect</button>
+    <button class="tab-btn active" id="tab-hero" data-tab="hero" aria-controls="panel-hero" role="tab" aria-selected="true">Overview</button>
+    <button class="tab-btn" id="tab-drill" data-tab="drill" aria-controls="panel-drill" role="tab" aria-selected="false">Holdings</button>
+    <button class="tab-btn" id="tab-risk" data-tab="risk" aria-controls="panel-risk" role="tab" aria-selected="false">Risk</button>
+    <button class="tab-btn" id="tab-market" data-tab="market" aria-controls="panel-market" role="tab" aria-selected="false">Signals</button>
+    <button class="tab-btn" id="tab-plan" data-tab="plan" aria-controls="panel-plan" role="tab" aria-selected="false">Plan</button>
+    <button class="tab-btn" id="tab-reflect" data-tab="reflect" aria-controls="panel-reflect" role="tab" aria-selected="false">Reflect</button>
   </nav>
   <div class="swipe-hint" aria-hidden="true"></div>
 </header>
@@ -162,7 +162,7 @@ layout: null
        ============================================ -->
   <div class="pager" id="pager">
 
-  <section class="panel active" data-panel="hero">
+  <section class="panel active" id="panel-hero" data-panel="hero" role="tabpanel" aria-labelledby="tab-hero">
     <h2>Overview</h2>
 
     <div class="overview-command">
@@ -380,7 +380,7 @@ layout: null
     </div>
 
   </section>
-  <section class="panel" data-panel="drill">
+  <section class="panel" id="panel-drill" data-panel="drill" role="tabpanel" aria-labelledby="tab-drill">
     <h2>Holdings</h2>
 
     <div class="sect-divider holdings-section-heading">持仓明细</div>
@@ -541,7 +541,7 @@ layout: null
     </div>
 
   </section>
-  <section class="panel" data-panel="risk">
+  <section class="panel" id="panel-risk" data-panel="risk" role="tabpanel" aria-labelledby="tab-risk">
     <h2>Risk</h2>
 
     <div class="sect-divider">敞口 · 杠杆 · 硬闸</div>
@@ -689,7 +689,7 @@ layout: null
     </div>
 
   </section>
-  <section class="panel" data-panel="market">
+  <section class="panel" id="panel-market" data-panel="market" role="tabpanel" aria-labelledby="tab-market">
     <h2>Signals</h2>
 
     <div class="card desktop-wide" id="tape-card">
@@ -791,7 +791,7 @@ layout: null
     </div>
 
   </section>
-  <section class="panel" data-panel="plan">
+  <section class="panel" id="panel-plan" data-panel="plan" role="tabpanel" aria-labelledby="tab-plan">
     <h2>Plan</h2>
 
     <div class="card lead" id="add-side-card" style="display:none">
@@ -836,7 +836,7 @@ layout: null
     </div>
 
   </section>
-  <section class="panel" data-panel="reflect">
+  <section class="panel" id="panel-reflect" data-panel="reflect" role="tabpanel" aria-labelledby="tab-reflect">
     <h2>Reflect</h2>
 
     <div class="sect-divider">决策质量 · 自评</div>

--- a/tests/test_dashboard_tabs_a11y.py
+++ b/tests/test_dashboard_tabs_a11y.py
@@ -1,0 +1,122 @@
+"""Tab semantics and keyboard focus on the dashboard shell.
+
+Two findings from the same root: the markup carries `role="tab"` without the
+attributes that make a tab a tab, and the stylesheet grew `:hover` affordances
+without the `:focus-visible` twin, one component at a time (#1446, #1453).
+
+* A `role="tab"` with no `aria-controls`, on a panel with no `role="tabpanel"`,
+  reads to a screen reader as a plain button: switching panels announces
+  nothing, so a keyboard user has no way to tell the content changed.
+* A control with a `:hover` style and no `:focus-visible` style is invisible to
+  the keyboard exactly where it is obvious to the mouse (WCAG 2.4.7). #1316 and
+  #1331 each fixed one such control; nothing stopped the next one from landing
+  the same way, which is why this file checks the baseline rule rather than a
+  list of components.
+"""
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+HTML = (ROOT / "site/index.html").read_text()
+CSS = (ROOT / "site/assets/css/dashboard.css").read_text()
+JS = "\n".join(p.read_text() for p in sorted((ROOT / "site/assets/js").glob("*.js")))
+
+TAB_BUTTONS = re.findall(r'<button class="tab-btn[^"]*"[^>]*role="tab"[^>]*>', HTML)
+PANELS = re.findall(r'<section class="panel[^"]*"[^>]*>', HTML)
+
+#: Classes that carry a `:hover` rule and deliberately have no `:focus-visible`
+#: twin, because nothing focusable ever wears them. `test_non_focusable_hover_
+#: classes_are_really_not_focusable` re-checks that claim against the markup.
+NON_FOCUSABLE_HOVER = {
+    "card": "面板里的容器 div，没有 tabindex；里面的按钮各自有焦点环",
+    "dm-signal": "决策地图的 <tr>；可聚焦的是单元格 .dm-cell（tabindex=0，已有 :focus-visible）",
+    "ret-cell": "只存在于 CSS，全仓没有任何生产者渲染它",
+}
+
+
+def _attr(tag, name):
+    m = re.search(rf'{name}="([^"]*)"', tag)
+    return m.group(1) if m else None
+
+
+def test_tab_buttons_and_panels_point_at_each_other():
+    assert len(TAB_BUTTONS) == 6, f"expected 6 tab buttons, found {len(TAB_BUTTONS)}"
+    assert len(PANELS) == 6, f"expected 6 panels, found {len(PANELS)}"
+
+    panels = {_attr(p, "data-panel"): p for p in PANELS}
+    assert None not in panels, "a .panel has no data-panel — the pager keys on it"
+
+    for btn in TAB_BUTTONS:
+        name = _attr(btn, "data-tab")
+        assert _attr(btn, "id") == f"tab-{name}", f"tab {name}: id"
+        assert _attr(btn, "aria-controls") == f"panel-{name}", f"tab {name}: aria-controls"
+        assert _attr(btn, "aria-selected") in {"true", "false"}, (
+            f"tab {name}: no aria-selected in the static markup — a reader that "
+            f"arrives before dashboard.ui.js runs sees a tablist with no state"
+        )
+        panel = panels[name]
+        assert _attr(panel, "id") == f"panel-{name}", f"panel {name}: id"
+        assert _attr(panel, "role") == "tabpanel", f"panel {name}: role"
+        assert _attr(panel, "aria-labelledby") == f"tab-{name}", (
+            f"panel {name}: aria-labelledby"
+        )
+
+
+def test_exactly_one_tab_starts_selected():
+    selected = [b for b in TAB_BUTTONS if _attr(b, "aria-selected") == "true"]
+    assert len(selected) == 1, f"{len(selected)} tabs start selected"
+    assert _attr(selected[0], "data-tab") == "hero", "the landing tab is Overview"
+
+
+def test_the_js_keeps_aria_selected_in_sync():
+    """The static markup is only the starting state; setActiveButton owns the rest."""
+    assert 'setAttribute("aria-selected"' in JS, (
+        "nothing updates aria-selected when the pager moves"
+    )
+
+
+def test_focus_visible_baseline_covers_every_focusable_element():
+    """One rule, so a new control is covered by default instead of by memory."""
+    m = re.search(r'((?:\s*(?:a|button|summary|input|select|textarea|\[tabindex\])'
+                  r':focus-visible,?)+)\s*\{([^}]*)\}', CSS)
+    assert m, (
+        "no element-level :focus-visible baseline in dashboard.css — every new "
+        "interactive component is back to needing its own rule, which is how "
+        ".refresh-btn / .dh-toggle / .panel-load-retry / .nav-link ended up with "
+        "no focus ring at all"
+    )
+    selectors = {s.strip() for s in m.group(1).split(",") if s.strip()}
+    for required in ("a:focus-visible", "button:focus-visible", "[tabindex]:focus-visible"):
+        assert required in selectors, f"baseline does not cover {required}"
+    assert "outline" in m.group(2) and "none" not in m.group(2), (
+        f"the baseline draws no outline: {m.group(2).strip()}"
+    )
+
+
+def test_every_hover_affordance_has_a_focus_twin_or_a_reason():
+    hover = {c for c in re.findall(r'\.([\w-]+):hover', CSS) if not c.isdigit()}
+    focus = set(re.findall(r'\.([\w-]+):focus-visible', CSS))
+    missing = sorted(hover - focus - set(NON_FOCUSABLE_HOVER))
+    assert not missing, (
+        "hover styling with no keyboard equivalent: "
+        + ", ".join(f".{c}" for c in missing)
+        + " — add a :focus-visible rule, or list it in NON_FOCUSABLE_HOVER with "
+          "the reason nothing focusable wears it"
+    )
+
+
+def test_non_focusable_hover_classes_are_really_not_focusable():
+    """The allowlist is a claim about the markup, so check it against the markup."""
+    for cls, reason in NON_FOCUSABLE_HOVER.items():
+        assert f".{cls}:hover" in CSS, (
+            f".{cls} no longer has a :hover rule — drop it from NON_FOCUSABLE_HOVER "
+            f"({reason})"
+        )
+        for source, label in ((HTML, "site/index.html"), (JS, "site/assets/js")):
+            for line in source.splitlines():
+                if cls not in line:
+                    continue
+                assert not re.search(r'tabindex=|role="button"', line), (
+                    f'.{cls} is listed as non-focusable but {label} renders it on a '
+                    f'focusable element: {line.strip()[:120]}'
+                )


### PR DESCRIPTION
## #1446 — tab 语义

6 个 tab 按钮有 `role="tab"` 和 `aria-selected`，但没有 `aria-controls`；6 个面板没有 `role="tabpanel"`、没有 `aria-labelledby`。读屏把它们念成普通 button，切面板时不播报面板标题。

- 按钮：`id="tab-<name>"` + `aria-controls="panel-<name>"`
- 面板：`id="panel-<name>"` + `role="tabpanel"` + `aria-labelledby="tab-<name>"`
- 非激活的 5 个按钮补 `aria-selected="false"`——静态 HTML 里只有 active 那个有状态，`dashboard.ui.js` 跑起来之前，读屏看到的是一个没有状态的 tablist

**没做**：面板没加 `hidden`、没加 `tabindex`。这六个面板是手机上的 scroll-snap 分页器，全都在 DOM 里，`hidden` 会直接废掉滑动。

## #1453 — 焦点环

7 个有 `:hover` 没 `:focus-visible` 的 class。逐个查了能不能聚焦，而不是照单全补：

| class | 结论 |
|---|---|
| `refresh-btn` / `dh-toggle` / `panel-load-retry` / `nav-link` | 真的是 `<button>` / `<a>`，键盘上去零反馈 → 补规则 |
| `dm-signal` | 决策地图的 `<tr>`；可聚焦的是 `.dm-cell`（`tabindex="0"`，line 3139 早有 `:focus-visible`） |
| `card` | 容器 div，没有 tabindex |
| `ret-cell` | **全仓只有 CSS 提到它**，没有任何生产者渲染 |

issue 自己写的 root cause 是「没有全局基线，新组件只能靠记得」——#1316（排序表头）、#1331（ECharts）都是单点修。所以这次按**元素选择器**加一条基线（`a` / `button` / `summary` / `input` / `select` / `textarea` / `[tabindex]`），特指度 0-0-1，组件自己的 `.foo:focus-visible` 照旧覆盖，包括 `.dm-dot` 那条故意的 `outline: none`（它用 `::before` 放大代替环）。

## 验证

### Chromium 实测（本地 http.server + playwright，1280×720）

```
refresh-btn 焦点环 computed: 2px solid rgb(0,120,201), offset 1px
第一次 Tab 落点:            .tab-btn.active, outline 2px solid, :focus-visible=true
aria 双向解析:              tab-hero -> panel-hero -> tabpanel -> tab-hero   (六个全通)
```

截图确认版面未变（本地没有 `assets/data/*.json`，所以卡片显示 load failed，与本 PR 无关）。

### 新测试红→绿

`tests/test_dashboard_tabs_a11y.py` 6 条。未打补丁（`git stash` 掉 `site/`）：

```
FAILED test_tab_buttons_and_panels_point_at_each_other
FAILED test_focus_visible_baseline_covers_every_focusable_element
FAILED test_every_hover_affordance_has_a_focus_twin_or_a_reason
3 failed, 3 passed
```

修后 `6 passed`。

闸不靠单点：hover/focus 那条要求「要么有 `:focus-visible`，要么进 `NON_FOCUSABLE_HOVER` 并写明理由」，另一条测试再拿 HTML/JS 反验这三条理由——被列为不可聚焦的 class 一旦出现在带 `tabindex` / `role="button"` 的行上就红。

## 风险

基线会让以前「键盘上去什么都没有」的元素现在有环——这是本 PR 的目的。鼠标点击不受影响（`:focus-visible` 不匹配鼠标路径）。

Closes #1446, closes #1453

https://claude.ai/code/session_01EVgkbxu7uktmDiFN9fHwhq
