### PR TITLE
tests: 顶层清单与输出清单收到各自的登记处，JS 那份用闸钉住 (#1448, #1449)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -573,11 +573,17 @@ jobs:
           PY
           strip="${RUNNER_TEMP:-/tmp}/strip_volatile.py"
           tmp="$(mktemp -d)"
-          for name in overview dashboard decision_audit shadow_portfolio decision_trail; do
+          # The write set comes from the contract, not from a copy of it (#1449).
+          # Spelling the five names here meant a sixth output would be built,
+          # published and never checked for determinism — the check would stay
+          # green about a file it had never read.
+          names="$(python3 -c "import json;print(' '.join(p.rsplit('/',1)[-1][:-5] for p in json.load(open('config/dashboard-outputs.json'))['outputs']))")"
+          echo "determinism check covers: $names"
+          for name in $names; do
             python3 "$strip" "assets/data/$name.json" > "$tmp/$name.first"
           done
           clawock dashboard-build > /dev/null
-          for name in overview dashboard decision_audit shadow_portfolio decision_trail; do
+          for name in $names; do
             if ! python3 "$strip" "assets/data/$name.json" | diff -u "$tmp/$name.first" -; then
               echo "::error::dashboard rebuild moved bytes beyond generation stamps ($name)"
               exit 1

--- a/config/root-allowlist.json
+++ b/config/root-allowlist.json
@@ -19,11 +19,13 @@
   },
   "AGENTS.md": {
    "owner": "runtime compatibility",
-   "consumer": "OpenClaw and coding agents"
+   "consumer": "OpenClaw and coding agents",
+   "baseline": true
   },
   "BOOTSTRAP.md": {
    "owner": "runtime compatibility",
-   "consumer": "OpenClaw bootstrap"
+   "consumer": "OpenClaw bootstrap",
+   "baseline": true
   },
   "CHANGELOG.md": {
    "owner": "public package release notes",
@@ -31,7 +33,8 @@
   },
   "CLAUDE.md": {
    "owner": "runtime compatibility",
-   "consumer": "Claude Code entry context"
+   "consumer": "Claude Code entry context",
+   "baseline": true
   },
   "DREAMS.md": {
    "owner": "runtime compatibility",
@@ -43,7 +46,8 @@
   },
   "IDENTITY.md": {
    "owner": "runtime compatibility",
-   "consumer": "OpenClaw identity context"
+   "consumer": "OpenClaw identity context",
+   "baseline": true
   },
   "INVESTMENT_SOP.md": {
    "owner": "runtime compatibility",
@@ -55,7 +59,8 @@
   },
   "MEMORY.md": {
    "owner": "runtime compatibility",
-   "consumer": "OpenClaw main-session memory; named as the authority by eight tracked instruction files"
+   "consumer": "OpenClaw main-session memory; named as the authority by eight tracked instruction files",
+   "baseline": true
   },
   "NOTICE": {
    "owner": "legal",
@@ -71,7 +76,8 @@
   },
   "SOUL.md": {
    "owner": "runtime compatibility",
-   "consumer": "OpenClaw persona context"
+   "consumer": "OpenClaw persona context",
+   "baseline": true
   },
   "THIRD_PARTY_LICENSES": {
    "owner": "legal",
@@ -79,11 +85,13 @@
   },
   "TOOLS.md": {
    "owner": "runtime compatibility",
-   "consumer": "OpenClaw tool routing"
+   "consumer": "OpenClaw tool routing",
+   "baseline": true
   },
   "USER.md": {
    "owner": "runtime compatibility",
-   "consumer": "OpenClaw user context"
+   "consumer": "OpenClaw user context",
+   "baseline": true
   },
   "assets": {
    "owner": "generated instance state",
@@ -115,7 +123,8 @@
   },
   "portfolio.json": {
    "owner": "KCNyu instance ledger",
-   "consumer": "installed workflows and dashboard"
+   "consumer": "installed workflows and dashboard",
+   "baseline": true
   },
   "pyproject.toml": {
    "owner": "public package metadata",

--- a/ops/system_check.py
+++ b/ops/system_check.py
@@ -134,8 +134,34 @@ BACKLOG_WARN_HOURS = 2.0
 #: quiet stretch, short enough that a fixed hop stops being reported the same day.
 RUN_SCAN_LIMIT = 40
 
-BASELINE_TRACKED = ['SOUL.md', 'IDENTITY.md', 'USER.md', 'MEMORY.md', 'TOOLS.md',
-                    'AGENTS.md', 'CLAUDE.md', 'BOOTSTRAP.md', 'portfolio.json']
+def _baseline_tracked():
+    """The bootstrap set, read from the registry that already owns the root.
+
+    This used to be a literal list living a few lines away from
+    `check_root_allowlist`, which reads `config/root-allowlist.json` — two
+    hand-kept lists of top-level files, nothing tying them together (#1448).
+    Adding a tracked root file had to be done twice, and the two halves fail in
+    opposite directions: forget the allowlist and `root ownership` goes CRITICAL
+    and blocks the push (loud); forget this list and the file simply stops being
+    required in every checkout (silent — the failure mode nobody sees).
+
+    So the registry is the single source and `baseline: true` is the flag. The
+    allowlist is already forced to stay complete by `git ls-files`, which is the
+    property this list never had.
+    """
+    try:
+        entries = json.loads(
+            (WS / 'config' / 'root-allowlist.json').read_text())['entries']
+    except Exception:
+        # check_baseline_files turns the empty set into a CRITICAL with a
+        # readable cause; an import-time traceback out of the pre-push hook is
+        # not a better message.
+        return []
+    return [name for name, meta in entries.items()
+            if isinstance(meta, dict) and meta.get('baseline')]
+
+
+BASELINE_TRACKED = _baseline_tracked()
 
 
 def check_baseline_files(r):
@@ -145,6 +171,11 @@ def check_baseline_files(r):
     every checkout — live workspace, agent worktree, CI runner — must have it.
     """
     required = list(BASELINE_TRACKED)
+    if not required:
+        r.add('baseline files', CRITICAL,
+              'baseline set unreadable: config/root-allowlist.json has no '
+              'entry flagged "baseline"')
+        return
     missing = [f for f in required if not (WS / f).exists()]
     if missing:
         r.add('baseline files', CRITICAL, f'missing: {missing}')

--- a/tests/test_manifest_parity.py
+++ b/tests/test_manifest_parity.py
@@ -1,0 +1,173 @@
+"""The repo's hand-kept lists of files, held against the registry that owns them.
+
+Two shapes of the same bug (#1448, #1449): a set of paths is declared in one
+place and re-declared, by hand, in another. Both halves stay right only as long
+as whoever adds a file remembers every copy — and the copies fail in opposite
+directions, so the one that matters is the one that fails silently.
+
+    BASELINE_TRACKED (ops/system_check.py)  vs  config/root-allowlist.json
+        forget the allowlist -> `root ownership` CRITICAL, push blocked (loud)
+        forget BASELINE_TRACKED -> the file quietly stops being required (silent)
+
+    config/dashboard-outputs.json  vs  ci.yml  vs  dashboard.ui.js
+        a sixth output is built and published, while the determinism check and
+        the live-origin routing table keep talking about five
+
+Both copies are gone now (the registry and the contract are read directly); what
+is left to pin is the JavaScript, which cannot import Python, and the claim that
+the registry-derived lists are actually complete.
+
+Deliberately NOT asserted: `pages-public.json::browser_data` ⊆
+`dashboard-outputs.json`, which #1449 proposed. `dashboard-outputs.json` is the
+DASHBOARD BUILDER's write set — the five files `write_generation` swaps in
+atomically and `test_dashboard_output_ownership` polices. `macro.json`,
+`sentiment.json`, `em_news.json`, `influencer_feed.json`, `us_news_digest.json`
+come from GitHub Actions scans and `brief_projection.json` from the brief
+preflight; declaring them as builder outputs to satisfy a freshness gate would
+make the write-set contract say something false. The invariant that IS true of
+browser_data — every file the browser fetches is declared public, and nothing
+else is — is checked below.
+"""
+import ast
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "ops"))
+
+import system_check  # noqa: E402
+
+ALLOWLIST = json.loads((ROOT / "config/root-allowlist.json").read_text())
+OUTPUTS = json.loads((ROOT / "config/dashboard-outputs.json").read_text())["outputs"]
+PAGES = json.loads((ROOT / "config/pages-public.json").read_text())
+UI_JS = (ROOT / "site/assets/js/dashboard.ui.js").read_text()
+CI_YML = (ROOT / ".github/workflows/ci.yml").read_text()
+
+
+# ── #1448: the bootstrap baseline ────────────────────────────────────────────
+
+def test_baseline_tracked_is_derived_not_retyped():
+    tree = ast.parse((ROOT / "ops/system_check.py").read_text())
+    assigned = [
+        node.value for node in ast.walk(tree)
+        if isinstance(node, ast.Assign)
+        and any(getattr(t, "id", None) == "BASELINE_TRACKED" for t in node.targets)
+    ]
+    assert assigned, "BASELINE_TRACKED is gone — point this gate at its replacement"
+    for value in assigned:
+        assert not isinstance(value, (ast.List, ast.Tuple, ast.Set)), (
+            "BASELINE_TRACKED is a literal list again. It is a second, "
+            "hand-kept copy of config/root-allowlist.json's top-level files; "
+            "flag the entry `\"baseline\": true` there instead."
+        )
+
+
+def test_every_baseline_file_is_owned_tracked_and_present():
+    baseline = system_check.BASELINE_TRACKED
+    assert len(baseline) >= 9, (
+        f"only {len(baseline)} baseline files — the registry flag stopped "
+        f"matching, and check_baseline_files now watches almost nothing"
+    )
+    tracked = set(subprocess.run(
+        ["git", "ls-files"], cwd=ROOT, capture_output=True, text=True, check=True,
+    ).stdout.split())
+    for name in baseline:
+        meta = ALLOWLIST["entries"].get(name)
+        assert meta, f"{name} is flagged baseline but has no allowlist entry"
+        assert meta.get("owner") and meta.get("consumer"), (
+            f"{name}: `root ownership` requires owner and consumer"
+        )
+        assert name in tracked, (
+            f"{name} is required in every checkout but is not tracked by git — "
+            f"no checkout can satisfy that"
+        )
+        assert (ROOT / name).exists(), f"{name} is missing from this checkout"
+
+
+def test_a_newly_flagged_root_file_joins_the_baseline_by_itself(tmp_path, monkeypatch):
+    """The point of deriving it: adding a file is one edit, not two."""
+    (tmp_path / "config").mkdir()
+    entries = dict(ALLOWLIST["entries"])
+    entries["NEWFILE.md"] = {"owner": "t", "consumer": "t", "baseline": True}
+    (tmp_path / "config/root-allowlist.json").write_text(
+        json.dumps({"schema_version": 1, "entries": entries})
+    )
+    monkeypatch.setattr(system_check, "WS", tmp_path)
+    assert "NEWFILE.md" in system_check._baseline_tracked()
+
+
+def test_an_unreadable_registry_is_a_readable_critical(tmp_path, monkeypatch):
+    monkeypatch.setattr(system_check, "WS", tmp_path)
+    monkeypatch.setattr(system_check, "BASELINE_TRACKED", [])
+    result = system_check.Result()
+    system_check.check_baseline_files(result)
+    assert result.critical_count() == 1, (
+        f"an unreadable baseline registry passes silently: {result.checks}"
+    )
+
+
+# ── #1449: the data-plane write set ──────────────────────────────────────────
+
+def _js_data_plane_names():
+    m = re.search(r"const DATA_PLANE_FILES = new Set\(\[(.*?)\]\)", UI_JS, re.S)
+    assert m, "DATA_PLANE_FILES is gone from dashboard.ui.js"
+    return set(re.findall(r'"([^"]+)"', m.group(1)))
+
+
+def _publisher_names():
+    sys.path.insert(0, str(ROOT / "ops/publish"))
+    import publish_data_branch  # noqa: E402
+    return {p.rsplit("/", 1)[-1].removesuffix(".json")
+            for p in publish_data_branch.DATA_PLANE_FILES}
+
+
+def test_the_browser_routes_exactly_the_files_the_publisher_puts_on_the_branch():
+    """`DATA_PLANE_FILES` in JS is a routing table for the live origin.
+
+    A file the publisher ships but the browser does not route reads from Pages
+    instead — up to a deploy behind, with every gate green. A name the browser
+    routes but the publisher never ships is a 404 on the live origin.
+    """
+    js, publisher = _js_data_plane_names(), _publisher_names()
+    assert js, "the JS routing table is empty"
+    assert js == publisher, (
+        f"data-plane routing drift — only in JS: {sorted(js - publisher)}; "
+        f"only in the publisher: {sorted(publisher - js)}"
+    )
+
+
+def test_browser_data_is_exactly_what_the_page_fetches():
+    """`pages-public.json::browser_data` vs the fetches dashboard.ui.js makes."""
+    m = re.search(r"const SIDECAR_TAB = \{(.*?)\n  \};", UI_JS, re.S)
+    assert m, "SIDECAR_TAB is gone from dashboard.ui.js"
+    fetched = set(re.findall(r"(\w+):\s*(?:\"|\[)", m.group(1)))
+    # The two the shell fetches directly, outside the sidecar machinery.
+    fetched |= {name for name in re.findall(r'_dataUrl\("(\w+)"', UI_JS)}
+    assert len(fetched) > 5, f"only found {sorted(fetched)} — the regex went stale"
+
+    declared = {p.rsplit("/", 1)[-1].removesuffix(".json")
+                for p in PAGES["browser_data"]}
+    assert declared == fetched, (
+        f"browser_data drift — fetched but not declared public (404 in the "
+        f"browser): {sorted(fetched - declared)}; declared but never fetched: "
+        f"{sorted(declared - fetched)}"
+    )
+
+
+def test_ci_reads_the_output_contract_instead_of_restating_it():
+    """The determinism check must cover whatever the contract says today."""
+    body = re.sub(r"^\s*#.*$", "", CI_YML, flags=re.M)
+    assert "config/dashboard-outputs.json" in body, (
+        "ci.yml never reads the output contract"
+    )
+    loops = re.findall(r"for name in ([^;]+); do", body)
+    assert loops, "the determinism loops are gone — point this gate at what replaced them"
+    for loop in loops:
+        assert loop.strip() == "$names", (
+            f"ci.yml restates the output names instead of reading the contract: "
+            f"`for name in {loop.strip()}` — a sixth output would be built, "
+            f"published, and never checked for determinism"
+        )


### PR DESCRIPTION
两个 issue 是同一个形状：一组路径在 A 处登记、又在 B 处手抄一遍。两半的失败方向
相反，而要命的是静默的那半。

## #1448 BASELINE_TRACKED

ops/system_check.py:137 的 9 个文件是手写 list，跟它隔几十行的 check_root_allowlist
读的是 config/root-allowlist.json 的 35 个 entry——两份手维护的顶层文件清单，没有
任何东西把它们钉在一起：
- 漏改 allowlist ⇒ root ownership CRITICAL 卡推送（响）
- 漏改 BASELINE_TRACKED ⇒ 新文件从此不被 check_baseline_files 要求（哑）

改法：registry 是单一真值源，entry 上加 "baseline": true，system_check 从那里派生。
allowlist 本身是被 `git ls-files` 逼着保持完整的——这正是手写 list 从来没有的性质。
读不出来时 check_baseline_files 报一条能看懂的 CRITICAL，而不是 import 期 traceback。

## #1449 输出清单

三份：config/dashboard-outputs.json（契约）、ci.yml 的两个 for 循环（手抄 5 个名字）、
dashboard.ui.js 的 DATA_PLANE_FILES（手抄 7 个名字）。

- ci.yml：改成从契约里读（`names="$(python3 -c ...)"`）。抄那份的后果是第六个输出
  会被构建、被发布、但确定性检查永远不看它——一条对着自己没读过的文件报绿的闸。
- JS 那份没法 import Python，所以用测试钉：JS 的 DATA_PLANE_FILES 必须等于
  publish_data_branch.DATA_PLANE_FILES（= 契约的 5 个 + DATA_PLANE_EXTRA 的 2 个）。
  漏一个 ⇒ 浏览器改从 Pages 读那份（最多落后一次部署），而所有闸都是绿的。
- pages-public.json::browser_data 必须等于 dashboard.ui.js 真去 fetch 的那批
  （SIDECAR_TAB 的 10 个 + dashboard + overview）。多了=声明了没人要的文件，
  少了=浏览器 404。

## 没做：issue 建议的 browser_data ⊆ dashboard-outputs

前提不成立。dashboard-outputs.json 是 **dashboard builder 的写集合**——
write_generation 原子换入的那 5 个文件，test_dashboard_output_ownership 盯着它。
macro/sentiment/em_news/influencer_feed/us_news_digest 来自 GitHub Actions 扫描，
brief_projection 来自 brief preflight；把它们塞进 builder 的写集合去满足一条
freshness 闸，等于让写集合契约说一句假话。真正成立的那条不变量（浏览器 fetch 的
文件必须被声明成公开、且仅此）已经按上面钉住。

## 验证

未打补丁（stash 掉三个源文件）：4 failed
  test_baseline_tracked_is_derived_not_retyped
  test_a_newly_flagged_root_file_joins_the_baseline_by_itself
  test_an_unreadable_registry_is_a_readable_critical
  test_ci_reads_the_output_contract_instead_of_restating_it
修后：7 passed（另外 3 条是 JS/publisher 的 parity，今天本来就同步，属回归护栏）

派生结果与原列表逐项相同（9 个）；`python3 ops/system_check.py`：
  ✓ baseline files  9 files present
  ✓ root ownership  35 tracked paths explicitly owned   · 23 ok · 2 warn · 0 critical
ci.yml 那行 shell 按字面量单独跑过：covers: overview dashboard decision_audit
shadow_portfolio decision_trail

既有测试：83 passed（memory_lives_on_the_host / dashboard_output_ownership /
site_deploy / pages_deployment_contract / ci_consolidation_contract /
dashboard_tab_lifecycle / examples_are_executed）。

Closes #1448, closes #1449

Claude-Session: https://claude.ai/code/session_01EVgkbxu7uktmDiFN9fHwhq

