### PR TITLE
fix(dashboard): 数据健康读数行不再把手机屏顶宽 158px（UI PR 全线被它卡住）

### DIFF
--- a/site/assets/css/dashboard.css
+++ b/site/assets/css/dashboard.css
@@ -2709,6 +2709,11 @@
      一条期限用量带；有问题才升级视觉权重。(#876) */
   .hero-health { grid-column: 1 / -1; padding: 16px 18px 14px; }
   .hero-health-head { display: flex; align-items: flex-start; gap: 14px; }
+  /* flex 子项的 min-width:auto 会让这一行按 min-content 撑开：读数行里只要有一段
+     比手机宽，「逐项」按钮就被推出卡外（2026-09-12 实测 390px 下溢出 158px，
+     按钮右边缘 531px vs 卡右 374px）。文本仍由 metaBits() 拆短，这里只是让
+     按钮的位置不再取决于别人写了多长的一句话。 */
+  .hero-health-head > :first-child { min-width: 0; }
   .hero-health-verdict {
     margin: 6px 0 0; color: var(--text); font-size: var(--fs-lg);
     letter-spacing: -.01em; text-transform: none;

--- a/site/assets/js/dashboard.core.js
+++ b/site/assets/js/dashboard.core.js
@@ -21,6 +21,16 @@
   // there a missing field used to print "undefined%" / "null @ $null" (2026-09-12,
   // found by rendering every tab with the numbers nulled out and then removed).
   const numText = (v) => (v == null || (typeof v === "number" && !isFinite(v))) ? DASH : String(v);
+  // 「数据健康」那条读数行把每个事实包成一个 .dh-meta-bit（nowrap），折行只允许
+  // 发生在 bit 之间。这条规则的前提是**每一段都比屏幕窄**：2026-09-12 的
+  // crawl_visibility 一行四个事实挤成一段，390px 实测把整块牌顶宽 158px，顺带
+  // 把「逐项」按钮推出卡外（浏览器契约因此变红，而它只有在 UI lane 跑时才会被
+  // 看见）。复合读数一律先在这里按分隔点拆短，让 nowrap 的前提由代码保证，
+  // 而不是靠下一个人记得。
+  const metaBits = (...lines) => lines
+    .flatMap(line => String(line == null ? "" : line).split(" · "))
+    .map(part => part.trim())
+    .filter(Boolean);
   // The decision trail (fills, their scope, the plan timeline) ships in its own
   // sidecar since 2026-09-12. A generation published before the move still has
   // the sections on the main document, so read the sidecar first and fall back.

--- a/site/assets/js/dashboard.hero.js
+++ b/site/assets/js/dashboard.hero.js
@@ -1386,25 +1386,28 @@
     }
 
     if (metaEl) {
-      const bits = [];
       // 微信单通道掉投：上游 ret=-2，kcn 已定不修也不告警（#771），但「这一
       // 窗口掉了几档」必须答得上来。它不改 tone，也不占泳道 —— 成品由
       // Telegram 兜住了，它属于「已知不修」，位置就该在这条安静的行里。
-      if (droppedTotal) bits.push(`微信掉投 ${droppedTotal} 档 · TG 已兜 · 已知不修`);
+      const dropBit = droppedTotal ? `微信掉投 ${droppedTotal} 档 · TG 已兜 · 已知不修` : "";
       // 搜索可见性，一行。它在这一行而不是一张牌里：数字本身很小（7 天几十次
       // 曝光、0 点击、1/107 页被收录），做成卡片是给一个不动的量配一块固定的
       // 版面。放在这里，是因为它回答的正是这张卡的问题——「页面上的数字有没
       // 有人看得见」。sitemap 从未被下载时说出来，那是整份读数里最有用的事实。
       const sv = safe(DATA, "crawl_visibility");
-      if (sv && sv.available) {
-        const fetched = sv.sitemap_fetched ? "sitemap 已抓" : "sitemap 从未被下载";
-        bits.push(`搜索 7 天 ${numText(sv.impressions)} 曝光 / ${numText(sv.clicks)} 点击`
-          + ` · 收录 ${numText(sv.pages_with_impressions)} 页 · ${fetched}`
-          + ` · 截至 ${String(sv.as_of || "").slice(0, 10)}`);
-      }
-      if (bs.generated_at) bits.push(`构建 ${String(bs.generated_at).replace("T", " ").slice(0, 16)}`);
+      const searchBit = (sv && sv.available)
+        ? `搜索 7 天 ${numText(sv.impressions)} 曝光 / ${numText(sv.clicks)} 点击`
+          + ` · 收录 ${numText(sv.pages_with_impressions)} 页`
+          + ` · ${sv.sitemap_fetched ? "sitemap 已抓" : "sitemap 从未被下载"}`
+          + ` · 截至 ${String(sv.as_of || "").slice(0, 10)}`
+        : "";
       // 每一段各自不折行：窄屏实测把「构建 2026-09-09 00:05」在「构建」后面
-      // 折开，一个时刻被读成两条信息。折行只准发生在分隔点上。
+      // 折开，一个时刻被读成两条信息。折行只准发生在分隔点上，所以复合读数
+      // 先过 metaBits() 拆短（它保证每段都比手机窄，见 dashboard.core.js）。
+      const bits = metaBits(
+        dropBit,
+        searchBit,
+        bs.generated_at ? `构建 ${String(bs.generated_at).replace("T", " ").slice(0, 16)}` : "");
       metaEl.innerHTML = bits.map(b => `<span class="dh-meta-bit">${escapeHtml(b)}</span>`)
         .join(`<span class="dh-meta-sep"> · </span>`);
     }

--- a/site/assets/js/dashboard.render.js
+++ b/site/assets/js/dashboard.render.js
@@ -1507,25 +1507,28 @@
     }
 
     if (metaEl) {
-      const bits = [];
       // 微信单通道掉投：上游 ret=-2，kcn 已定不修也不告警（#771），但「这一
       // 窗口掉了几档」必须答得上来。它不改 tone，也不占泳道 —— 成品由
       // Telegram 兜住了，它属于「已知不修」，位置就该在这条安静的行里。
-      if (droppedTotal) bits.push(`微信掉投 ${droppedTotal} 档 · TG 已兜 · 已知不修`);
+      const dropBit = droppedTotal ? `微信掉投 ${droppedTotal} 档 · TG 已兜 · 已知不修` : "";
       // 搜索可见性，一行。它在这一行而不是一张牌里：数字本身很小（7 天几十次
       // 曝光、0 点击、1/107 页被收录），做成卡片是给一个不动的量配一块固定的
       // 版面。放在这里，是因为它回答的正是这张卡的问题——「页面上的数字有没
       // 有人看得见」。sitemap 从未被下载时说出来，那是整份读数里最有用的事实。
       const sv = safe(DATA, "crawl_visibility");
-      if (sv && sv.available) {
-        const fetched = sv.sitemap_fetched ? "sitemap 已抓" : "sitemap 从未被下载";
-        bits.push(`搜索 7 天 ${numText(sv.impressions)} 曝光 / ${numText(sv.clicks)} 点击`
-          + ` · 收录 ${numText(sv.pages_with_impressions)} 页 · ${fetched}`
-          + ` · 截至 ${String(sv.as_of || "").slice(0, 10)}`);
-      }
-      if (bs.generated_at) bits.push(`构建 ${String(bs.generated_at).replace("T", " ").slice(0, 16)}`);
+      const searchBit = (sv && sv.available)
+        ? `搜索 7 天 ${numText(sv.impressions)} 曝光 / ${numText(sv.clicks)} 点击`
+          + ` · 收录 ${numText(sv.pages_with_impressions)} 页`
+          + ` · ${sv.sitemap_fetched ? "sitemap 已抓" : "sitemap 从未被下载"}`
+          + ` · 截至 ${String(sv.as_of || "").slice(0, 10)}`
+        : "";
       // 每一段各自不折行：窄屏实测把「构建 2026-09-09 00:05」在「构建」后面
-      // 折开，一个时刻被读成两条信息。折行只准发生在分隔点上。
+      // 折开，一个时刻被读成两条信息。折行只准发生在分隔点上，所以复合读数
+      // 先过 metaBits() 拆短（它保证每段都比手机窄，见 dashboard.core.js）。
+      const bits = metaBits(
+        dropBit,
+        searchBit,
+        bs.generated_at ? `构建 ${String(bs.generated_at).replace("T", " ").slice(0, 16)}` : "");
       metaEl.innerHTML = bits.map(b => `<span class="dh-meta-bit">${escapeHtml(b)}</span>`)
         .join(`<span class="dh-meta-sep"> · </span>`);
     }

