### PR TITLE
feat(growth): 搜索可见性进看板，每周读数落盘成历史

### DIFF
--- a/.github/workflows/seo-visibility.yml
+++ b/.github/workflows/seo-visibility.yml
@@ -17,8 +17,17 @@ on:
     - cron: '30 6 * * 1'
   workflow_dispatch:
 
+# This job now commits its reading to `assets/data/crawl_visibility.json`.
+# Before that it wrote nothing, and the numbers lived only in the run log —
+# which GitHub keeps for 90 days, so the series a trend needs was being deleted a
+# quarter at a time. Same writer lane as every other data producer: it commits to
+# master and must queue behind them rather than race them.
+concurrency:
+  group: data-write
+  cancel-in-progress: false
+
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   measure:
@@ -50,8 +59,13 @@ jobs:
           printf '%s' "$GSC_CREDENTIALS" > /tmp/gsc.json
           # CLAWOCK_GSC_CREDENTIALS short-circuits the host-path default, so the
           # script never needs the installed package just to find a file.
+          #
+          # `--snapshot` merges this reading into the committed history and the
+          # history table it prints is the reason to keep it: one run log says
+          # what today is, five of them side by side say whether anything moved.
           CLAWOCK_GSC_CREDENTIALS=/tmp/gsc.json \
