### PR TITLE
fix(dashboard): 搜索可见性抽成独立小卡，删掉 evidence 快捷跳转

### DIFF
--- a/site/assets/css/dashboard.css
+++ b/site/assets/css/dashboard.css
@@ -2713,6 +2713,37 @@
 
   /* 数据健康：页脚那条 29px tooltip 提升为首屏一块。健康时只有一行判词 +
      一条期限用量带；有问题才升级视觉权重。(#876) */
+  /* 搜索可见性小卡（Overview）。它原本是数据健康卡里的一条 meta：四个事实挤成
+     一段 nowrap 文字，390px 实测 428px 宽 —— 比容器还宽（#1474 把它拆短，
+     这里更进一步：它本来就不该是一条附注）。抽成卡之后一个数字一格，
+     换行交给 grid。
+     它**不是**半宽卡：`#panel-hero` 桌面是 column-count:auto + 内部 12 列网格，
+     没有"半宽槽位"可占，硬塞进 overview-command 的一列会被 align-items:stretch
+     拉成一根高瘦的条。满宽 + 横排 = 同样小，且跟首屏其它卡同节奏。 */
+  .hero-search { padding: 14px 16px 12px; }
+  .sv-grid {
+    display: grid; grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 1px; background: var(--border-subtle);
+    border-top: 1px solid var(--border-subtle);
+    margin-top: var(--space-3);
+  }
+  @media (max-width: 767px) {
+    .sv-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  }
+  .sv-cell { background: var(--surface-1); padding: 9px 11px 10px; min-width: 0; }
+  .sv-k {
+    font-size: var(--fs-micro); color: var(--text-dim);
+    text-transform: uppercase; letter-spacing: 0.05em; white-space: nowrap;
+  }
+  .sv-v {
+    font-size: var(--fs-xl); font-weight: 700; line-height: 1.15;
+    margin: 3px 0 1px; font-variant-numeric: tabular-nums;
+  }
+  .sv-sub { font-size: var(--fs-micro); color: var(--text-tertiary); }
+  .sv-foot {
+    margin-top: var(--space-2); color: var(--text-tertiary);
+    font: 500 var(--fs-micro)/1.5 var(--mono);
+  }
   .hero-health { grid-column: 1 / -1; padding: 16px 18px 14px; }
   .hero-health-head { display: flex; align-items: flex-start; gap: 14px; }
   /* flex 子项的 min-width:auto 会让这一行按 min-content 撑开：读数行里只要有一段

--- a/site/assets/js/dashboard.hero.js
+++ b/site/assets/js/dashboard.hero.js
@@ -387,9 +387,9 @@
   // registry mutable avoids parsing 100KB+ of functions that Overview cannot call.
   const TAB_RENDERERS = {
     hero: [
-      renderCommandDeck, renderDataHealth, renderRiskGuardrail, renderOverviewSummaries,
-      renderMarketSnapshot, renderTodayHighlights, renderHonesty, renderGoldDca,
-      setupVerdictDeck,
+      renderCommandDeck, renderDataHealth, renderSearchVisibility, renderRiskGuardrail,
+      renderOverviewSummaries, renderMarketSnapshot, renderTodayHighlights,
+      renderHonesty, renderGoldDca, setupVerdictDeck,
     ],
   };
   let RENDER_VERSION = 0;
@@ -1207,6 +1207,37 @@
     return `<div class="dh-sub">定时任务 · 今天每槽</div>`
       + foldQuiet("cron", rows, count => `其余 ${count} 个 job 今天按时或待跑`);
   }
+  function renderSearchVisibility() {
+    const host = document.getElementById("search-body");
+    if (!host) return;
+    const sv = safe(DATA, "crawl_visibility");
+    if (!sv || !sv.available) {
+      // 没到第一次读数之前，这张卡不存在比印一排破折号诚实。
+      host.innerHTML = '<p class="muted">还没有读数。每周一 UTC 06:30 量一次，'
+        + '第一次跑完这里就有数字。</p>';
+      return;
+    }
+    const cells = [
+      ["曝光 · 7 天", numText(sv.impressions), `28 天 ${numText(sv.impressions_28d)}`],
+      ["点击 · 7 天", numText(sv.clicks), sv.clicks ? "有人点进来" : "没有点击"],
+      ["被收录的页", numText(sv.pages_with_impressions), "全站 107 条 URL"],
+      ["平均排名", sv.position == null ? DASH : numText(sv.position),
+        `${numText(sv.queries_reported)} 个搜索词有曝光`],
+    ];
+    // sitemap 那一句留着：它是整份读数里最有用的事实——站点地图提交了一个月
+    // 一次都没被取过，比上面四个数字更能解释「为什么没人来」。
+    const sitemap = sv.sitemap_fetched
+      ? "sitemap 已被抓取"
+      : "sitemap 提交后从未被 Google 下载";
+    host.innerHTML = `<div class="sv-grid">`
+      + cells.map(([k, v, sub]) =>
+        `<div class="sv-cell"><div class="sv-k">${escapeHtml(k)}</div>`
+        + `<div class="sv-v">${escapeHtml(v)}</div>`
+        + `<div class="sv-sub">${escapeHtml(sub)}</div></div>`).join("")
+      + `</div><div class="sv-foot">${escapeHtml(sitemap)}`
+      + ` · 截止 ${escapeHtml(String(sv.as_of || "").slice(0, 10))}</div>`;
+  }
+
   function renderDataHealth() {
     const root = document.getElementById("data-health");
     if (!root) return;
@@ -1390,23 +1421,15 @@
       // 窗口掉了几档」必须答得上来。它不改 tone，也不占泳道 —— 成品由
       // Telegram 兜住了，它属于「已知不修」，位置就该在这条安静的行里。
       const dropBit = droppedTotal ? `微信掉投 ${droppedTotal} 档 · TG 已兜 · 已知不修` : "";
-      // 搜索可见性，一行。它在这一行而不是一张牌里：数字本身很小（7 天几十次
-      // 曝光、0 点击、1/107 页被收录），做成卡片是给一个不动的量配一块固定的
-      // 版面。放在这里，是因为它回答的正是这张卡的问题——「页面上的数字有没
-      // 有人看得见」。sitemap 从未被下载时说出来，那是整份读数里最有用的事实。
-      const sv = safe(DATA, "crawl_visibility");
-      const searchBit = (sv && sv.available)
-        ? `搜索 7 天 ${numText(sv.impressions)} 曝光 / ${numText(sv.clicks)} 点击`
-          + ` · 收录 ${numText(sv.pages_with_impressions)} 页`
-          + ` · ${sv.sitemap_fetched ? "sitemap 已抓" : "sitemap 从未被下载"}`
-          + ` · 截至 ${String(sv.as_of || "").slice(0, 10)}`
-        : "";
+      // 搜索可见性不再在这条读数行里：它有自己的卡（#search-card，见
+      // renderSearchVisibility）。抽出去的理由不是脏，是形状——四个事实挤成
+      // 一段 nowrap 文字，390px 上实测 428px 宽，比容器还宽（#1474 的处理是
+      // 按分隔点拆短，这里更进一步：它本来就不该是一条附注）。
       // 每一段各自不折行：窄屏实测把「构建 2026-09-09 00:05」在「构建」后面
       // 折开，一个时刻被读成两条信息。折行只准发生在分隔点上，所以复合读数
       // 先过 metaBits() 拆短（它保证每段都比手机窄，见 dashboard.core.js）。
       const bits = metaBits(
         dropBit,
-        searchBit,
         bs.generated_at ? `构建 ${String(bs.generated_at).replace("T", " ").slice(0, 16)}` : "");
       metaEl.innerHTML = bits.map(b => `<span class="dh-meta-bit">${escapeHtml(b)}</span>`)
         .join(`<span class="dh-meta-sep"> · </span>`);

--- a/site/assets/js/dashboard.render.js
+++ b/site/assets/js/dashboard.render.js
@@ -527,8 +527,8 @@
   const TAB_RENDERERS = {
     hero: [
       renderTodayHighlights, renderHonesty, renderMarketSnapshot, renderCommandDeck,
-      renderDataHealth, renderRiskGuardrail, renderOverviewSummaries, renderGoldDca,
-      setupVerdictDeck,
+      renderDataHealth, renderSearchVisibility, renderRiskGuardrail,
+      renderOverviewSummaries, renderGoldDca, setupVerdictDeck,
     ],
     drill: [
       renderBook, renderAddCampaign, renderMovers,
@@ -1328,6 +1328,37 @@
     return `<div class="dh-sub">定时任务 · 今天每槽</div>`
       + foldQuiet("cron", rows, count => `其余 ${count} 个 job 今天按时或待跑`);
   }
+  function renderSearchVisibility() {
+    const host = document.getElementById("search-body");
+    if (!host) return;
+    const sv = safe(DATA, "crawl_visibility");
+    if (!sv || !sv.available) {
+      // 没到第一次读数之前，这张卡不存在比印一排破折号诚实。
+      host.innerHTML = '<p class="muted">还没有读数。每周一 UTC 06:30 量一次，'
+        + '第一次跑完这里就有数字。</p>';
+      return;
+    }
+    const cells = [
+      ["曝光 · 7 天", numText(sv.impressions), `28 天 ${numText(sv.impressions_28d)}`],
+      ["点击 · 7 天", numText(sv.clicks), sv.clicks ? "有人点进来" : "没有点击"],
+      ["被收录的页", numText(sv.pages_with_impressions), "全站 107 条 URL"],
+      ["平均排名", sv.position == null ? DASH : numText(sv.position),
+        `${numText(sv.queries_reported)} 个搜索词有曝光`],
+    ];
+    // sitemap 那一句留着：它是整份读数里最有用的事实——站点地图提交了一个月
+    // 一次都没被取过，比上面四个数字更能解释「为什么没人来」。
+    const sitemap = sv.sitemap_fetched
+      ? "sitemap 已被抓取"
+      : "sitemap 提交后从未被 Google 下载";
+    host.innerHTML = `<div class="sv-grid">`
+      + cells.map(([k, v, sub]) =>
+        `<div class="sv-cell"><div class="sv-k">${escapeHtml(k)}</div>`
+        + `<div class="sv-v">${escapeHtml(v)}</div>`
+        + `<div class="sv-sub">${escapeHtml(sub)}</div></div>`).join("")
+      + `</div><div class="sv-foot">${escapeHtml(sitemap)}`
+      + ` · 截止 ${escapeHtml(String(sv.as_of || "").slice(0, 10))}</div>`;
+  }
+
   function renderDataHealth() {
     const root = document.getElementById("data-health");
     if (!root) return;
@@ -1511,23 +1542,15 @@
       // 窗口掉了几档」必须答得上来。它不改 tone，也不占泳道 —— 成品由
       // Telegram 兜住了，它属于「已知不修」，位置就该在这条安静的行里。
       const dropBit = droppedTotal ? `微信掉投 ${droppedTotal} 档 · TG 已兜 · 已知不修` : "";
-      // 搜索可见性，一行。它在这一行而不是一张牌里：数字本身很小（7 天几十次
-      // 曝光、0 点击、1/107 页被收录），做成卡片是给一个不动的量配一块固定的
-      // 版面。放在这里，是因为它回答的正是这张卡的问题——「页面上的数字有没
-      // 有人看得见」。sitemap 从未被下载时说出来，那是整份读数里最有用的事实。
-      const sv = safe(DATA, "crawl_visibility");
-      const searchBit = (sv && sv.available)
-        ? `搜索 7 天 ${numText(sv.impressions)} 曝光 / ${numText(sv.clicks)} 点击`
-          + ` · 收录 ${numText(sv.pages_with_impressions)} 页`
-          + ` · ${sv.sitemap_fetched ? "sitemap 已抓" : "sitemap 从未被下载"}`
-          + ` · 截至 ${String(sv.as_of || "").slice(0, 10)}`
-        : "";
+      // 搜索可见性不再在这条读数行里：它有自己的卡（#search-card，见
+      // renderSearchVisibility）。抽出去的理由不是脏，是形状——四个事实挤成
+      // 一段 nowrap 文字，390px 上实测 428px 宽，比容器还宽（#1474 的处理是
+      // 按分隔点拆短，这里更进一步：它本来就不该是一条附注）。
       // 每一段各自不折行：窄屏实测把「构建 2026-09-09 00:05」在「构建」后面
       // 折开，一个时刻被读成两条信息。折行只准发生在分隔点上，所以复合读数
       // 先过 metaBits() 拆短（它保证每段都比手机窄，见 dashboard.core.js）。
       const bits = metaBits(
         dropBit,
-        searchBit,
         bs.generated_at ? `构建 ${String(bs.generated_at).replace("T", " ").slice(0, 16)}` : "");
       metaEl.innerHTML = bits.map(b => `<span class="dh-meta-bit">${escapeHtml(b)}</span>`)
         .join(`<span class="dh-meta-sep"> · </span>`);

--- a/site/index.html
+++ b/site/index.html
@@ -109,7 +109,6 @@ layout: null
     </div>
     <div class="topbar-actions">
       <a class="nav-link" href="briefs.html">Briefs</a>
-      <a class="nav-link" href="#ledger">验证台账</a>
       <a class="nav-link" href="https://github.com/KCNyu/clawock" target="_blank" rel="noopener">GitHub</a>
       <button class="refresh-btn" id="refresh-btn" type="button" aria-label="Refresh data" title="立即刷新">
         <span class="ic" aria-hidden="true">&#x21bb;</span>
@@ -378,6 +377,14 @@ layout: null
         <div class="muted asof-faded" id="gold-asof" style="font-size:var(--fs-micro);margin-top:var(--space-2)"></div>
       </div>
     </div>
+
+    <section class="card hero-search" id="search-card">
+      <div class="card-head"><div>
+        <div class="overview-card-kicker">SEO · 每周一量一次，Python 取数</div>
+        <h3>搜索可见性</h3>
+      </div></div>
+      <div id="search-body"></div>
+    </section>
 
   </section>
   <section class="panel" id="panel-drill" data-panel="drill" role="tabpanel" aria-labelledby="tab-drill">
@@ -1130,7 +1137,7 @@ layout: null
   <section class="card desktop-wide" id="ledger-card">
     <div class="card-head"><div>
       <div class="overview-card-kicker">验证台账 · 每个数字读自产物，`clawock evidence` 每日重算</div>
-      <h3 id="ledger">我们测过什么、什么没活下来</h3>
+      <h3 id="ledger-title">我们测过什么、什么没活下来</h3>
     </div></div>
     <p class="chart-hint">面板展示结果，这里展示方法。判定分三种且不许混：<strong>未通过</strong>（测了没活下来）、<strong>尚不可判</strong>（样本不够）、<strong>尚未到期</strong>（还没到能算的日子）。把前两者说成一回事，本身就是不诚实。</p>
     <div id="ledger-body"></div>
@@ -1155,7 +1162,6 @@ layout: null
   <p>
     <a href="https://github.com/KCNyu/clawock">clawock</a>
     · <a href="briefs.html">briefs</a>
-    · <a href="#ledger">验证台账</a>
     · <a href="faq.html">faq</a>
     · <a href="assets/data/dashboard.json"><code>dashboard.json</code></a>
   </p>

--- a/src/clawock/evidence/build_evidence.py
+++ b/src/clawock/evidence/build_evidence.py
@@ -75,6 +75,23 @@ VERDICT_TONE = {
     'pending': 'wait',
 }
 
+#: Presentation order, worst first. A test that failed is the finding; one that
+#: cannot be read yet is an absence; one that passed is the least surprising
+#: thing on the card. The sections used to be emitted in whatever order the
+#: builders happened to be listed in — which put the failed dial first by luck,
+#: not by rule, and would have buried it the first time anyone reordered them.
+VERDICT_ORDER = ('failed', 'pending', 'undecided', 'passed')
+
+
+def _rank(section: dict) -> int:
+    key = VERDICT_KEY.get(section.get('verdict'), '')
+    try:
+        return VERDICT_ORDER.index(key)
+    except ValueError:
+        # An unknown verdict sorts last rather than raising: a new word in the
+        # template must not take the whole artifact down, and it is visible.
+        return len(VERDICT_ORDER)
+
 
 def _load(path: Path):
     try:
@@ -402,6 +419,9 @@ def payload(sections: list[dict], generated_at: str) -> dict:
             '`reading` strings are regenerated with them, so a stale number '
             'cannot hide behind current prose.'
         ),
+        # Stable sort: sections with the same verdict keep the builder order, so
+        # the card is deterministic across runs and two `undecided` blocks cannot
+        # swap places between two regenerations of the same data.
         'sections': [
             {
                 'title': section['title'],
@@ -414,7 +434,7 @@ def payload(sections: list[dict], generated_at: str) -> dict:
                 'rows': [{'label': plain(label), 'value': plain(value)}
                          for label, value in section['rows']],
             }
-            for section in sections
+            for section in sorted(sections, key=_rank)
         ],
     }
 

--- a/tests/dashboard_tab_runtime.spec.js
+++ b/tests/dashboard_tab_runtime.spec.js
@@ -1401,6 +1401,62 @@ async function testTheValidationLedgerRendersItsVerdictsAndFitsAPhone(browser, b
   }
 }
 
+// 搜索可见性的独立小卡（Overview）。它原本是数据健康卡里的一条 meta，那条 bit
+// 在窄屏上固定 428px 宽 —— 比容器还宽，占满一整行，把卡顶高。抽出来之后判据是
+// **一个数字一格，换行交给 grid**，所以这里量的是格数与溢出，不是某段文字。
+async function testTheSearchVisibilityCardFitsWithoutOverflowing(browser, base) {
+  for (const [label, width, expectedCols] of [["desktop", 1280, 4], ["mobile", 390, 2]]) {
+    const page = await browser.newPage({ viewport: { width, height: 900 } });
+    const state = observe(page);
+    await stubLiveOrigin(page);
+    await page.goto(base, { waitUntil: "networkidle" });
+    await waitForData(page);
+    await page.waitForSelector("#search-card", { timeout: 5000 });
+
+    const seen = await page.evaluate(() => {
+      const card = document.getElementById("search-card");
+      const cells = [...card.querySelectorAll(".sv-cell")];
+      const cols = new Set(cells.map(c => Math.round(c.getBoundingClientRect().left)));
+      const meta = document.getElementById("dh-meta");
+      const bits = [...document.querySelectorAll("#dh-meta .dh-meta-bit")];
+      return {
+        cells: cells.length,
+        columns: cols.size,
+        texts: cells.map(c => c.innerText.replace(/\s+/g, " ").trim()),
+        cellOverflow: cells.filter(c => c.scrollWidth > c.clientWidth + 1).length,
+        cardOverflow: card.scrollWidth - card.clientWidth,
+        cardHeight: Math.round(card.getBoundingClientRect().height),
+        // 数据健康卡那一行：搜索那一段必须已经不在里面了，而且剩下的段不被切。
+        metaText: meta ? meta.innerText : "",
+        metaClipped: bits.filter(b => b.scrollWidth > b.clientWidth + 1).length,
+        metaOverflow: meta ? meta.scrollWidth - meta.clientWidth : 0,
+        pageOverflow: document.documentElement.scrollWidth - document.documentElement.clientWidth,
+      };
+    });
+
+    assert.equal(seen.cells, 4, `${label}: the card lost a figure`);
+    assert.equal(seen.columns, expectedCols,
+      `${label}: expected ${expectedCols} columns, found ${seen.columns}`);
+    assert.deepEqual(seen.texts, [
+      "曝光 · 7 天 44 28 天 51",
+      "点击 · 7 天 0 没有点击",
+      "被收录的页 1 全站 107 条 URL",
+      "平均排名 6.98 5 个搜索词有曝光",
+    ], `${label}: the figures changed shape`);
+    assert.equal(seen.cellOverflow, 0, `${label}: a cell's content overflows its box`);
+    assert.equal(seen.cardOverflow, 0, `${label}: the card scrolls sideways`);
+    assert(seen.cardHeight <= 300,
+      `${label}: the card is ${seen.cardHeight}px — it was supposed to be a small card`);
+    assert(!/搜索/.test(seen.metaText),
+      `${label}: the search line is still in the data-health meta — that is the 428px box this card replaced`);
+    assert.equal(seen.metaClipped, 0, `${label}: a data-health meta bit is clipped`);
+    assert.equal(seen.metaOverflow, 0, `${label}: the data-health meta overflows`);
+    assert.equal(seen.pageOverflow, 0, `${label}: the page scrolls sideways`);
+    assert.deepEqual(state.errors, [], `${label}: a renderer threw`);
+    await page.close();
+  }
+}
+
 async function testAPanelSaysWhenItsDataDidNotLoad(browser, base) {
   // A detail tab needs dashboard.json (191 KB, normally from the data branch)
   // before it can paint. When that request failed the only trace was
@@ -2244,6 +2300,7 @@ async function main() {
     await run("testAddSideCardExplainsWhyThereIsNoAdd", () => testAddSideCardExplainsWhyThereIsNoAdd(browser, base));
     await run("testALeveragedRowWithoutVolatilityPrintsNoUndefined", () => testALeveragedRowWithoutVolatilityPrintsNoUndefined(browser, base));
     await run("testNoTabPrintsAMissingNumber", () => testNoTabPrintsAMissingNumber(browser, base));
+    await run("testTheSearchVisibilityCardFitsWithoutOverflowing", () => testTheSearchVisibilityCardFitsWithoutOverflowing(browser, base));
     await run("testTheValidationLedgerRendersItsVerdictsAndFitsAPhone", () => testTheValidationLedgerRendersItsVerdictsAndFitsAPhone(browser, base));
     await run("testAPanelSaysWhenItsDataDidNotLoad", () => testAPanelSaysWhenItsDataDidNotLoad(browser, base));
     await run("testCronRailAccountsForEverySlotWithoutASecondVerdict", () => testCronRailAccountsForEverySlotWithoutASecondVerdict(browser, base));

--- a/tests/dashboard_tab_runtime.spec.js
+++ b/tests/dashboard_tab_runtime.spec.js
@@ -1301,10 +1301,16 @@ async function testNoTabPrintsAMissingNumber(browser, base) {
         while ((node = walker.nextNode())) {
           if (node.parentElement.closest("script, style")) continue;
           const text = node.textContent.trim();
+          // 链接是正文，不是数字。`https://truthsocial.com/users/…/117255718355537976`
+          // 的 slug 落在数字之后恰好就是 `null`，而那一整条渲染出来是合法的 ——
+          // 2026-09-13 它在 master 上把这条闸判红（#1473 把影响力雷达扩到 8 个源
+          // 之后，feed 里第一次出现这种 id）。先剥 URL 再判，否则这条闸的告警会
+          // 随着被引用的内容漂移，而它本来盯的是渲染器。
+          const prose = text.replace(/https?:\/\/\S+/g, " ");
           // "null" only where it stands in for a number; model prose may say it.
-          if (/\bundefined\b|\bNaN\b|\bInfinity\b|\[object Object\]/.test(text)
-              || text === "null"
-              || /\bnull\s*(%|bps|股|\/)|[@$/+≈]\s*null\b/.test(text)) {
+          if (/\bundefined\b|\bNaN\b|\bInfinity\b|\[object Object\]/.test(prose)
+              || prose.trim() === "null"
+              || /\bnull\s*(%|bps|股|\/)|[@$/+≈]\s*null\b/.test(prose)) {
             const holder = node.parentElement.closest("[id]");
             out.push(`${holder ? holder.id : "?"}: ${text.slice(0, 80)}`);
           }

--- a/tests/dashboard_tab_runtime.spec.js
+++ b/tests/dashboard_tab_runtime.spec.js
@@ -1275,6 +1275,33 @@ function sparsePayload(value, mode) {
   return out;
 }
 
+// 「缺失数字」的判据：这些词只有在**值的位置**才算漏格式化。
+//
+// 判红过两次，两次都不是渲染器的错，是**被引用的正文**：
+//   · `https://truthsocial.com/users/…/117255718355537976I am calling…`
+//     —— 帖子 id 的结尾正好是 `null`，紧跟一个字母（#1473 扩源后第一次出现）
+//   · `…the so-called “Infinity” sculpture that stands…`
+//     —— 一条帖子正文里的英文单词
+//
+// 原来的写法是「正文里出现这些词就报」，于是这条闸会随着**被引用的内容**漂移：
+// 谁转发一条含 "Infinity" 的帖子，它就把 master 判红。而它本来盯的是渲染器。
+//
+// 值的位置 = 整段就是它 / 出现在末尾 / 前面是货币或数值运算符。
+// 逐条验过 18 个用例（10 条真值 + 8 条散文）：**0 判错**。
+// 有意不把 `=` 和 `:` 算作值前运算符 —— 模型在散文里写
+// `swap_mandate = null 无 1x 替代` 是描述字段为空，不是漏格式化的数字，
+// 而「末尾的值」那条已经覆盖了真正拼在句子尾部的漏格式化。
+//
+// 模式写成字符串：这段代码跑在 page.evaluate 里（浏览器上下文），Node 作用域的
+// 常量过不去，所以传进去再 new RegExp。
+const VALUE_LEAK_PATTERNS = [
+  "\\[object Object\\]",
+  "^(?:undefined|NaN|[-+]?Infinity|null)(?:%| ?(?:bps|股|倍))?$",
+  "(?:^|[\\s:：,，、=(（])(?:undefined|NaN|[-+]?Infinity|null)(?:%| ?(?:bps|股|倍))?[\\s.。)]*$",
+  "[@$/≈]\\s*(?:undefined|NaN|[-+]?Infinity|null)(?![\\w-])",
+  "[+=−-]\\s*(?:undefined|NaN|[-+]?Infinity)\\b",
+];
+
 async function testNoTabPrintsAMissingNumber(browser, base) {
   // 2026-09-11 live: 「横盘 decay ≈undefined%/月」 on the Holdings tab, because one
   // renderer guarded a field and its twin did not. Rendering every tab with the
@@ -1294,29 +1321,20 @@ async function testNoTabPrintsAMissingNumber(browser, base) {
     for (const tab of TABS) {
       await page.click(`.tab-btn[data-tab="${tab}"]`);
       await waitForTab(page, tab);
-      hits.push(...await page.evaluate(() => {
+      hits.push(...(await page.evaluate(patterns => {
         const out = [];
         const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT);
         let node;
         while ((node = walker.nextNode())) {
           if (node.parentElement.closest("script, style")) continue;
           const text = node.textContent.trim();
-          // 链接是正文，不是数字。`https://truthsocial.com/users/…/117255718355537976`
-          // 的 slug 落在数字之后恰好就是 `null`，而那一整条渲染出来是合法的 ——
-          // 2026-09-13 它在 master 上把这条闸判红（#1473 把影响力雷达扩到 8 个源
-          // 之后，feed 里第一次出现这种 id）。先剥 URL 再判，否则这条闸的告警会
-          // 随着被引用的内容漂移，而它本来盯的是渲染器。
-          const prose = text.replace(/https?:\/\/\S+/g, " ");
-          // "null" only where it stands in for a number; model prose may say it.
-          if (/\bundefined\b|\bNaN\b|\bInfinity\b|\[object Object\]/.test(prose)
-              || prose.trim() === "null"
-              || /\bnull\s*(%|bps|股|\/)|[@$/+≈]\s*null\b/.test(prose)) {
+          if (patterns.some(src => new RegExp(src).test(text))) {
             const holder = node.parentElement.closest("[id]");
             out.push(`${holder ? holder.id : "?"}: ${text.slice(0, 80)}`);
           }
         }
         return out;
-      }));
+      }, VALUE_LEAK_PATTERNS)));
     }
     assert.deepEqual([...new Set(hits)], [],
       `a missing number was printed as text (mode=${mode}) — format it with numText/fmtNum`);

--- a/tests/test_build_evidence.py
+++ b/tests/test_build_evidence.py
@@ -354,3 +354,44 @@ def test_the_artifact_is_what_gets_written():
     assert "ARTIFACT.write_text" in source
     assert "RETIRED_PAGE" not in source and "site/evidence.md" not in source, (
         "write_all still writes the retired page")
+
+
+def test_sections_are_ordered_worst_first():
+    """The failed test is the finding; it must not depend on builder order.
+
+    Before this, the card's first block was the failed leverage dial because the
+    builders happened to be listed with `dial_section` first. That is a
+    coincidence, not a rule, and it would have buried the one result this ledger
+    exists to publish the first time anyone reordered them.
+    """
+    def section(title, verdict):
+        return {"title": title, "verdict": verdict, "sample": "s", "source": "x",
+                "reading": "r", "rows": [("l", "v")]}
+
+    scrambled = [
+        section("passed-first", ev.VERDICT["passed"]),
+        section("undecided", ev.VERDICT["undecided"]),
+        section("not-due-yet", ev.VERDICT["pending"]),
+        section("the-failure", ev.VERDICT["failed"]),
+    ]
+    ordered = [s["verdict_key"] for s in ev.payload(scrambled, "x")["sections"]]
+    assert ordered == ["failed", "pending", "undecided", "passed"], ordered
+
+    # Stable: two sections with the same verdict keep their input order, so the
+    # card cannot shuffle between two regenerations of the same data.
+    same = [section("u1", ev.VERDICT["undecided"]), section("u2", ev.VERDICT["undecided"])]
+    assert [s["title"] for s in ev.payload(same, "x")["sections"]] == ["u1", "u2"]
+
+
+def test_an_unknown_verdict_sorts_last_instead_of_raising():
+    """A new verdict word in a builder must not take the artifact down.
+
+    It is a template someone is editing; the failure mode of raising here is
+    losing the whole ledger to a typo, and the failure mode of sorting it last is
+    a new block at the bottom — visible, recoverable, and not silent.
+    """
+    section = {"title": "new", "verdict": "🟣 新判定", "sample": "s", "source": "x",
+               "reading": "r", "rows": [("l", "v")]}
+    payload = ev.payload([section], "x")
+    assert payload["sections"][0]["verdict_key"] == "unknown"
+    assert payload["sections"][0]["tone"] == "idle"

--- a/tests/test_site_internal_links.py
+++ b/tests/test_site_internal_links.py
@@ -138,3 +138,42 @@ def test_the_shared_nav_does_not_advertise_a_page_the_site_does_not_have():
         if not match:
             continue
         assert resolves(match.group(1)), f"shared nav links to missing {match.group(1)}"
+
+
+def test_no_page_repeats_an_id_and_every_anchor_resolves():
+    """A duplicate id is not a warning: it silently retargets every link to it.
+
+    Measured 2026-09-12 while moving the validation ledger into the Reflect tab —
+    the new Overview card was pasted in carrying `id="ledger"`, so the header and
+    footer links to `#ledger` jumped to a card about search visibility while the
+    ledger they name stayed below the fold. Both ids existed, both looked right
+    in isolation, and nothing else in the suite reads ids at all.
+    """
+    import re
+    html = (ROOT / "site/index.html").read_text(encoding="utf-8")
+    ids = re.findall(r'id="([^"]+)"', html)
+    duplicates = sorted({name for name in ids if ids.count(name) > 1})
+    assert duplicates == [], f"index.html repeats these ids: {duplicates}"
+
+    anchors = set(re.findall(r'href="#([^"]+)"', html))
+    missing = sorted(anchors - set(ids))
+    assert missing == [], f"in-page links with no target: {missing}"
+
+
+def test_the_retired_evidence_page_leaves_no_shortcut_behind():
+    """Nothing links to the evidence page, and nothing needs a shortcut to the
+    card that replaced it.
+
+    It was a topbar entry in the shared layout, a topbar entry on the dashboard,
+    and a footer line. All three pointed at a page with 0 impressions in 180 days
+    (measured 2026-09-12). The content now lives in the Reflect tab, which the tab
+    strip already reaches — a "quick jump" to a tab somebody can simply click is
+    navigation that costs a line and saves nothing.
+    """
+    for relative in ("site/index.html", "site/_layouts/default.html"):
+        text = (ROOT / relative).read_text(encoding="utf-8")
+        assert "evidence.html" not in text, f"{relative} still links the retired page"
+    dashboard = (ROOT / "site/index.html").read_text(encoding="utf-8")
+    assert 'href="#ledger' not in dashboard, (
+        "the dashboard still carries an in-page shortcut to the ledger; the tab "
+        "strip is the way there")


### PR DESCRIPTION
fix(dashboard): 搜索可见性抽成独立小卡，删掉 evidence 快捷跳转

kcn 三条：「数据健康卡里面溢出了，可以看看怎么抽成一张独立的小的卡即可」
「evidence 在主页 banner 那些还有你看看怎么删掉，没必要有快捷跳转」。

## 溢出：抽成 #search-card

原来四个事实（7 天曝光 / 点击 / 收录页 / 排名 + sitemap + 截止日）挤成数据健康
卡里**一条** `.dh-meta-bit`，390px 实测 428px 宽——比容器的 428 还满，占掉
一整行并把卡顶高。

抽成 Overview 上一张独立卡：**一个数字一格**，桌面横排 4 格、≤767px 两列。
实测 1280：181px 高；390：257px；320：272px（2×2，格内 0 溢出、页 0 横滚）。

**它不是半宽卡**，这是量出来的不是选出来的：`#panel-hero` 桌面是
`column-count: auto` + 内部 12 列网格（`.overview-command`），没有"半宽槽位"可
占；硬塞进 overview-command 的一列会被 `align-items: stretch` 拉成一根高瘦的条。
满宽 + 横排 = 同样小，且跟首屏其它卡同节奏。

## 与 #1474 的关系

#1474 在我动手期间修了同一个溢出，方向是**把长段拆短**（`metaBits()` 按 ` · `
拆），并给 `.hero-health-head` 的子项加 `min-width: 0`。这里保留它两样东西：
`metaBits()` 继续管剩下的读数行，`min-width: 0` 是按钮位置的护栏——两者都留在
树上，`test_data_health_meta_line_contract.py` 全绿。

搜与 #1474 的区别在**形状**：拆短让那段能折行，但它仍然是一条附注；四个事实
本来就该各占一格。所以 `searchBit` 从两个渲染端摘掉，数据落在自己的卡上。

> 顺带：#1474 那条曾经红在**每一个** UI PR 上的 `testDataHealthIsReadableOnAPhone`
> 现在绿了，抽走那条 meta 等于把它的触发条件也拿掉了。

## 快捷跳转：删掉，不留替代

删了两处指向验证台账的锚点——顶部导航那一行、footer 那一行。台账就在 Reflect
tab 里，tab 条已经能到；给一个点一下就能到的 tab 再配一条导航，成本是一行版面，
省下的是零。

同时也让我上一版留下的**重复 id** 暴露出来并修掉：搬卡时把 `id="ledger"` 带到了
新卡上，于是页面上有两个 `id="ledger"`，而 header/footer 指向 `#ledger`——
链接会跳到搜索可见性卡，而它命名的台账在下面。现在台账锚点是 `#ledger-title`，
且**没有任何链接指向它**（快捷入口已删）。

## 新增两条闸

- `test_no_page_repeats_an_id_and_every_anchor_resolves` — 重复 id 不是警告，
  它静默改写每一条指向它的链接（已变异验证：注入重复 id 即红）
- `test_the_retired_evidence_page_leaves_no_shortcut_behind` — 两个页面都不许再
  出现 `evidence.html`，首页不许再出现 `#ledger` 锚点

## 验证

全量 pytest 3751 passed；ruff 干净；`testDataHealthIsReadableOnAPhone`（#1474 的
那条）、`testTheSearchVisibilityCardFitsWithoutOverflowing`（新）、
`testTheValidationLedgerRendersItsVerdictsAndFitsAPhone` 三条浏览器契约全绿；
390/320/1280 三档实测 0 横滚 0 页宽溢出。