--- a/tests/test_data_health_meta_line_contract.py
+++ b/tests/test_data_health_meta_line_contract.py
@@ -1,0 +1,63 @@
+"""「数据健康」读数行的折行契约。
+
+2026-09-12：`crawl_visibility` 那四个事实挤成一个 `.dh-meta-bit`（`nowrap`），
+390px 手机实测把整块牌顶宽 158px、还把「逐项」按钮推出卡外（按钮右边缘
+531px vs 卡右 374px）。抓到它的是浏览器契约——但 master 的纯数据提交不跑 UI
+lane，所以这块牌一直红在**每一个** UI PR 的 validate 上（本地用
+`ops/pages/fetch_data_plane.py` 拉真数据后同样复现）。
+
+修法：复合读数交给 `dashboard.core.js` 的 `metaBits()` 按分隔点（` · `）拆短，
+`nowrap` 的前提「每一段都比屏幕窄」由代码保证；`.hero-health-head` 的子项加
+`min-width: 0`，让按钮位置不再取决于别人写了多长的一句话。
+
+这条闸盯的是**两个渲染端**：首屏走 `dashboard.hero.js`，详情 tab 走
+`dashboard.render.js`，历史上一份改了另一份没改的漂移在这个仓库里反复出现
+（见 tests/test_dashboard_bundle_parity.py）。
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+JS = ROOT / "site" / "assets" / "js"
+CORE = JS / "dashboard.core.js"
+RENDERERS = (JS / "dashboard.hero.js", JS / "dashboard.render.js")
+CSS = ROOT / "site" / "assets" / "css" / "dashboard.css"
+
+
+def _meta_block(path: Path) -> str:
+    """`if (metaEl) {` … 组装 `.dh-meta-bit` 之间的那段源码。
+
+    只在这里断言"没有绕过拆分器"是有意的：整份文件里别的 `bits` 数组（成品
+    状态、落地计数）本来就该自由 push，它们不印在 `nowrap` 的行里。
+    """
+    src = path.read_text(encoding="utf-8")
+    start = src.index("if (metaEl) {")
+    end = src.index("metaEl.innerHTML = bits.map", start)
+    return src[start:end]
+
+
+def test_the_splitter_lives_in_the_shared_core():
+    src = CORE.read_text(encoding="utf-8")
+    assert "const metaBits = " in src, (
+        "dashboard.core.js 里没有 metaBits —— 两个渲染端会各自拼长句，"
+        "下一次数据加一栏就又把手机顶宽")
+    assert '.split(" · ")' in src, "metaBits 必须在分隔点（ · ）上拆，而不是硬切字符"
+
+
+def test_both_data_health_renderers_go_through_the_splitter():
+    for path in RENDERERS:
+        block = _meta_block(path)
+        assert "metaBits(" in block, (
+            f"{path.name}: 数据健康读数行没走 metaBits() —— 一段比手机宽的 "
+            "nowrap 文字会把整块牌顶出屏幕（2026-09-12 实测 158px）")
+        assert "push(" not in block, (
+            f"{path.name}: 这段直接 push 了一个 bit 到 nowrap 的行里；"
+            "长读数必须过 metaBits() 拆短，否则 390px 手机会被顶宽")
+
+
+def test_the_header_can_shrink_so_the_toggle_stays_on_card():
+    css = CSS.read_text(encoding="utf-8")
+    assert ".hero-health-head > :first-child { min-width: 0; }" in css, (
+        "flex 子项的 min-width:auto 会让读数行按 min-content 撑开，"
+        "把「逐项」按钮推出卡外；这条 min-width:0 是它的护栏")


### PR DESCRIPTION
## 现象

`validate` 的浏览器契约在 390px 上失败：

```
AssertionError: data-health overflows horizontally by 158px at 390px
  at testDataHealthIsReadableOnAPhone (tests/dashboard_tab_runtime.spec.js:1890)
```

## 根因（不是猜的，是在干净 master 上复现的）

`origin/master` 的独立 worktree + `ops/pages/fetch_data_plane.py` 拉真数据后本地重跑，**同样 158px**：卡 `scrollWidth 514 / clientWidth 356`。

- `crawl_visibility` 那行 4 个事实被 push 成**一个** `.dh-meta-bit`，而 `.dh-meta-bit` 是 `white-space: nowrap` → 该段 428px，比 320px 的可视宽度还宽。
- 外层 `.hero-health-head` 是 flex，子项默认 `min-width: auto` → 整行按 min-content 撑开：428 + 14(gap) + 54(按钮) = 496。
- 后果不止溢出：`#dh-toggle`（「逐项」）右边缘 531px vs 卡右 374px —— **按钮在手机上根本点不到**。

master 一直没红，是因为纯数据提交不触发 `ui` lane；它红在**每一个**改了 UI 的 PR 上（本次是 #1473 发现）。

## 修法

| 文件 | 改动 |
|---|---|
| `dashboard.core.js` | 新增 `metaBits(...lines)`：复合读数按分隔点 ` · ` 拆短，`nowrap` 的前提「每段都比屏幕窄」交给代码保证 |
| `dashboard.hero.js` / `dashboard.render.js` | 两个渲染端都改为先过 `metaBits()`（首屏一份、详情一份，历史上漂移过） |
| `dashboard.css` | `.hero-health-head > :first-child { min-width: 0 }`，按钮位置不再取决于别人写了多长的一句话 |
| `tests/test_data_health_meta_line_contract.py` | 新闸：枚举两个渲染端，断言这段读数行必须走拆分器、不许自己 `push(` 长段 |

## 验证

- `node tests/dashboard_tab_runtime.spec.js`（本地、真数据）：**修复前**在 data-health 那条断言失败（158px，与 CI 同一数字），**修复后全绿**。
- 新契约测试 + `test_dashboard_bundle_parity.py` 全绿。