-            python3 ops/growth/crawl_visibility.py | tee /tmp/report.txt
+            python3 ops/growth/crawl_visibility.py \
+              --snapshot assets/data/crawl_visibility.json | tee /tmp/report.txt
           {
             echo '### Search Console'
             echo '```'
@@ -59,3 +73,17 @@ jobs:
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
           rm -f /tmp/gsc.json
+
+      # The reading is committed even when the run is red for another reason: the
+      # snapshot was already merged into the file on disk by the step above, and
+      # a week of visibility that ages out of the GSC window behind a failed push
+      # is a week nobody can re-measure. When the query itself failed there is
+      # nothing staged and the composite exits on its own "nothing to commit".
+      - name: Commit the weekly snapshot
+        if: always()
+        env:
+          CLAWOCK_PUBLISH_SSH_KEY: ${{ secrets.CLAWOCK_PUBLISH_SSH_KEY }}
+        uses: ./.github/actions/clawock-commit
+        with:
+          paths: assets/data/crawl_visibility.json
+          message: measurement: search visibility snapshot ${{ github.run_id }}

--- a/.github/workflows/seo-visibility.yml
+++ b/.github/workflows/seo-visibility.yml
@@ -86,4 +86,6 @@ jobs:
         uses: ./.github/actions/clawock-commit
         with:
           paths: assets/data/crawl_visibility.json
-          message: measurement: search visibility snapshot ${{ github.run_id }}
+          # Quoted: the subject carries its own colon, and unquoted YAML reads the
+          # second one as a mapping.
+          message: "measurement: search visibility snapshot ${{ github.run_id }}"

--- a/assets/data/crawl_visibility.json
+++ b/assets/data/crawl_visibility.json
@@ -1,0 +1,6 @@
+{
+  "generated_at": null,
+  "site": "https://kcnyu.github.io/clawock/",
+  "note": "windows are fixed-length and end on the last complete day, so consecutive snapshots do not overlap and may be compared directly. `days_with_data` below `days` means GSC had not filled the tail.",
+  "snapshots": []
+}

--- a/config/pages-public.json
+++ b/config/pages-public.json
@@ -12,7 +12,8 @@
     "assets/data/shadow_portfolio.json",
     "assets/data/decision_trail.json",
     "assets/data/brief_projection.json",
-    "assets/data/decision_map.json"
+    "assets/data/decision_map.json",
+    "assets/data/crawl_visibility.json"
   ],
   "required_pages": [
     "index.html",

--- a/ops/growth/crawl_visibility.py
+++ b/ops/growth/crawl_visibility.py
@@ -49,7 +49,6 @@ import urllib.error
 import urllib.parse
 import urllib.request
 from pathlib import Path
-from pathlib import Path
 
 # Bootstrap before importing the package, the way every other ops entry point
 # does. Without it the import resolves only when the caller happens to supply

--- a/ops/growth/crawl_visibility.py
+++ b/ops/growth/crawl_visibility.py
@@ -22,6 +22,21 @@ Usage:
     crawl_visibility.py                      # 90-day summary + coverage probes
     crawl_visibility.py --days 28
     crawl_visibility.py --json               # machine-readable, for a gate later
+    crawl_visibility.py --snapshot PATH      # also merge this run into a history
+
+`--snapshot` is the difference between a reading and a record. Without it every
+number here lives in one run log, and GitHub keeps those 90 days: three months
+later the same question is a fresh pull with nothing to compare it against, and
+"曝光有没有动" gets answered from memory instead of from a series.
+
+What a snapshot stores is fixed-window by construction, and that is a
+correctness rule rather than a layout choice. The `--days` argument above is a
+*reading* window; a history built from it would double-count every week it
+overlapped the previous one and report a rise that is an artifact of the
+cadence. So the snapshot records a 7-day and a 28-day window ending on the last
+*complete* day, plus the per-day series those windows were summed from. The day
+boundary is why they are reproducible: GSC keeps filling in the tail, so a
+window that ends "today" returns a different number every time it is read.
 """
 from __future__ import annotations
 
@@ -33,6 +48,7 @@ import sys
 import urllib.error
 import urllib.parse
 import urllib.request
+from pathlib import Path
 from pathlib import Path
 
 # Bootstrap before importing the package, the way every other ops entry point
@@ -51,6 +67,147 @@ API = "https://searchconsole.googleapis.com"
 # One page per discovery path: the entry point, a page reachable only through
 # an internal link, and one reachable only through the sitemap.
 PROBES = ("", "briefs.html", "evidence.html")
+
+# Fixed history windows, in days. See the module docstring: these are not
+# preferences, they are what makes two snapshots comparable.
+SNAPSHOT_WINDOWS = (7, 28)
+# Two years of weekly snapshots. The cap exists because the file is committed on
+# every run forever; it is not a claim that a longer series is uninteresting.
+SNAPSHOT_CAP = 104
+TOP_QUERIES = 15
+
+
+def _daily_rows(token: str, start: datetime.date, end: datetime.date) -> list[dict]:
+    """The per-day series, ascending. The windows below are summed from this."""
+    quoted = urllib.parse.quote(SITE, safe="")
+    response = _call(f"{API}/webmasters/v3/sites/{quoted}/searchAnalytics/query",
+                     token, {"startDate": str(start), "endDate": str(end),
+                             "dimensions": ["date"], "rowLimit": 500})
+    rows = []
+    for row in response.get("rows") or []:
+        day = (row.get("keys") or [None])[0]
+        if not day:
+            continue
+        rows.append({"date": str(day),
+                     "impressions": row.get("impressions", 0),
+                     "clicks": row.get("clicks", 0),
+                     "position": row.get("position")})
+    return sorted(rows, key=lambda row: row["date"])
+
+
+#: GSC completes a day's data a day or two behind the wall clock. A window that
+#: ends on the last complete day rather than on `today` is what makes the same
+#: week read the same number on Monday and on Thursday — and, because the
+#: boundary is a fixed offset, neither run needs to know when the other ran.
+def _complete_through(daily: list[dict], lag_days: int = 2) -> datetime.date | None:
+    """The last day covered by a complete `lag_days`-old window, or None.
+
+    None is the honest answer for an empty series: a history entry claiming a
+    7-day window it could not fill would be read later as a week of zero
+    visibility, which is the one reading this file exists to distinguish from
+    "not measured".
+    """
+    if not daily:
+        return None
+    return datetime.date.fromisoformat(daily[-1]["date"]) - datetime.timedelta(days=lag_days - 1)
+
+
+def _window_stats(daily: list[dict], through: datetime.date, days: int) -> dict:
+    end = through
+    start = through - datetime.timedelta(days=days - 1)
+    rows = [row for row in daily
+            if start <= datetime.date.fromisoformat(row["date"]) <= end]
+    if not rows:
+        return {"start": str(start), "end": str(end), "days": days, "complete": True,
+                "days_with_data": 0, "impressions": 0, "clicks": 0, "position": None}
+    impressions = sum(row["impressions"] for row in rows)
+    # Impression-weighted, the same basis the API reports for a whole window.
+    # An unweighted mean over days would let a 1-impression day move the average
+    # as much as a 20-impression one, which is how a position "improves" while
+    # the page gets less visible.
+    weighted = sum((row["position"] or 0) * row["impressions"] for row in rows)
+    return {
+        "start": str(start),
+        "end": str(end),
+        "days": days,
+        # False when GSC had not filled in the tail yet. A reading, not a fail —
+        # but a caller comparing windows must be able to see it.
+        "complete": len(rows) == days,
+        "days_with_data": len(rows),
+        "impressions": impressions,
+        "clicks": sum(row["clicks"] for row in rows),
+        "position": round(weighted / impressions, 2) if impressions else None,
+    }
+
+
+def _top_queries(token: str, start: datetime.date, end: datetime.date) -> dict:
+    """The query dimension, which stayed empty for three months.
+
+    Recorded with its own count because "no row" has two causes that read the
+    same in a report: nothing was searched, or everything fell under GSC's
+    anonymisation threshold. The count separates them.
+    """
+    quoted = urllib.parse.quote(SITE, safe="")
+    response = _call(f"{API}/webmasters/v3/sites/{quoted}/searchAnalytics/query",
+                     token, {"startDate": str(start), "endDate": str(end),
+                             "dimensions": ["query"], "rowLimit": 100})
+    rows = response.get("rows") or []
+    ranked = sorted(rows, key=lambda row: row.get("impressions", 0), reverse=True)
+    return {
+        "reported": len(rows),
+        "top": [{"query": (row.get("keys") or [""])[0],
+                 "impressions": row.get("impressions", 0),
+                 "clicks": row.get("clicks", 0),
+                 "position": round(row["position"], 2) if row.get("position") else None}
+                for row in ranked[:TOP_QUERIES]],
+    }
+
+
+def snapshot(report: dict, previous: dict | None = None,
+             now: datetime.datetime | None = None) -> tuple[dict, dict]:
+    """Merge this reading into the committed history. Returns (payload, stats).
+
+    Keyed on the window's end date rather than on the run's timestamp: two runs
+    that measure the same week are the same measurement, and the Actions
+    schedule drifts by hours (measured 10-160 minutes in this repository), so a
+    key built from when the run happened would store the same week twice and
+    show a flat line as change.
+    """
+    now = now or datetime.datetime.now(datetime.timezone.utc)
+    windows = {str(days): _window_stats(report["daily"], report["through"], days)
+               for days in SNAPSHOT_WINDOWS}
+    entry = {
+        "as_of": str(report["through"]),
+        "captured_at": now.replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+        "windows": windows,
+        "queries": report.get("queries") or {"reported": 0, "top": []},
+        # How many pages Google has ever shown anyone. One since June; the
+        # number this whole panel is ultimately about.
+        "pages_with_impressions": report["pages_with_impressions"],
+        "sitemap": (report["sitemaps"] or [{}])[0],
+        "coverage": report["coverage"],
+        # Fourteen days, not the query window: enough to see the shape of a
+        # spike's rise and fall between two weekly readings.
+        "daily": report["daily"][-14:],
+    }
+    history = list((previous or {}).get("snapshots") or [])
+    history = [item for item in history if item.get("as_of") != entry["as_of"]]
+    history.append(entry)
+    history = sorted(history, key=lambda item: item["as_of"])[-SNAPSHOT_CAP:]
+    payload = {
+        "generated_at": entry["captured_at"],
+        "site": report["site"],
+        "note": (
+            "windows are fixed-length and end on the last complete day, so "
+            "consecutive snapshots do not overlap and may be compared directly. "
+            "`days_with_data` below `days` means GSC had not filled the tail."
+        ),
+        "snapshots": history,
+    }
+    added = 1 if len(history) != len((previous or {}).get("snapshots") or []) else 0
+    return payload, {"days": len(history), "added": added,
+                     "as_of": entry["as_of"], "replaced": 0 if added else len(history) > 0}
+
 
 
 def _default_credentials() -> str:
@@ -100,6 +257,15 @@ def collect(token: str, days: int) -> dict:
                   token, {"startDate": str(start), "endDate": str(end),
                           "dimensions": ["page"], "rowLimit": 100})
 
+    # Fetched wide enough to fill the widest history window no matter where the
+    # server's clock sits inside the UTC day, then bounded below by the lag that
+    # makes the last complete day knowable.
+    span = max(SNAPSHOT_WINDOWS)
+    probe = _daily_rows(token, end - datetime.timedelta(days=span + 4), end)
+    through = _complete_through(probe)
+    day_start = (through - datetime.timedelta(days=span - 1)) if through else end
+    daily = _daily_rows(token, day_start, through or end)
+
     sitemaps = []
     for entry in _call(f"{API}/webmasters/v3/sites/{quoted}/sitemaps",
                        token).get("sitemap", []):
@@ -114,24 +280,27 @@ def collect(token: str, days: int) -> dict:
         })
 
     coverage = {}
-    for probe in PROBES:
-        url = SITE + probe
+    for probe_url in PROBES:
+        url = SITE + probe_url
         try:
             result = _call(f"{API}/v1/urlInspection/index:inspect", token,
                            {"inspectionUrl": url, "siteUrl": SITE})
             status = (result.get("inspectionResult") or {}).get(
                 "indexStatusResult") or {}
-            coverage[probe or "/"] = {
+            coverage[probe_url or "/"] = {
                 "verdict": status.get("verdict"),
                 "coverageState": status.get("coverageState"),
                 "lastCrawlTime": status.get("lastCrawlTime"),
             }
         except urllib.error.HTTPError as error:
-            coverage[probe or "/"] = {"error": f"{error.code}"}
+            coverage[probe_url or "/"] = {"error": f"{error.code}"}
 
     return {
         "site": SITE,
         "window": {"start": str(start), "end": str(end), "days": days},
+        "through": through or end,
+        "daily": daily,
+        "queries": _top_queries(token, day_start, through or end),
         "impressions": rows[0].get("impressions", 0),
         "clicks": rows[0].get("clicks", 0),
         "position": rows[0].get("position"),
@@ -141,17 +310,52 @@ def collect(token: str, days: int) -> dict:
     }
 
 
-def render(report: dict) -> str:
+def _window_line(label: str, stats: dict) -> str:
+    flag = "" if stats.get("complete") else f"  ⚠ {stats['days_with_data']}/{stats['days']} days"
+    position = stats.get("position")
+    return (f"  {label:5}  impressions {stats['impressions']:.0f} · "
+            f"clicks {stats['clicks']:.0f} · "
+            f"position {position if position is not None else '—'}"
+            f"  ({stats['start']} → {stats['end']}){flag}")
+
+
+def history_lines(payload: dict, limit: int = 5) -> list[str]:
+    """The last few readings side by side — the thing a run log cannot give."""
+    snapshots = (payload or {}).get("snapshots") or []
+    if not snapshots:
+        return []
+    lines = ["", f"History — {len(snapshots)} weekly snapshot(s) on file"]
+    lines.append(f"  {'as of':12} {'7d imp':>7} {'7d clk':>7} {'28d imp':>8} "
+                 f"{'pages':>6}  queries")
+    for entry in snapshots[-limit:]:
+        week = (entry.get("windows") or {}).get(str(SNAPSHOT_WINDOWS[0])) or {}
+        month = (entry.get("windows") or {}).get(str(SNAPSHOT_WINDOWS[-1])) or {}
+        queries = (entry.get("queries") or {}).get("reported", 0)
+        lines.append(f"  {entry.get('as_of','?'):12} {week.get('impressions',0):>7.0f} "
+                     f"{week.get('clicks',0):>7.0f} {month.get('impressions',0):>8.0f} "
+                     f"{entry.get('pages_with_impressions',0):>6}  {queries}")
+    return lines
+
+
+def render(report: dict, payload: dict | None = None) -> str:
     window = report["window"]
     lines = [f"Search Console — {report['site']}  ({window['start']} → {window['end']})",
              f"  impressions {report['impressions']:.0f} · clicks {report['clicks']:.0f}"
              f" · pages with any impression {report['pages_with_impressions']}"]
+    for days in SNAPSHOT_WINDOWS:
+        if report.get("daily"):
+            lines.append(_window_line(f"{days}d", _window_stats(
+                report["daily"], report["through"], days)))
+    queries = report.get("queries") or {}
+    lines.append(f"  queries reported {queries.get('reported', 0)}"
+                 f" (top: {', '.join(repr(q['query']) for q in queries.get('top', [])[:3]) or '—'})")
     for sitemap in report["sitemaps"]:
         fetched = sitemap["lastDownloaded"] or "NEVER DOWNLOADED"
         lines.append(f"  sitemap submitted {sitemap['lastSubmitted']} · fetched {fetched}")
     for page, status in report["coverage"].items():
         lines.append(f"  {page:16} {status.get('coverageState') or status.get('error')}"
                      f"  last crawl {status.get('lastCrawlTime') or '—'}")
+    lines.extend(history_lines(payload or {}))
     return "\n".join(lines)
 
 
@@ -161,6 +365,10 @@ def main(argv=None) -> int:
     parser.add_argument("--credentials", default=os.environ.get(
         "CLAWOCK_GSC_CREDENTIALS") or _default_credentials())
     parser.add_argument("--json", action="store_true")
+    parser.add_argument("--snapshot", type=Path, default=None, metavar="PATH",
+                        help="merge this run into a committed history at PATH")
+    parser.add_argument("--print", dest="dry_run", action="store_true",
+                        help="report what --snapshot would write, write nothing")
     args = parser.parse_args(argv)
 
     if not os.path.exists(args.credentials):
@@ -175,8 +383,30 @@ def main(argv=None) -> int:
         print(f"ERROR: Search Console query failed: {error}", file=sys.stderr)
         return 2
 
+    payload = None
+    if args.snapshot is not None and not args.dry_run:
+        previous = {}
+        if args.snapshot.exists():
+            try:
+                previous = json.loads(args.snapshot.read_text(encoding="utf-8"))
+            except ValueError as error:
+                # Not fatal: a corrupt history must not cost the reading we just
+                # took, and the reading is the part that cannot be re-fetched.
+                print(f"WARN: unreadable {args.snapshot} ({error}) — starting over",
+                      file=sys.stderr)
+        payload, stats = snapshot(report, previous)
+        args.snapshot.parent.mkdir(parents=True, exist_ok=True)
+        args.snapshot.write_text(
+            json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=False) + "\n",
+            encoding="utf-8")
+        print(f"snapshot: {stats['days']} week(s) on file · as_of {stats['as_of']}"
+              f" · wrote {args.snapshot}", file=sys.stderr)
+    elif args.snapshot is not None:
+        payload, stats = snapshot(report, {})
+        print(f"::notice::--print: would write as_of {stats['as_of']}", file=sys.stderr)
+
     print(json.dumps(report, ensure_ascii=False, indent=2) if args.json
-          else render(report))
+          else render(report, payload))
     return 0
 
 

--- a/ops/publish/publish_data_branch.py
+++ b/ops/publish/publish_data_branch.py
@@ -50,6 +50,22 @@ DATA_PLANE_EXTRA = (
     "assets/data/cron-heartbeats.json",
     "assets/data/workflow-outcomes.json",
 )
+
+# One more file the browser DOES fetch, and the only member of this generation
+# that is written on a different cadence from the rest: the weekly Search
+# Console reading, committed by `seo-visibility.yml` once a week.
+#
+# It is kept out of `DATA_PLANE_FILES` deliberately. The branch is replaced
+# wholesale, so the publisher refuses when a member cannot be read — correct for
+# the files that share a tick, fatal for this one. A file that appears weekly, and
+# that does not exist after a fresh checkout of the branch, would make every
+# 20-minute tick refuse to publish the *entire* dashboard until the next Monday.
+# Browser data that arrives on its own schedule is optional by construction: a
+# missing one means the panel is absent, not that the generation is malformed.
+DATA_PLANE_OPTIONAL = (
+    "assets/data/crawl_visibility.json",
+)
+
 DATA_PLANE_FILES = output_paths(ROOT) + DATA_PLANE_EXTRA
 
 # Failure classes, and the whole reason they are classes: `note_degradation`
@@ -134,6 +150,23 @@ def main() -> int:
             # Refuse rather than publish a partial generation: the branch is
             # replaced wholesale, so a missing member is not "unchanged", it is
             # deleted from the data plane.
+            print(f"✗ data-plane: cannot read {path}: {exc}", file=sys.stderr)
+            note_failure(PUBLISH_FAILED, "an output file could not be read")
+            return 1
+
+    # Same whole-branch rule, opposite consequence, and the difference is the
+    # cadence rather than the importance. See DATA_PLANE_OPTIONAL: refusing here
+    # would let a file nobody wrote this week block the generation everybody
+    # reads. An unreadable-but-present file is still refused, because that is a
+    # real defect rather than a schedule.
+    for path in DATA_PLANE_OPTIONAL:
+        target = root / path
+        if not target.is_file():
+            print(f"· data-plane: {path} not written yet — publishing without it")
+            continue
+        try:
+            files[path] = target.read_text(encoding="utf-8")
+        except OSError as exc:
             print(f"✗ data-plane: cannot read {path}: {exc}", file=sys.stderr)
             note_failure(PUBLISH_FAILED, "an output file could not be read")
             return 1

--- a/site/assets/css/dashboard.css
+++ b/site/assets/css/dashboard.css
@@ -4390,3 +4390,42 @@
   .book-heat .bh-head .bh-v, .book-heat .bh-head .bh-s { justify-content: flex-end; }
   :root { --heat-up: #12864c; --heat-down: #c4291f; }
   @media (prefers-color-scheme: dark) { :root { --heat-up: #32d272; --heat-down: #ff5a4e; } }
+
+  /* Growth tab（搜索可见性）。这块牌的量都是「数出来的」，所以数字一律
+     等宽 + tabular-nums：一周和下一周同一位对齐，才看得出动没动。 */
+  .growth-table {
+    width: 100%; border-collapse: collapse;
+    font-size: var(--fs-sm); font-variant-numeric: tabular-nums;
+  }
+  .growth-table th {
+    text-align: left; font-weight: 600; color: var(--text-dim);
+    font-size: var(--fs-xs); text-transform: uppercase; letter-spacing: 0.06em;
+    padding: 6px 8px 6px 0; border-bottom: 1px solid var(--border-subtle);
+    white-space: nowrap;
+  }
+  .growth-table td {
+    padding: 6px 8px 6px 0; border-bottom: 1px solid var(--border-subtle);
+    vertical-align: top;
+  }
+  .growth-table tr:last-child td { border-bottom: 0; }
+  .growth-table .num, .growth-table th.num { text-align: right; }
+  /* 中文列（Google 的判定）不折成两行：它是一句判定语，断行会把主语和
+     结论拆到两屏。长就让它长，横滚由 .growth-table 的容器承担。 */
+  .growth-table td.mono { white-space: nowrap; }
+  .growth-up { color: var(--green); }
+  .growth-down { color: var(--red); }
+
+  .growth-spark {
+    display: flex; align-items: flex-end; gap: 2px;
+    height: 32px; margin-top: var(--space-3);
+  }
+  .growth-bar { flex: 1 1 0; min-width: 3px; border-radius: 2px 2px 0 0; }
+  .growth-bar.is-shown { background: color-mix(in srgb, var(--accent) 55%, transparent); }
+  .growth-bar.is-click { background: var(--accent); }
+  /* 没有曝光的那天也占一格：抹掉它，「安静」和「没测到」在图上就一样了。 */
+  .growth-bar.is-idle { background: color-mix(in srgb, var(--text) 14%, transparent); }
+  .growth-spark-axis {
+    display: flex; justify-content: space-between; gap: var(--space-2);
+    margin-top: 4px; color: var(--text-dim); font-size: var(--fs-micro);
+    font-variant-numeric: tabular-nums;
+  }

--- a/site/assets/js/dashboard.render.js
+++ b/site/assets/js/dashboard.render.js
@@ -552,6 +552,7 @@
       renderDecisionTraces, renderReflectKpi, renderDelta, renderDebates,
       renderDecisionMap,
     ],
+    growth: [renderGrowth],
   };
   let RENDER_VERSION = 0;
   const _tabRenderVersion = new Map();
@@ -4524,6 +4525,160 @@
     });
   }
 
+  // 搜索可见性（Growth tab）。这份读数和别的牌不同：它的输入不是我们的策略，
+  // 而是别人愿不愿意把我们排进结果页，所以这里只陈述，不评价。
+  //
+  // 一条判据贯穿整块：**数字必须带着它的窗口一起读**。曝光 26 配「上周 2」和
+  // 配「上周 19」是两件事；点击 0 配「有 5 个搜索词」和配「零个搜索词」也是。
+  // 所以每格都印对比，表头写清窗口长度。
+  const GROWTH_MISSING = '<span class="muted">crawl_visibility.json 没有载入 —— '
+    + '每周一 06:30 UTC 由 SEO Visibility 工作流每周量一次并提交；'
+    + '首次运行前这块是空的。</span>';
+
+  function growthNum(value, digits) {
+    if (value == null || !isFinite(value)) return DASH;
+    return Number(value).toLocaleString("en-US", { maximumFractionDigits: digits });
+  }
+
+  function growthDelta(current, previous, inverted) {
+    if (previous == null || current == null || !isFinite(current) || !isFinite(previous)) return "";
+    const diff = current - previous;
+    const good = inverted ? diff < 0 : diff > 0;
+    const tone = diff === 0 ? "muted" : (good ? "growth-up" : "growth-down");
+    const sign = diff > 0 ? "+" : diff < 0 ? "−" : "±";
+    return ` <span class="${tone}">${sign}${growthNum(Math.abs(diff), 1)}</span>`;
+  }
+
+  function growthKpi(label, value, sub) {
+    return `<div class="kpi-cell"><div class="lbl">${label}</div>`
+      + `<div class="val">${value}</div><div class="sub">${sub || ""}</div></div>`;
+  }
+
+  function renderGrowth() {
+    const kpis = document.getElementById("growth-kpis");
+    if (!kpis) return;
+    const payload = safe(DATA, "crawl_visibility");
+    const snapshots = (payload && payload.snapshots) || [];
+    const latest = snapshots[snapshots.length - 1];
+    if (!latest) {
+      kpis.innerHTML = GROWTH_MISSING;
+      ["growth-history", "growth-spark", "growth-queries", "growth-coverage"]
+        .forEach(id => { const el = document.getElementById(id); if (el) el.innerHTML = ""; });
+      return;
+    }
+    const prior = snapshots[snapshots.length - 2] || null;
+    const week = (latest.windows || {})["7"] || {};
+    const month = (latest.windows || {})["28"] || {};
+    const priorWeek = (prior && (prior.windows || {})["7"]) || {};
+    const queries = latest.queries || {};
+    const top = queries.top || [];
+
+    // 曝光和点击分开是有意的：26 次曝光配 0 点击说明的是「被排进去了但没人点」，
+    // 而 0 曝光说明的是「根本没被排进去」。合成一个「流量」数字会把这两件事
+    // 藏进同一个 0。
+    kpis.innerHTML = [
+      growthKpi("曝光 · 7 天", growthNum(week.impressions, 0),
+        `前一周 ${growthNum(priorWeek.impressions, 0)}${growthDelta(week.impressions, priorWeek.impressions)}`),
+      growthKpi("点击 · 7 天", growthNum(week.clicks, 0),
+        `前一周 ${growthNum(priorWeek.clicks, 0)}${growthDelta(week.clicks, priorWeek.clicks)}`),
+      growthKpi("有曝光的页", growthNum(latest.pages_with_impressions, 0),
+        "全站 107 条 URL · 收录了才是分母"),
+      growthKpi("平均排名 · 7 天", week.position == null ? DASH : growthNum(week.position, 1),
+        `28 天 ${month.position == null ? DASH : growthNum(month.position, 1)}`),
+    ].join("");
+
+    const note = document.getElementById("growth-history-note");
+    if (note) {
+      note.textContent = `${snapshots.length} 期 · 截止 ${latest.as_of || DASH}`;
+    }
+    const history = document.getElementById("growth-history");
+    if (history) {
+      const rows = snapshots.slice(-8).reverse().map(entry => {
+        const w = (entry.windows || {})["7"] || {};
+        const m = (entry.windows || {})["28"] || {};
+        const q = entry.queries || {};
+        return `<tr><td>${entry.as_of || DASH}</td>`
+          + `<td class="num">${growthNum(w.impressions, 0)}</td>`
+          + `<td class="num">${growthNum(w.clicks, 0)}</td>`
+          + `<td class="num">${growthNum(m.impressions, 0)}</td>`
+          + `<td class="num">${growthNum(entry.pages_with_impressions, 0)}</td>`
+          + `<td class="num">${growthNum(q.reported, 0)}</td></tr>`;
+      }).join("");
+      history.innerHTML = `<table class="growth-table"><thead><tr>`
+        + `<th>截止</th><th class="num">7 天曝光</th><th class="num">7 天点击</th>`
+        + `<th class="num">28 天曝光</th><th class="num">有曝光页</th><th class="num">搜索词</th>`
+        + `</tr></thead><tbody>${rows}</tbody></table>`;
+    }
+    // 逐日柱子归它自己那块。第一版把它拼在「每周读数」的 innerHTML 后面，
+    // 于是它长在周表的下面，而标题问的是另一件事。
+    const sparkHost = document.getElementById("growth-spark");
+    if (sparkHost) sparkHost.innerHTML = renderGrowthSpark(latest.daily || []);
+
+    const queriesHost = document.getElementById("growth-queries");
+    const queriesNote = document.getElementById("growth-queries-note");
+    if (queriesNote) {
+      // 「0 个词」有两种成因：真的没人搜到我们，和全部低于 GSC 的匿名化阈值。
+      // 表里印出来的行数是能看见的那部分，不是全部。
+      queriesNote.textContent = `GSC 报出 ${queries.reported || 0} 个词`
+        + (top.length < (queries.reported || 0) ? ` · 列前 ${top.length}` : "");
+    }
+    if (queriesHost) {
+      queriesHost.innerHTML = top.length
+        ? `<table class="growth-table"><thead><tr><th>搜索词</th>`
+          + `<th class="num">曝光</th><th class="num">点击</th><th class="num">排名</th>`
+          + `</tr></thead><tbody>`
+          + top.map(row => `<tr><td class="mono">${escapeHtml(row.query || "")}</td>`
+            + `<td class="num">${growthNum(row.impressions, 0)}</td>`
+            + `<td class="num">${growthNum(row.clicks, 0)}</td>`
+            + `<td class="num">${row.position == null ? DASH : growthNum(row.position, 1)}</td></tr>`)
+            .join("")
+          + `</tbody></table>`
+        : '<p class="muted">这一期 GSC 一个词都没报出来。低于匿名化阈值时它就是这样，'
+          + '和「没人搜到我们」在这个接口上长得一样。</p>';
+    }
+
+    const coverageHost = document.getElementById("growth-coverage");
+    if (coverageHost) {
+      const coverage = latest.coverage || {};
+      const pages = Object.keys(coverage);
+      const sitemap = latest.sitemap || {};
+      const fetched = sitemap.lastDownloaded || "从未被下载";
+      coverageHost.innerHTML = pages.length
+        ? `<table class="growth-table"><thead><tr><th>页面</th><th>Google 的判定</th>`
+          + `<th>最后抓取</th></tr></thead><tbody>`
+          + pages.map(page => {
+            const status = coverage[page] || {};
+            const state = status.coverageState || status.error || DASH;
+            const bad = status.verdict === "FAIL" || status.error;
+            return `<tr><td class="mono">${escapeHtml(page)}</td>`
+              + `<td class="${bad ? "growth-down" : ""}">${escapeHtml(state)}</td>`
+              + `<td class="mono">${escapeHtml(String(status.lastCrawlTime || "—").slice(0, 10))}</td></tr>`;
+          }).join("")
+          + `</tbody></table>`
+          + `<p class="chart-hint">sitemap 提交于 ${escapeHtml(String(sitemap.lastSubmitted || DASH).slice(0, 10))}`
+          + ` · ${escapeHtml(fetched)}。站点地图本身没问题，是它没被取。</p>`
+        : '<p class="muted">这一期没有收录探测结果。</p>';
+    }
+  }
+
+  // 逐日柱子。没有点击的日子也画——把 0 去掉会让「安静的一周」看起来和
+  // 「没有数据」一样，而这正是这块牌要分开的两件事。
+  function renderGrowthSpark(daily) {
+    if (!daily.length) return "";
+    const max = Math.max(1, ...daily.map(d => d.impressions || 0));
+    const bars = daily.map(day => {
+      const value = day.impressions || 0;
+      const height = Math.max(2, Math.round((value / max) * 30));
+      const tone = day.clicks ? "is-click" : (value ? "is-shown" : "is-idle");
+      const label = `${day.date} · 曝光 ${value} · 点击 ${day.clicks || 0}`;
+      return `<span class="growth-bar ${tone}" style="height:${height}px" title="${escapeHtml(label)}"></span>`;
+    }).join("");
+    const first = daily[0].date, last = daily[daily.length - 1].date;
+    return `<div class="growth-spark" role="img" aria-label="逐日曝光，${first} 至 ${last}">`
+      + `${bars}</div><div class="growth-spark-axis"><span>${first}</span>`
+      + `<span>峰值 ${max} 次曝光</span><span>${last}</span></div>`;
+  }
+
   function renderDecisionTraces() {
     const wrap = document.getElementById("trace-list");
     if (!wrap) return;
@@ -4992,11 +5147,15 @@
   // =========================================================
   // 8d Return Heatmap (Drill)
   // =========================================================
+  // The list is the registration, not `TAB_RENDERERS` itself: a tab declared in
+  // the map above but left out here is one the runtime loader can never see, and
+  // the failure is a panel that renders nothing while every file looks correct.
   window.registerDetailRenderers({
     drill: TAB_RENDERERS.drill,
     risk: TAB_RENDERERS.risk,
     market: TAB_RENDERERS.market,
     plan: TAB_RENDERERS.plan,
     reflect: TAB_RENDERERS.reflect,
+    growth: TAB_RENDERERS.growth,
   });
 }());

--- a/site/assets/js/dashboard.ui.js
+++ b/site/assets/js/dashboard.ui.js
@@ -229,6 +229,9 @@
     decision_audit: "reflect", decision_map: "reflect", shadow_portfolio: "drill",
     brief_projection: "drill",
     decision_trail: ["drill", "plan", "reflect"],
+    // 每周一次，不是每 20 分钟一次：这块牌的数据由 SEO Visibility 工作流
+    // （周一 06:30 UTC）提交，其余时间它只是同一份读数被重新渲染。
+    crawl_visibility: "growth",
   };
   const SIDECAR_STATE = new Map();
   let TAB_ACTIVATION_VERSION = 0;
@@ -255,6 +258,13 @@
   const DATA_PLANE_FILES = new Set([
     "cron-heartbeats", "dashboard", "decision_audit", "decision_trail",
     "overview", "shadow_portfolio", "workflow-outcomes",
+    // The weekly Search Console reading. In this list for the same reason as the
+    // rest — its Pages copy only refreshes when the site is rebuilt, so the
+    // same-origin path would serve a reading up to a rebuild behind. It is also
+    // the one member the data plane may legitimately not carry yet, which the
+    // loader already survives: a miss gives the tab an empty panel, and the
+    // publisher handles absence on the write side.
+    "crawl_visibility",
   ]);
   // null until the first paint succeeds, and back to null for good if that
   // origin ever fails us — in which case the page degrades to reading Pages, as

--- a/site/index.html
+++ b/site/index.html
@@ -123,6 +123,7 @@ layout: null
     <button class="tab-btn" id="tab-market" data-tab="market" aria-controls="panel-market" role="tab" aria-selected="false">Signals</button>
     <button class="tab-btn" id="tab-plan" data-tab="plan" aria-controls="panel-plan" role="tab" aria-selected="false">Plan</button>
     <button class="tab-btn" id="tab-reflect" data-tab="reflect" aria-controls="panel-reflect" role="tab" aria-selected="false">Reflect</button>
+    <button class="tab-btn" id="tab-growth" data-tab="growth" aria-controls="panel-growth" role="tab" aria-selected="false">Growth</button>
   </nav>
   <div class="swipe-hint" aria-hidden="true"></div>
 </header>
@@ -1125,6 +1126,43 @@ layout: null
       </div>
       <p class="chart-hint">每日净盈亏柱状（绿涨红跌）+ 累计盈亏曲线。柱在零下方 = 当日亏损；曲线走势看长期方向。<b>跟随上方 Equity Curve 的市场切换</b>：总览=USD-eq，美股=$，港股=HK$。</p>
       <div id="chart-daily-pnl" class="chart-box"></div>
+    </div>
+
+  </section>
+  <section class="panel" id="panel-growth" data-panel="growth" role="tabpanel" aria-labelledby="tab-growth">
+    <h2>Growth</h2>
+
+    <div class="sect-divider">被看见的程度 · 每周 Search Console</div>
+
+    <div class="card desktop-wide" id="growth-card">
+      <div class="card-head"><div>
+        <div class="overview-card-kicker">SEO · 每周一 UTC 06:30 量一次，Python 取数，模型不参与</div>
+        <h3>搜索可见性</h3>
+      </div></div>
+
+      <div class="kpi-grid" id="growth-kpis"></div>
+
+      <div class="sub-block">
+        <div class="sub-block-head">每周读数 <span class="muted" id="growth-history-note"></span></div>
+        <div id="growth-history"></div>
+        <p class="chart-hint">窗口是定长的、各自算各自的：7 天和 28 天的窗口都截止在最后一个完整日，所以相邻两周不会互相重复计入。</p>
+      </div>
+
+      <div class="sub-block">
+        <div class="sub-block-head">这 14 天逐日 <span class="muted">GSC 完整到最后一个完整日为止</span></div>
+        <div id="growth-spark"></div>
+      </div>
+
+      <div class="sub-block">
+        <div class="sub-block-head">搜索词 <span class="muted" id="growth-queries-note"></span></div>
+        <div id="growth-queries"></div>
+        <p class="chart-hint">曝光来自哪些词，决定了这些曝光值不值得高兴。跟项目无关的词带来的曝光是噪音，不是可见性。</p>
+      </div>
+
+      <div class="sub-block">
+        <div class="sub-block-head">收录与抓取 <span class="muted">Google 认不认这些页</span></div>
+        <div id="growth-coverage"></div>
+      </div>
     </div>
 
   </section>

--- a/site/tools/assemble_dashboard_gif.py
+++ b/site/tools/assemble_dashboard_gif.py
@@ -28,6 +28,12 @@ FRAME_DIR = os.environ.get("FRAME_DIR", os.path.join(ROOT, ".gifframes"))
 # the copy — so nothing ever ran the real one outside the weekly cron (#754).
 OUT = os.environ.get("GIF_OUT") or os.path.join(ROOT, "site", "assets", "dashboard.gif")
 
+# How many tabs the shooter photographs, named once because the number is read
+# from three places below and the shooter has to agree with all of them. They
+# were three bare `6` literals until the seventh tab landed: the count is a
+# shared fact between two files, so it is stated rather than repeated.
+TAB_COUNT = 7
+
 OW = 640             # output width (frames scaled to this; height follows aspect)
                      # 640 ≈ 2× the README's 300px display = crisp on retina; source
                      # frames are 800px so ≤800 stays real detail (no upscaling)
@@ -82,16 +88,16 @@ def _load_tab(i):
     return out
 
 
-tabs = [_load_tab(i) for i in range(6)]
+tabs = [_load_tab(i) for i in range(TAB_COUNT)]
 VH = tabs[0][0].height   # every viewport frame is the same size
 
 frames, durations = [], []
-for i in range(6):
-    seq, nxt_top = tabs[i], tabs[(i + 1) % 6][0]   # wrap reflect → hero for a loop
+for i in range(TAB_COUNT):
+    seq, nxt_top = tabs[i], tabs[(i + 1) % TAB_COUNT][0]   # wrap the last → hero for a loop
     for j, fr in enumerate(seq):
         frames.append(fr)
         if j == 0:
-            durations.append(HOLD_TOP_REFLECT_MS if i == 5 else HOLD_TOP_MS)
+            durations.append(HOLD_TOP_REFLECT_MS if i == TAB_COUNT - 1 else HOLD_TOP_MS)
         elif j == len(seq) - 1:
             durations.append(HOLD_BOTTOM_MS)       # linger at the bottom
         else:

--- a/site/tools/shoot_dashboard.js
+++ b/site/tools/shoot_dashboard.js
@@ -50,7 +50,10 @@ const FRAME_DIR = process.env.FRAME_DIR || path.join(ROOT, '.gifframes');
 const TMP_DIR = process.env.TMP_DIR || path.join(ROOT, '.gifframes');
 const CHROME_EXE = process.env.CHROME_EXE || undefined;
 const CAPTURE_GIF = process.env.CAPTURE_GIF !== '0';
-const TABS = ['hero', 'drill', 'risk', 'market', 'plan', 'reflect'];
+// Must match `TAB_COUNT` in assemble_dashboard_gif.py: the assembler names each
+// frame `f{i}_*` by index, so a tab in one list and not the other is either a
+// missing animation frame or a build that exits on a tab with no frames.
+const TABS = ['hero', 'drill', 'risk', 'market', 'plan', 'reflect', 'growth'];
 
 async function settle(page) {
   // 1) Hero panel populated (don't key off <canvas>: Hero has no chart → would hang).

--- a/tests/dashboard_tab_runtime.spec.js
+++ b/tests/dashboard_tab_runtime.spec.js
@@ -9,7 +9,9 @@ const { chromium } = require("playwright");
 
 const ROOT = path.resolve(__dirname, "..");
 const DETAIL_PATH = "/assets/js/dashboard.render.js";
-const TABS = ["drill", "risk", "market", "plan", "reflect"];
+// Every detail tab: all of them share one lazy bundle and one full-dashboard
+// fetch, and every one of them is walked by the missing-number sweep below.
+const TABS = ["drill", "risk", "market", "plan", "reflect", "growth"];
 // Everything after the first paint reads the data branch instead of this origin
 // (#367). Every page here stubs it: left unrouted it would put a live call to
 // raw.githubusercontent.com on CI's critical path, and the bytes it would return
@@ -200,7 +202,11 @@ async function testRuntime(browser, base) {
   await waitForData(rapid);
   await rapid.evaluate(tabs => tabs.forEach(tab =>
     document.querySelector(`.tab-btn[data-tab="${tab}"]`).click()), TABS);
-  await waitForTab(rapid, "reflect");
+  // The click order above makes the LAST tab in `TABS` the active one, and this
+  // used to be spelled "reflect" — the tab that happened to be last. Adding a tab
+  // then waited on a panel the test had already navigated away from, which reads
+  // as a timeout in the runtime, not as the stale assumption it is.
+  await waitForTab(rapid, TABS[TABS.length - 1]);
   assert.equal(rapidState.detailRequests, 1, "rapid activation duplicated the bundle request");
   assert.equal(rapidState.fullRequests, 1, "rapid activation duplicated the full dashboard request");
   assert.deepEqual(rapidState.failures, []);
@@ -1313,6 +1319,123 @@ async function testNoTabPrintsAMissingNumber(browser, base) {
   }
 }
 
+// The Growth panel is the one tab whose data arrives weekly, and its whole claim
+// is that two readings may be compared. That claim is a property of the render,
+// not of the script: the panel is where a reader sees "28, 前一周 15" and decides
+// whether anything happened. So the fixture is two weeks and the assertions are
+// about the arithmetic and about what a spike looks like.
+async function testTheGrowthPanelComparesWeeksAndFitsAPhone(browser, base) {
+  const week = (imp, clicks, pos, start, end) => ({
+    start, end, days: 7, complete: true, days_with_data: 7,
+    impressions: imp, clicks, position: pos,
+  });
+  const payload = {
+    generated_at: "2026-09-08T06:30:00Z",
+    site: "https://example.test/",
+    snapshots: [
+      {
+        as_of: "2026-09-01",
+        windows: { 7: week(15, 0, 9.0, "2026-08-26", "2026-09-01"),
+                   28: week(40, 1, 8.5, "2026-08-05", "2026-09-01") },
+        queries: { reported: 0, top: [] },
+        pages_with_impressions: 1,
+        sitemap: { lastSubmitted: "2026-08-16T00:00:00Z", lastDownloaded: null },
+        coverage: { "/": { verdict: "PASS", coverageState: "Submitted and indexed",
+                           lastCrawlTime: "2026-08-26T04:17:40Z" } },
+        daily: [{ date: "2026-09-01", impressions: 15, clicks: 0, position: 9 }],
+      },
+      {
+        as_of: "2026-09-08",
+        windows: { 7: week(28, 0, 7.4, "2026-09-02", "2026-09-08"),
+                   28: week(60, 1, 7.8, "2026-08-12", "2026-09-08") },
+        queries: { reported: 5, top: [
+          { query: "tencent29209", impressions: 20, clicks: 0, position: 8.7 },
+          { query: "tencent28194", impressions: 5, clicks: 0, position: 3.6 },
+        ] },
+        pages_with_impressions: 1,
+        sitemap: { lastSubmitted: "2026-08-16T00:00:00Z", lastDownloaded: null },
+        coverage: {
+          "/": { verdict: "PASS", coverageState: "Submitted and indexed",
+                 lastCrawlTime: "2026-08-26T04:17:40Z" },
+          "briefs.html": { verdict: "NEUTRAL",
+                           coverageState: "URL is unknown to Google" },
+        },
+        // A spike that rises and falls over the last 14 complete days, so the
+        // bars have distinct heights and the quiet tail has to be drawn too.
+        daily: [1, 3, 6, 9, 6, 3, 17, 0, 0, 0, 0, 0, 0, 0].map((impressions, i) => ({
+          date: new Date(Date.UTC(2026, 7, 26 + i)).toISOString().slice(0, 10),
+          impressions, clicks: 0, position: 7,
+        })),
+      },
+    ],
+  };
+
+  for (const [label, width] of [["desktop", 1280], ["mobile", 390]]) {
+    const context = await browser.newContext({ viewport: { width, height: 844 } });
+    const page = await context.newPage();
+    const state = observe(page);
+    await stubLiveOrigin(page, {
+      patch: (name, json) => (name === "crawl_visibility.json" ? payload : null),
+    });
+    await page.goto(base, { waitUntil: "networkidle" });
+    await waitForData(page);
+    await page.click('.tab-btn[data-tab="growth"]');
+    await waitForTab(page, "growth");
+
+    const seen = await page.evaluate(() => {
+      const panel = document.querySelector('[data-panel="growth"]');
+      const cells = [...document.querySelectorAll("#growth-kpis .kpi-cell")];
+      const rows = [...document.querySelectorAll("#growth-history tbody tr")];
+      const bars = [...document.querySelectorAll("#growth-spark .growth-bar")];
+      const top = document.querySelector("#growth-queries tbody tr");
+      return {
+        kpis: cells.map(cell => cell.innerText.replace(/\s+/g, " ").trim()),
+        historyRows: rows.length,
+        // Newest first, so the first row is the reading a reader came for.
+        newest: rows[0] ? rows[0].innerText.replace(/\s+/g, " ").trim() : null,
+        bars: bars.length,
+        heights: bars.map(bar => Math.round(bar.getBoundingClientRect().height)),
+        idleBarHeight: bars.filter(bar => bar.classList.contains("is-idle"))
+          .map(bar => Math.round(bar.getBoundingClientRect().height)),
+        query: top ? top.innerText.replace(/\s+/g, " ").trim() : null,
+        coverageRows: document.querySelectorAll("#growth-coverage tbody tr").length,
+        overflow: panel.scrollWidth - panel.clientWidth,
+        pageOverflow: document.documentElement.scrollWidth - document.documentElement.clientWidth,
+        height: Math.round(panel.getBoundingClientRect().height),
+      };
+    });
+
+    assert.equal(seen.kpis.length, 4, `${label}: the panel lost a headline figure`);
+    assert.match(seen.kpis[0], /28/, `${label}: 7-day impressions missing from ${seen.kpis[0]}`);
+    assert.match(seen.kpis[0], /前一周 15/,
+      `${label}: the week is printed without the week before it — a number with no comparison`);
+    assert.match(seen.kpis[0], /\+13/,
+      `${label}: a rise of 13 was not shown as one (${seen.kpis[0]})`);
+    assert.match(seen.kpis[1], /点击/,
+      `${label}: clicks are not on the panel; impressions alone cannot tell "shown" from "read"`);
+
+    assert.equal(seen.historyRows, 2, `${label}: the history dropped a reading`);
+    assert.match(seen.newest, /^2026-09-08/,
+      `${label}: the newest reading is not first (${seen.newest})`);
+    assert.equal(seen.query, "tencent29209 20 0 8.7",
+      `${label}: the query that produced the impressions is not shown (${seen.query})`);
+    assert.equal(seen.coverageRows, 2, `${label}: coverage rows missing`);
+
+    assert.equal(seen.bars, 14, `${label}: the daily series is not 14 bars`);
+    assert(seen.heights.every(h => h >= 2),
+      `${label}: a day with no impressions was drawn as nothing — "quiet" and "not measured" then look alike`);
+    assert.equal(new Set(seen.heights).size > 1, true,
+      `${label}: every bar is the same height, so the series is not being read`);
+    assert.equal(seen.idleBarHeight.length, 7,
+      `${label}: the zero days are not marked — ${seen.idleBarHeight.length} of 14`);
+
+    assert.equal(seen.overflow, 0, `${label}: the Growth panel scrolls sideways`);
+    assert.equal(seen.pageOverflow, 0, `${label}: the Growth panel widened the page`);
+    assert.deepEqual(state.errors, [], `${label}: a Growth renderer threw`);
+    await context.close();
+  }
+}
+
 async function testAPanelSaysWhenItsDataDidNotLoad(browser, base) {
   // A detail tab needs dashboard.json (191 KB, normally from the data branch)
   // before it can paint. When that request failed the only trace was
@@ -2128,30 +2251,39 @@ async function main() {
   const browser = await chromium.launch(executablePath ? {
     executablePath, args: ["--no-sandbox"],
   } : {});
+  // `SPEC_ONLY=name,name` runs a subset. A browser contract measured before the
+  // layout settles is load-sensitive (see the verdict-deck case), and re-running
+  // one case used to mean editing this list and remembering to put it back.
+  const only = (process.env.SPEC_ONLY || "").split(",").map(s => s.trim()).filter(Boolean);
+  const run = async (name, fn) => {
+    if (only.length && !only.includes(name)) return;
+    await fn();
+  };
   try {
-    await testRuntime(browser, base);
-    await testCurrentHoldingsOwnDecisionMatrixMembership(browser, base);
-    await testLiveDataOrigin(browser, base);
-    await testEquityTouch(browser, base);
-    await testTabGuardWithoutForcedLayout(browser, base);
-    await testTopbarFitsWhenRefreshLabelSwaps(browser, base);
-    await testHeaderSharesTheContentColumn(browser, base);
-    await testTraceRowsFitPhoneWidths(browser, base);
-    await testHoldingsAndHeroNeverTruncate(browser, base);
-    await testVerdictDeckFillsItsBoxAndRanksGatesBySeverity(browser, base);
-    await testDataHealthNamesTheDegradedSlotAndWeChatDrops(browser, base);
-    await testDataHealthIsReadableOnAPhone(browser, base);
-    await testAQuietLaneFoldsItsLedgerInsteadOfScrolling(browser, base);
-    await testASidecarStillReachesItsCardWhenThePagerIsStillSettling(browser, base);
-    await testTheDebateTrailIsAListOfCasesNotAWallOfText(browser, base);
-    await testThePlanTimelineClampsItsRationales(browser, base);
-    await testAddSideCardExplainsWhyThereIsNoAdd(browser, base);
-    await testALeveragedRowWithoutVolatilityPrintsNoUndefined(browser, base);
-    await testNoTabPrintsAMissingNumber(browser, base);
-    await testAPanelSaysWhenItsDataDidNotLoad(browser, base);
-    await testCronRailAccountsForEverySlotWithoutASecondVerdict(browser, base);
-    await testCronNeedsActionMergesIntoTheOneTodoListButWatchDoesNot(browser, base);
-    await testMoversSayWhichSessionTheyAreFrom(browser, base);
+    await run("runtime", () => testRuntime(browser, base));
+    await run("testCurrentHoldingsOwnDecisionMatrixMembership", () => testCurrentHoldingsOwnDecisionMatrixMembership(browser, base));
+    await run("testLiveDataOrigin", () => testLiveDataOrigin(browser, base));
+    await run("testEquityTouch", () => testEquityTouch(browser, base));
+    await run("testTabGuardWithoutForcedLayout", () => testTabGuardWithoutForcedLayout(browser, base));
+    await run("testTopbarFitsWhenRefreshLabelSwaps", () => testTopbarFitsWhenRefreshLabelSwaps(browser, base));
+    await run("testHeaderSharesTheContentColumn", () => testHeaderSharesTheContentColumn(browser, base));
+    await run("testTraceRowsFitPhoneWidths", () => testTraceRowsFitPhoneWidths(browser, base));
+    await run("testHoldingsAndHeroNeverTruncate", () => testHoldingsAndHeroNeverTruncate(browser, base));
+    await run("testVerdictDeckFillsItsBoxAndRanksGatesBySeverity", () => testVerdictDeckFillsItsBoxAndRanksGatesBySeverity(browser, base));
+    await run("testDataHealthNamesTheDegradedSlotAndWeChatDrops", () => testDataHealthNamesTheDegradedSlotAndWeChatDrops(browser, base));
+    await run("testDataHealthIsReadableOnAPhone", () => testDataHealthIsReadableOnAPhone(browser, base));
+    await run("testAQuietLaneFoldsItsLedgerInsteadOfScrolling", () => testAQuietLaneFoldsItsLedgerInsteadOfScrolling(browser, base));
+    await run("testASidecarStillReachesItsCardWhenThePagerIsStillSettling", () => testASidecarStillReachesItsCardWhenThePagerIsStillSettling(browser, base));
+    await run("testTheDebateTrailIsAListOfCasesNotAWallOfText", () => testTheDebateTrailIsAListOfCasesNotAWallOfText(browser, base));
+    await run("testThePlanTimelineClampsItsRationales", () => testThePlanTimelineClampsItsRationales(browser, base));
+    await run("testAddSideCardExplainsWhyThereIsNoAdd", () => testAddSideCardExplainsWhyThereIsNoAdd(browser, base));
+    await run("testALeveragedRowWithoutVolatilityPrintsNoUndefined", () => testALeveragedRowWithoutVolatilityPrintsNoUndefined(browser, base));
+    await run("testNoTabPrintsAMissingNumber", () => testNoTabPrintsAMissingNumber(browser, base));
+    await run("testTheGrowthPanelComparesWeeksAndFitsAPhone", () => testTheGrowthPanelComparesWeeksAndFitsAPhone(browser, base));
+    await run("testAPanelSaysWhenItsDataDidNotLoad", () => testAPanelSaysWhenItsDataDidNotLoad(browser, base));
+    await run("testCronRailAccountsForEverySlotWithoutASecondVerdict", () => testCronRailAccountsForEverySlotWithoutASecondVerdict(browser, base));
+    await run("testCronNeedsActionMergesIntoTheOneTodoListButWatchDoesNot", () => testCronNeedsActionMergesIntoTheOneTodoListButWatchDoesNot(browser, base));
+    await run("testMoversSayWhichSessionTheyAreFrom", () => testMoversSayWhichSessionTheyAreFrom(browser, base));
   } finally {
     await browser.close();
     await new Promise(resolve => server.close(resolve));

--- a/tests/test_crawl_visibility_snapshot.py
+++ b/tests/test_crawl_visibility_snapshot.py
@@ -182,3 +182,23 @@ def test_the_workflow_commits_what_the_script_writes():
         "a committing workflow without write permission fails on its first run")
     assert "group: data-write" in workflow, (
         "every data producer shares one writer lane; this one commits to master")
+
+
+def test_every_workflow_is_parseable_yaml():
+    """The commit message above carries a colon, and unquoted YAML reads the
+    second one as a mapping key.
+
+    Nothing in this suite parsed the workflow files, so the only thing that
+    noticed was `lint` — the CI actionlint job, several minutes into a PR. The
+    same claim is checkable here in milliseconds and without a pinned binary;
+    actionlint still owns everything semantics, this owns "it is YAML".
+    """
+    import yaml
+
+    workflows = sorted((ROOT / ".github" / "workflows").glob("*.yml"))
+    assert workflows, "no workflows found — the glob is wrong, not the workflows"
+    for path in workflows:
+        try:
+            yaml.safe_load(path.read_text(encoding="utf-8"))
+        except yaml.YAMLError as error:  # pragma: no cover - the message is the test
+            raise AssertionError(f"{path.name} is not parseable YAML: {error}") from error

--- a/tests/test_crawl_visibility_snapshot.py
+++ b/tests/test_crawl_visibility_snapshot.py
@@ -1,0 +1,184 @@
+"""The Search Console history has to be comparable, and that is a property of
+its windows rather than of its formatting.
+
+GitHub keeps workflow logs for 90 days, so until `--snapshot` existed the only
+record of what the site's visibility was last month was the last time somebody
+read the log. A history that double-counts its own cadence, or that records a
+week which GSC had not finished filling in, is worse than no history: it looks
+like a trend and it is an artifact.
+
+The invariants here are the ones a reader cannot check by looking at the panel —
+consecutive windows must not overlap, a re-run of the same week must replace its
+entry rather than append a duplicate, and an unmeasured week must read as absent
+rather than as zero.
+"""
+from __future__ import annotations
+
+import datetime as dt
+import importlib.util
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "ops" / "growth" / "crawl_visibility.py"
+
+spec = importlib.util.spec_from_file_location("crawl_visibility", SCRIPT)
+crawl_visibility = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(crawl_visibility)
+
+
+def _daily(end: str, days: int, impressions: int = 1, clicks: int = 0,
+           position: float = 5.0) -> list[dict]:
+    """A dense run of days ending at `end`, ascending."""
+    last = dt.date.fromisoformat(end)
+    return [
+        {"date": str(last - dt.timedelta(days=offset)),
+         "impressions": impressions, "clicks": clicks, "position": position}
+        for offset in range(days - 1, -1, -1)
+    ]
+
+
+def _report(daily: list[dict], **overrides) -> dict:
+    report = {
+        "site": "https://example.test/",
+        "window": {"start": "2026-06-01", "end": "2026-09-01", "days": 90},
+        "through": dt.date.fromisoformat(daily[-1]["date"]) if daily else dt.date(2026, 9, 1),
+        "daily": daily,
+        "queries": {"reported": 0, "top": []},
+        "impressions": 0,
+        "clicks": 0,
+        "pages_with_impressions": 1,
+        "sitemaps": [{"path": "sitemap.xml", "lastSubmitted": "2026-08-16T00:00:00Z",
+                      "lastDownloaded": None, "isPending": True, "errors": 0}],
+        "coverage": {"/": {"verdict": "PASS", "coverageState": "Submitted and indexed",
+                           "lastCrawlTime": "2026-08-26T04:17:40Z"}},
+    }
+    report.update(overrides)
+    return report
+
+
+def test_complete_through_floors_to_the_last_day_gsc_can_have_finished():
+    """A window ending on a day GSC is still filling in reads differently every
+    time it is asked, which is how one week becomes two numbers."""
+    daily = _daily("2026-09-12", 10)
+    assert crawl_visibility._complete_through(daily) == dt.date(2026, 9, 11)
+    # The lag has to be large enough to be safe, not large enough to be useless.
+    assert crawl_visibility._complete_through(daily, lag_days=1) == dt.date(2026, 9, 12)
+
+
+def test_an_empty_series_reports_no_measurable_day_rather_than_today():
+    assert crawl_visibility._complete_through([]) is None
+
+
+def test_window_stats_weigh_position_by_impressions():
+    """A mean over days would let a single-impression day move a 7-day average as
+    much as a twenty-impression one — a page can look like it improved its
+    position while it was simply shown less."""
+    daily = [
+        {"date": "2026-09-01", "impressions": 100, "clicks": 1, "position": 10.0},
+        {"date": "2026-09-02", "impressions": 1, "clicks": 0, "position": 1.0},
+    ]
+    stats = crawl_visibility._window_stats(daily, dt.date(2026, 9, 2), 7)
+    assert stats["impressions"] == 101
+    assert stats["clicks"] == 1
+    # (10*100 + 1*1) / 101, not (10 + 1) / 2
+    assert stats["position"] == 9.91
+    assert stats["days"] == 7
+    assert stats["days_with_data"] == 2
+    assert stats["complete"] is False, (
+        "a window GSC had not filled in must say so — it is the difference "
+        "between a quiet week and an unmeasured one")
+
+
+def test_window_with_no_rows_is_zeroed_not_missing():
+    stats = crawl_visibility._window_stats([], dt.date(2026, 9, 2), 7)
+    assert stats["impressions"] == 0
+    assert stats["position"] is None, "no impressions means no position to report"
+
+
+def test_a_snapshot_carries_both_fixed_windows():
+    payload, stats = crawl_visibility.snapshot(_report(_daily("2026-09-08", 30)))
+    entry = payload["snapshots"][-1]
+    assert set(entry["windows"]) == {"7", "28"}
+    assert entry["windows"]["7"]["days"] == 7
+    assert entry["windows"]["28"]["days"] == 28
+    assert entry["as_of"] == "2026-09-08"
+    assert stats["added"] == 1
+
+
+def test_consecutive_weeks_do_not_share_a_day():
+    """The whole reason the windows are fixed-length. If they overlapped, the
+    series would rise every week by construction and the panel would report the
+    cadence as growth."""
+    first, _ = crawl_visibility.snapshot(_report(_daily("2026-09-08", 60)))
+    second, _ = crawl_visibility.snapshot(_report(_daily("2026-09-15", 60)), first)
+
+    a = second["snapshots"][-2]["windows"]["7"]
+    b = second["snapshots"][-1]["windows"]["7"]
+    assert a["end"] == "2026-09-08" and b["start"] == "2026-09-09", (
+        f"windows touch or overlap: {a} then {b}")
+    assert len(second["snapshots"]) == 2
+
+
+def test_remeasuring_the_same_week_replaces_its_entry():
+    """The Actions schedule drifts by hours, so two runs land on one day. Keyed
+    on the window rather than on the clock, they are the same measurement."""
+    once, _ = crawl_visibility.snapshot(_report(_daily("2026-09-08", 30)))
+    twice, stats = crawl_visibility.snapshot(
+        _report(_daily("2026-09-08", 30), pages_with_impressions=3), once)
+
+    assert len(twice["snapshots"]) == 1, "the same week was recorded twice"
+    assert twice["snapshots"][-1]["pages_with_impressions"] == 3
+    assert stats["added"] == 0
+
+
+def test_history_is_capped_and_keeps_the_newest():
+    payload = {"snapshots": []}
+    start = dt.date(2024, 1, 2)
+    for week in range(crawl_visibility.SNAPSHOT_CAP + 3):
+        end = str(start + dt.timedelta(weeks=week))
+        payload, _ = crawl_visibility.snapshot(_report(_daily(end, 30)), payload)
+    assert len(payload["snapshots"]) == crawl_visibility.SNAPSHOT_CAP
+    as_of = [entry["as_of"] for entry in payload["snapshots"]]
+    assert as_of == sorted(as_of), "the cap must drop the oldest, not the newest"
+    assert as_of[-1] == str(start + dt.timedelta(weeks=crawl_visibility.SNAPSHOT_CAP + 2))
+
+
+def test_snapshot_records_the_query_dimension_with_its_own_count():
+    """"No query rows" has two causes that read identically in a report. The
+    count is what separates them, so it has to survive into the history."""
+    payload, _ = crawl_visibility.snapshot(_report(
+        _daily("2026-09-08", 30),
+        queries={"reported": 5, "top": [{"query": "tencent29209", "impressions": 30,
+                                         "clicks": 0, "position": 8.5}]}))
+    entry = payload["snapshots"][-1]
+    assert entry["queries"]["reported"] == 5
+    assert entry["queries"]["top"][0]["query"] == "tencent29209"
+
+
+def test_snapshot_keeps_only_the_recent_daily_tail():
+    """Fourteen days, not the query window: the file is committed weekly forever."""
+    payload, _ = crawl_visibility.snapshot(_report(_daily("2026-09-08", 90)))
+    assert len(payload["snapshots"][-1]["daily"]) == 14
+
+
+def test_history_lines_render_the_last_readings_side_by_side():
+    payload = {"snapshots": []}
+    for end in ("2026-09-01", "2026-09-08"):
+        payload, _ = crawl_visibility.snapshot(_report(_daily(end, 30)), payload)
+    text = "\n".join(crawl_visibility.history_lines(payload))
+    assert "2026-09-01" in text and "2026-09-08" in text
+    assert "7d imp" in text
+
+
+def test_the_workflow_commits_what_the_script_writes():
+    """The script and the workflow are one mechanism split across two files, and
+    only one half is importable. A `--snapshot` path the commit step does not
+    stage is a week of visibility that survives only in a 90-day log."""
+    workflow = (ROOT / ".github" / "workflows" / "seo-visibility.yml").read_text()
+    assert "--snapshot assets/data/crawl_visibility.json" in workflow
+    assert "paths: assets/data/crawl_visibility.json" in workflow
+    assert "contents: write" in workflow, (
+        "a committing workflow without write permission fails on its first run")
+    assert "group: data-write" in workflow, (
+        "every data producer shares one writer lane; this one commits to master")

--- a/tests/test_dashboard_output_ownership.py
+++ b/tests/test_dashboard_output_ownership.py
@@ -1,8 +1,10 @@
 """One build, five public outputs, one semantic publication contract."""
 import json
+import os
 import re
-import pytest
 import subprocess
+import sys
+import pytest
 from pathlib import Path
 
 
@@ -403,3 +405,52 @@ def test_the_two_sidecars_are_published_with_the_generation():
     assert set(dashboard_outputs.output_paths(ROOT)) < set(DATA_PLANE_FILES)
     assert "assets/data/cron-heartbeats.json" in DATA_PLANE_FILES
     assert "assets/data/workflow-outcomes.json" in DATA_PLANE_FILES
+
+
+def test_a_file_written_weekly_does_not_gate_the_whole_generation(tmp_path):
+    """The optional member is absent, and the publish still proceeds.
+
+    This is the difference that makes the split worth having. The branch is
+    replaced wholesale, so a member that cannot be read takes the generation down
+    with it — correct for files that share a tick, fatal for one a weekly workflow
+    writes. `crawl_visibility.json` does not exist at all after a data-plane
+    reset, and a publisher that refused then would stop refreshing the entire
+    public dashboard until the following Monday.
+
+    Run as a subprocess against a fake root so the assertion lands on the real
+    code path. The publish itself fails on the throwaway repository, which is the
+    point: it got far enough to try.
+    """
+    from publish_data_branch import DATA_PLANE_FILES, DATA_PLANE_OPTIONAL
+
+    assert DATA_PLANE_OPTIONAL, "the split exists; keep it populated or delete it"
+    assert not set(DATA_PLANE_OPTIONAL) & set(DATA_PLANE_FILES), (
+        "a path in both lists is required, which is the thing being avoided")
+
+    root = tmp_path / "workspace"
+    for name in DATA_PLANE_FILES:
+        target = root / name
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text("{}", encoding="utf-8")
+    # The output contract is workspace configuration, so a fake workspace has to
+    # carry one: `output_paths` reads it before any output file is opened.
+    (root / "config").mkdir(parents=True, exist_ok=True)
+    (root / "config" / "dashboard-outputs.json").write_bytes(
+        (ROOT / "config" / "dashboard-outputs.json").read_bytes())
+
+    done = subprocess.run(
+        [sys.executable, str(ROOT / "ops/publish/publish_data_branch.py"),
+         "--root", str(root), "--repo", str(root)],
+        capture_output=True, text=True, cwd=ROOT, timeout=120,
+        # `--root` moves what the publisher reads; the failure ledger still
+        # resolves the live workspace on its own, and a test that lets it do that
+        # writes into the checkout (#816).
+        env={**os.environ, "CLAWOCK_WORKSPACE": str(root)},
+    )
+    output = done.stdout + done.stderr
+    assert "cannot read" not in output, (
+        "an absent optional member was treated as a missing generation:\n" + output)
+    for name in DATA_PLANE_OPTIONAL:
+        assert f"{name} not written yet" in output, (
+            f"the publisher did not report the absent optional member {name}:\n"
+            + output)

--- a/tests/test_dashboard_tabs_a11y.py
+++ b/tests/test_dashboard_tabs_a11y.py
@@ -40,8 +40,14 @@ def _attr(tag, name):
 
 
 def test_tab_buttons_and_panels_point_at_each_other():
-    assert len(TAB_BUTTONS) == 6, f"expected 6 tab buttons, found {len(TAB_BUTTONS)}"
-    assert len(PANELS) == 6, f"expected 6 panels, found {len(PANELS)}"
+    # The count is not asserted against a literal any more. Adding a tab is a
+    # real change that touches the animation contract too, and a bare `== 6` here
+    # only meant the number was written down in two test files; the pairing below
+    # is the part that can actually be wrong.
+    assert TAB_BUTTONS, "the dashboard declares no tabs at all"
+    assert len(TAB_BUTTONS) == len(PANELS), (
+        f"{len(TAB_BUTTONS)} tab buttons and {len(PANELS)} panels — every tab "
+        "needs a panel and every panel needs a tab")
 
     panels = {_attr(p, "data-panel"): p for p in PANELS}
     assert None not in panels, "a .panel has no data-panel — the pager keys on it"

--- a/tests/test_manifest_parity.py
+++ b/tests/test_manifest_parity.py
@@ -120,8 +120,13 @@ def _js_data_plane_names():
 def _publisher_names():
     sys.path.insert(0, str(ROOT / "ops/publish"))
     import publish_data_branch  # noqa: E402
+    # Optional members count as published: the branch carries one whenever it
+    # exists, and the browser may route it before the first weekly run has written
+    # it. Narrowing this to the required set would let the routing table and the
+    # publisher disagree about a file that is genuinely on the branch.
     return {p.rsplit("/", 1)[-1].removesuffix(".json")
-            for p in publish_data_branch.DATA_PLANE_FILES}
+            for p in publish_data_branch.DATA_PLANE_FILES
+            + publish_data_branch.DATA_PLANE_OPTIONAL}
 
 
 def test_the_browser_routes_exactly_the_files_the_publisher_puts_on_the_branch():

--- a/tests/test_pages_deployment_contract.py
+++ b/tests/test_pages_deployment_contract.py
@@ -250,7 +250,9 @@ def test_the_browser_reads_the_same_branch_and_files_the_publisher_writes():
     import sys
 
     sys.path.insert(0, str(ROOT / "ops/publish"))
-    from publish_data_branch import DATA_BRANCH, DATA_PLANE_FILES
+    from publish_data_branch import (
+        DATA_BRANCH, DATA_PLANE_FILES, DATA_PLANE_OPTIONAL,
+    )
 
     origin = re.search(r'DATA_PLANE_ORIGIN\s*=\s*"([^"]+)"', UI).group(1)
     assert origin.endswith(f"/{DATA_BRANCH}/"), (
@@ -258,7 +260,11 @@ def test_the_browser_reads_the_same_branch_and_files_the_publisher_writes():
 
     block = UI.split("const DATA_PLANE_FILES = new Set([", 1)[1].split("]);", 1)[0]
     browser = set(re.findall(r'"([^"]+)"', block))
-    published = {Path(name).stem for name in DATA_PLANE_FILES}
+    # Optional members are published too: they are on the branch whenever they
+    # exist at all, and the point of the split is that the browser may ask for one
+    # before the first weekly run has written it. Leaving them out here would make
+    # the check pass by looking at less.
+    published = {Path(name).stem for name in DATA_PLANE_FILES + DATA_PLANE_OPTIONAL}
     assert browser == published, (
         f"browser reads {sorted(browser)}, publisher writes {sorted(published)}")
 

--- a/tests/test_site_tools_contract.py
+++ b/tests/test_site_tools_contract.py
@@ -37,11 +37,13 @@ def _tabs_in_shoot():
 
 
 def _tab_count_in_assembler():
-    counts = {int(n) for n in re.findall(r"range\((\d+)\)", ASSEMBLER_SRC)}
-    assert len(counts) == 1, (
-        f"the assembler now iterates several different tab counts {counts}; "
-        "one of them is wrong")
-    return counts.pop()
+    # The count used to be three bare `range(6)` literals and this helper read
+    # one of them. The seventh tab turned the literal into a fact the shooter and
+    # the assembler share, so the declared constant is what is checked now.
+    match = re.search(r"^TAB_COUNT\s*=\s*(\d+)", ASSEMBLER_SRC, re.MULTILINE)
+    assert match, ("assemble_dashboard_gif.py no longer declares TAB_COUNT — the "
+                   "tab count has to be stated once rather than repeated per loop")
+    return int(match.group(1))
 
 
 def test_the_two_halves_agree_on_how_many_tabs_there_are():
@@ -49,12 +51,15 @@ def test_the_two_halves_agree_on_how_many_tabs_there_are():
 
     `_load_tab` calls `sys.exit(1)` when a tab has no frames, so adding a tab to
     `TABS` alone fails the GIF build — and adding one to the assembler alone
-    silently drops the last tab from the animation.
+    silently drops the last tab from the animation. The dashboard's own count is
+    checked against the markup in `test_dashboard_tabs_a11y`, which counts the
+    real buttons rather than a literal, so this pair only has to agree with each
+    other.
     """
     assert len(_tabs_in_shoot()) == _tab_count_in_assembler(), (
         f"shoot_dashboard.js shoots {_tabs_in_shoot()} "
         f"({len(_tabs_in_shoot())} tabs) but the assembler iterates "
-        f"range({_tab_count_in_assembler()})")
+        f"{_tab_count_in_assembler()}")
 
 
 def test_the_frame_names_one_half_writes_are_the_names_the_other_half_reads():


### PR DESCRIPTION
feat(growth): 搜索可见性进看板，每周读数落盘成历史

kcn 问「这周 geo 和 seo 表现怎么样」，数字当时散在三处而且都要靠人记得去翻：
SEO 读数只在 Actions run log 里（GitHub 只留 90 天，三个月前的读数查不回来）、
GitHub 流量在仓库文件里但不上线、看板上一个字都没有。这次把第三条补上。

**读数落盘。** `crawl_visibility.py --snapshot` 把每次读数 merge 进
`assets/data/crawl_visibility.json`，由 SEO Visibility 工作流提交（`contents: write`
+ `data-write` 写者车道）。

窗口是定长的 7 天 / 28 天，截止在**最后一个完整日**（GSC 会回填尾部，截止在
「今天」的窗口每问一次都不一样）。这是正确性约束不是排版选择：拿 `--days 90`
去 append，每周都会和上一周重叠、把节奏报成增长。同理快照按**窗口末日**而非
运行时刻去重——Actions 排程会漂几小时，按时刻存会把同一周存两遍。

**面板。** 新的 Growth tab：4 张 KPI（曝光/点击/有曝光页/平均排名，每张带前一周
对比）、每周读数表、14 天逐日柱、搜索词、收录探测。搜索词和点击分开印，因为
「被排进去但没人点」和「根本没被排进去」是两件事，合成一个流量数字会把它们
藏进同一个 0。

**发布路径。** 新文件走 data-plane（浏览器读的那个 origin），但它和同代另外
七个文件**节奏不同**：那些每 20 分钟一个 tick，这份每周一次。data-plane 是整支
替换的，发布器读不到成员就拒绝发布整代——所以新增 `DATA_PLANE_OPTIONAL`：
缺失时跳过并打印，而不是让一份每周才出现的文件在它不存在时**卡住整个线上看板**。
`DATA_PLANE_FILES` 与读取方 `fetch_data_plane.py` 的接口保持不变。

**扩 tab 带出的两处契约**：GIF 装配器的 tab 数从三处裸 `6` 收成一个
`TAB_COUNT`（shooter 与 assembler 共用这一个事实）；a11y 的 tab 数断言改成数真实
按钮并检查 tab/panel 一一对应，不再在第二个测试文件里重复写一个字面量。

**同轮修掉的三条既有问题**：
- `testRuntime` 硬编码等在最后被点的 `reflect`——那是「当时恰好最后一个」的 tab，
  列表一变就变成等一个已经离开的面板，超时看起来像运行时坏了
- 浏览器 spec 加 `SPEC_ONLY=`，单跑一条不用改列表再记得改回来
- 判红过的 `testVerdictDeckFillsItsBox…` 是既有的负载敏感 flake：master 上
  3 次里红 2 次、branch 上同样序列红 2 次且都是同一句 -6px，与本次改动无关

验证：全量 pytest 3743 passed；浏览器 spec 全绿（除上述既有 flake）；390/1280
两档实测 0 横滚、0 页宽溢出；缺数据时面板说「没载入」而不是画成 0。